### PR TITLE
Config/api-response API 응답 객체 변경 

### DIFF
--- a/src/main/java/com/even/zaro/controller/ApiTestController.java
+++ b/src/main/java/com/even/zaro/controller/ApiTestController.java
@@ -1,7 +1,7 @@
 package com.even.zaro.controller;
 
-import com.even.zaro.global.ApiResponse;
 import com.even.zaro.dto.ExDTO;
+import com.even.zaro.global.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.extern.slf4j.Slf4j;
@@ -16,7 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = "API 테스트 컨트롤러")
 public class ApiTestController {
 
-    @Operation(summary= "테스트 API", description = "테스트 API 컨트롤러입니다.")
+    @Operation(summary = "테스트 API", description = "테스트 API 컨트롤러입니다.")
     @GetMapping("/test")
     public ResponseEntity<ApiResponse<ExDTO>> test() {
         ExDTO exDto = ExDTO.builder()
@@ -24,6 +24,6 @@ public class ApiTestController {
                 .username("동훈")
                 .build();
 
-        return ResponseEntity.ok(ApiResponse.success(exDto, "API 테스트 성공~"));
+        return ResponseEntity.ok(ApiResponse.success("API 테스트 성공~", exDto));
     }
 }

--- a/src/main/java/com/even/zaro/controller/ApiTestController.java
+++ b/src/main/java/com/even/zaro/controller/ApiTestController.java
@@ -2,6 +2,8 @@ package com.even.zaro.controller;
 
 import com.even.zaro.dto.ExDTO;
 import com.even.zaro.global.ApiResponse;
+import com.even.zaro.global.exception.exampleEx.ExampleException;
+import com.even.zaro.global.exception.userEx.UserException;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.extern.slf4j.Slf4j;
@@ -25,5 +27,17 @@ public class ApiTestController {
                 .build();
 
         return ResponseEntity.ok(ApiResponse.success("API 테스트 성공~", exDto));
+    }
+
+    @Operation(summary = "예외 테스트 API", description = "예외 테스트 응답 확인용")
+    @GetMapping("/error-throw")
+    public ResponseEntity<ApiResponse<?>> errorThrow() {
+        throw UserException.NotFoundUserException();
+    }
+
+    @Operation(summary = "예외 테스트 API", description = "예외 테스트 응답 확인용")
+    @GetMapping("/error-throw/ex")
+    public ResponseEntity<ApiResponse<?>> errorThrowEx() {
+        throw ExampleException.NotFoundExampleException();
     }
 }

--- a/src/main/java/com/even/zaro/controller/ApiTestController.java
+++ b/src/main/java/com/even/zaro/controller/ApiTestController.java
@@ -24,6 +24,6 @@ public class ApiTestController {
                 .username("동훈")
                 .build();
 
-        return ResponseEntity.ok(ApiResponse.success(exDto, "성공"));
+        return ResponseEntity.ok(ApiResponse.success(exDto, "API 테스트 성공~"));
     }
 }

--- a/src/main/java/com/even/zaro/global/ApiResponse.java
+++ b/src/main/java/com/even/zaro/global/ApiResponse.java
@@ -7,29 +7,30 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class ApiResponse<T> {
 
-    private boolean success;
     private T data;
+    private String status;
     private String message;
 
-    private ApiResponse(boolean success, T data, String message) {
-        this.success = success;
+    private ApiResponse(T data, String success, String message) {
         this.data = data;
+        this.status = success;
         this.message = message;
     }
 
-    public static <T> ApiResponse<T> success(T data) {
-        return new ApiResponse<>(true, data, null);
-    }
-
     public static <T> ApiResponse<T> success(T data, String message) {
-        return new ApiResponse<>(true, data, message);
+        return new ApiResponse<>(data, "SUCCESS", message);
+    }
+//
+//    public static <T> ApiResponse<T> success(T data, String status, String message) {
+//        return new ApiResponse<>(data, status, message);
+//    }
+
+    //
+    public static <T> ApiResponse<T> fail(String status, String message) {
+        return new ApiResponse<>(null, status, message);
     }
 
-    public static <T> ApiResponse<T> fail(String message) {
-        return new ApiResponse<>(false, null, message);
-    }
-
-    public static <T> ApiResponse<T> fail(T data, String message) {
-        return new ApiResponse<>(false, data, message);
-    }
+//    public static <T> ApiResponse<T> fail(T data, String status, String message) {
+//        return new ApiResponse<>(data, status, message);
+//    }
 }

--- a/src/main/java/com/even/zaro/global/ApiResponse.java
+++ b/src/main/java/com/even/zaro/global/ApiResponse.java
@@ -21,12 +21,7 @@ public class ApiResponse<T> {
     public static <T> ApiResponse<T> success(String message, T data) {
         return new ApiResponse<>("SUCCESS", message, data);
     }
-//
-//    public static <T> ApiResponse<T> success(T data, String status, String message) {
-//        return new ApiResponse<>(data, status, message);
-//    }
 
-    //
     public static <T> ApiResponse<T> fail(ErrorCode errorCode) {
         return new ApiResponse<>(errorCode.getCode(), errorCode.getDefaultMessage(), null);
     }
@@ -35,8 +30,4 @@ public class ApiResponse<T> {
         return new ApiResponse<>(errorCode.getCode(), message, null);
     }
 
-//    public static <T> ApiResponse<T> fail(ErrorCode errorCode, HttpStatus httpStatus) {
-//        return new ApiResponse<>(false, errorCode.getCode(), null);
-//
-//    }
 }

--- a/src/main/java/com/even/zaro/global/ApiResponse.java
+++ b/src/main/java/com/even/zaro/global/ApiResponse.java
@@ -2,6 +2,7 @@ package com.even.zaro.global;
 
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.http.HttpStatus;
 
 @Getter
 @NoArgsConstructor
@@ -26,11 +27,16 @@ public class ApiResponse<T> {
 //    }
 
     //
-    public static <T> ApiResponse<T> fail(String code, String message) {
-        return new ApiResponse<>(code, message, null);
+    public static <T> ApiResponse<T> fail(ErrorCode errorCode) {
+        return new ApiResponse<>(errorCode.getCode(), errorCode.getDefaultMessage(), null);
     }
 
-//    public static <T> ApiResponse<T> fail(T data, String status, String message) {
-//        return new ApiResponse<>(data, status, message);
+    public static <T> ApiResponse<T> fail(ErrorCode errorCode, String message) {
+        return new ApiResponse<>(errorCode.getCode(), message, null);
+    }
+
+//    public static <T> ApiResponse<T> fail(ErrorCode errorCode, HttpStatus httpStatus) {
+//        return new ApiResponse<>(false, errorCode.getCode(), null);
+//
 //    }
 }

--- a/src/main/java/com/even/zaro/global/ApiResponse.java
+++ b/src/main/java/com/even/zaro/global/ApiResponse.java
@@ -7,18 +7,18 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class ApiResponse<T> {
 
-    private T data;
-    private String status;
+    private String code;
     private String message;
+    private T data;
 
-    private ApiResponse(T data, String success, String message) {
-        this.data = data;
-        this.status = success;
+    private ApiResponse(String code, String message, T data){
+        this.code = code;
         this.message = message;
+        this.data = data;
     }
 
-    public static <T> ApiResponse<T> success(T data, String message) {
-        return new ApiResponse<>(data, "SUCCESS", message);
+    public static <T> ApiResponse<T> success(String message, T data) {
+        return new ApiResponse<>("SUCCESS", message, data);
     }
 //
 //    public static <T> ApiResponse<T> success(T data, String status, String message) {
@@ -26,8 +26,8 @@ public class ApiResponse<T> {
 //    }
 
     //
-    public static <T> ApiResponse<T> fail(String status, String message) {
-        return new ApiResponse<>(null, status, message);
+    public static <T> ApiResponse<T> fail(String code, String message) {
+        return new ApiResponse<>(code, message, null);
     }
 
 //    public static <T> ApiResponse<T> fail(T data, String status, String message) {

--- a/src/main/java/com/even/zaro/global/ErrorCode.java
+++ b/src/main/java/com/even/zaro/global/ErrorCode.java
@@ -1,0 +1,34 @@
+package com.even.zaro.global;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum ErrorCode {
+
+    // 기본 예외
+    UNKNOWN_REQUEST("UNKNOWN_REQUEST", HttpStatus.INTERNAL_SERVER_ERROR, "알 수 없는 오류 요청 URL을 다시 확인해보십시오."),
+    ILLEGAL_STATE("ILLEGAL_STATE", HttpStatus.INTERNAL_SERVER_ERROR, "잘못된 상태입니다."),
+    NULL_POINTER("NULL_POINTER", HttpStatus.BAD_REQUEST, "필수 데이터가 누락되었습니다."),
+    INVALID_ARGUMENT("INVALID_ARGUMENT", HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
+    TYPE_MISMATCH("TYPE_MISMATCH", HttpStatus.BAD_REQUEST, "요청 파라미터 타입이 일치하지 않습니다."),
+    NUMBER_FORMAT_ERROR("NUMBER_FORMAT_ERROR", HttpStatus.BAD_REQUEST, "숫자 형식 오류입니다."),
+    DB_ACCESS_ERROR("DB_ACCESS_ERROR", HttpStatus.INTERNAL_SERVER_ERROR, "데이터베이스 접근 오류입니다."),
+    NO_RESULT("NO_RESULT", HttpStatus.NOT_FOUND, "데이터를 찾을 수 없습니다."),
+    EMPTY_RESULT("EMPTY_RESULT", HttpStatus.NOT_FOUND, "결과가 존재하지 않습니다."),
+    INTERNAL_SERVER_ERROR("INTERNAL_SERVER_ERROR", HttpStatus.INTERNAL_SERVER_ERROR, "서버에서 알 수 없는 오류가 발생했습니다."),
+
+    // 커스텀 예외
+    EXAMPLE_EXCEPTION("EXAMPLE_EXCEPTION", HttpStatus.INTERNAL_SERVER_ERROR, "예시 예외 발생"),
+    USER_EXCEPTION("USER_EXCEPTION", HttpStatus.INTERNAL_SERVER_ERROR, "사용자 예외 발생");
+
+    private final String code;
+    private final HttpStatus httpStatus;
+    private final String defaultMessage;
+
+    ErrorCode(String code, HttpStatus httpStatus, String defaultMessage) {
+        this.code = code;
+        this.httpStatus = httpStatus;
+        this.defaultMessage = defaultMessage;
+    }
+}

--- a/src/main/java/com/even/zaro/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/even/zaro/global/exception/GlobalExceptionHandler.java
@@ -20,7 +20,7 @@ public class GlobalExceptionHandler {
     // 기타 예외 처리
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ApiResponse<?>> handleGeneralException(Exception ex) {
-        ApiResponse<?> response = ApiResponse.fail("알 수 없는 오류 요청 URL을 다시 확인해보십시오: " + ex.getMessage());
+        ApiResponse<?> response = ApiResponse.fail("UNKNOWN_REQUEST", "알 수 없는 오류 요청 URL을 다시 확인해보십시오: " + ex.getMessage());
         log.error(ex.getMessage(), ex);
         return new ResponseEntity<>(response, HttpStatus.INTERNAL_SERVER_ERROR);
     }
@@ -28,7 +28,7 @@ public class GlobalExceptionHandler {
     // 이메일 중복 인증 발생 예외 처리
     @ExceptionHandler(IllegalStateException.class)
     public ResponseEntity<ApiResponse<?>> handleIllegalStateException(IllegalStateException ex) {
-        ApiResponse<?> response = ApiResponse.fail(ex.getMessage());
+        ApiResponse<?> response = ApiResponse.fail("ILLEGAL_STATE", ex.getMessage());
         log.error(ex.getMessage(), ex);
         return new ResponseEntity<>(response, HttpStatus.INTERNAL_SERVER_ERROR);
     }
@@ -37,45 +37,45 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(MethodArgumentTypeMismatchException.class)
     public ApiResponse<?> handleTypeMismatchException(MethodArgumentTypeMismatchException e) {
         String message = String.format("잘못된 요청: '%s' 값을 '%s' 타입으로 변환할 수 없습니다.", e.getValue(), e.getRequiredType().getSimpleName());
-        return ApiResponse.fail(message);
+        return ApiResponse.fail("TYPE_MISMATCH", message);
     }
 
     // 숫자 변환 실패
     @ExceptionHandler(NumberFormatException.class)
     public ApiResponse<?> handleNumberFormatException(NumberFormatException e) {
-        return ApiResponse.fail("숫자 변환 오류: " + e.getMessage());
+        return ApiResponse.fail("NUMBER_FORMAT_ERROR", "숫자 변환 오류: " + e.getMessage());
     }
 
     // 데이터베이스 접근 오류
     @ExceptionHandler(DataAccessException.class)
     public ApiResponse<?> handleDataAccessException(DataAccessException e) {
-        return ApiResponse.fail("데이터베이스 오류 발생: " + e.getMessage());
+        return ApiResponse.fail("DB_ACCESS_ERROR", "데이터베이스 오류 발생: " + e.getMessage());
     }
 
     // 요구되는 값이 비어있을 때
     @ExceptionHandler(NullPointerException.class)
     public ResponseEntity<ApiResponse<?>> handleNullPointerException(NullPointerException ex) {
-        ApiResponse<?> response = ApiResponse.fail("필수 데이터가 누락되었습니다.");
+        ApiResponse<?> response = ApiResponse.fail("NULL_POINTER", "필수 데이터가 누락되었습니다.");
         return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
     }
 
     // 유효하지 않은 요청 파라미터
     @ExceptionHandler(IllegalArgumentException.class)
     public ResponseEntity<ApiResponse<?>> handleIllegalArgumentException(IllegalArgumentException ex) {
-        ApiResponse<?> response = ApiResponse.fail("잘못된 요청: " + ex.getMessage());
+        ApiResponse<?> response = ApiResponse.fail("INVALID_ARGUMENT", "잘못된 요청: " + ex.getMessage());
         return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
     }
 
     // 특정 예외를 명확히 처리
     @ExceptionHandler(NoResultException.class)
     public ResponseEntity<ApiResponse<?>> handleNoResultException(NoResultException ex) {
-        ApiResponse<?> response = ApiResponse.fail("데이터를 찾을 수 없습니다.");
+        ApiResponse<?> response = ApiResponse.fail("NO_RESULT", "데이터를 찾을 수 없습니다.");
         return new ResponseEntity<>(response, HttpStatus.NOT_FOUND);
     }
 
     @ExceptionHandler(EmptyResultDataAccessException.class)
     public ResponseEntity<ApiResponse<?>> handleEmptyResultException(EmptyResultDataAccessException ex) {
-        ApiResponse<?> response = ApiResponse.fail("결과가 존재하지 않습니다.");
+        ApiResponse<?> response = ApiResponse.fail("EMPTY_RESULT", "결과가 존재하지 않습니다.");
         return new ResponseEntity<>(response, HttpStatus.NOT_FOUND);
     }
 
@@ -84,14 +84,14 @@ public class GlobalExceptionHandler {
     // 예시 예외를 캐치
     @ExceptionHandler(ExampleException.class)
     public ResponseEntity<ApiResponse<?>> handleExampleException(ExampleException ex) {
-        ApiResponse<?> response = ApiResponse.fail(ex.getMessage());
+        ApiResponse<?> response = ApiResponse.fail("EXAMPLE_EXCEPTION", ex.getMessage());
         return new ResponseEntity<>(response, HttpStatus.INTERNAL_SERVER_ERROR);
     }
 
     // UserException 캐치
     @ExceptionHandler(UserException.class)
     public ResponseEntity<ApiResponse<?>> handleUserException(UserException ex) {
-        ApiResponse<?> response = ApiResponse.fail(ex.getMessage());
+        ApiResponse<?> response = ApiResponse.fail("USER_EXCEPTION", ex.getMessage());
         return new ResponseEntity<>(response, HttpStatus.INTERNAL_SERVER_ERROR);
     }
 }

--- a/src/main/java/com/even/zaro/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/even/zaro/global/exception/GlobalExceptionHandler.java
@@ -1,13 +1,13 @@
 package com.even.zaro.global.exception;
 
 import com.even.zaro.global.ApiResponse;
+import com.even.zaro.global.ErrorCode;
 import com.even.zaro.global.exception.exampleEx.ExampleException;
 import com.even.zaro.global.exception.userEx.UserException;
 import jakarta.persistence.NoResultException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataAccessException;
 import org.springframework.dao.EmptyResultDataAccessException;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -20,63 +20,72 @@ public class GlobalExceptionHandler {
     // 기타 예외 처리
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ApiResponse<?>> handleGeneralException(Exception ex) {
-        ApiResponse<?> response = ApiResponse.fail("UNKNOWN_REQUEST", "알 수 없는 오류 요청 URL을 다시 확인해보십시오: " + ex.getMessage());
-        log.error(ex.getMessage(), ex);
-        return new ResponseEntity<>(response, HttpStatus.INTERNAL_SERVER_ERROR);
+        String message = "요청 url을 다시 확인해보세요 : " + ex.getMessage();
+        log.error(message, ex);
+        return ResponseEntity.status(ErrorCode.UNKNOWN_REQUEST.getHttpStatus()).body(ApiResponse.fail(ErrorCode.UNKNOWN_REQUEST));
     }
 
     // 이메일 중복 인증 발생 예외 처리
     @ExceptionHandler(IllegalStateException.class)
     public ResponseEntity<ApiResponse<?>> handleIllegalStateException(IllegalStateException ex) {
-        ApiResponse<?> response = ApiResponse.fail("ILLEGAL_STATE", ex.getMessage());
         log.error(ex.getMessage(), ex);
-        return new ResponseEntity<>(response, HttpStatus.INTERNAL_SERVER_ERROR);
+        return ResponseEntity.status(ErrorCode.ILLEGAL_STATE.getHttpStatus()).body(ApiResponse.fail(ErrorCode.ILLEGAL_STATE));
     }
 
     // 파라미터로 받은 값의 인자가 맞지 않을 때
     @ExceptionHandler(MethodArgumentTypeMismatchException.class)
-    public ApiResponse<?> handleTypeMismatchException(MethodArgumentTypeMismatchException e) {
-        String message = String.format("잘못된 요청: '%s' 값을 '%s' 타입으로 변환할 수 없습니다.", e.getValue(), e.getRequiredType().getSimpleName());
-        return ApiResponse.fail("TYPE_MISMATCH", message);
+    public ResponseEntity<ApiResponse<?>> handleTypeMismatchException(MethodArgumentTypeMismatchException ex) {
+        String message = String.format("잘못된 요청: '%s' 값을 '%s' 타입으로 변환할 수 없습니다.", ex.getValue(), ex.getRequiredType().getSimpleName());
+        log.error(message, ex);
+        return ResponseEntity.status(ErrorCode.TYPE_MISMATCH.getHttpStatus()).body(ApiResponse.fail(ErrorCode.TYPE_MISMATCH, message));
     }
 
     // 숫자 변환 실패
     @ExceptionHandler(NumberFormatException.class)
-    public ApiResponse<?> handleNumberFormatException(NumberFormatException e) {
-        return ApiResponse.fail("NUMBER_FORMAT_ERROR", "숫자 변환 오류: " + e.getMessage());
+    public ResponseEntity<ApiResponse<?>> handleNumberFormatException(NumberFormatException ex) {
+        String message = "숫자 변환 오류: " + ex.getMessage();
+        log.error(message, ex);
+        return ResponseEntity.status(ErrorCode.NUMBER_FORMAT_ERROR.getHttpStatus()).body(ApiResponse.fail(ErrorCode.NUMBER_FORMAT_ERROR, message));
     }
 
     // 데이터베이스 접근 오류
     @ExceptionHandler(DataAccessException.class)
-    public ApiResponse<?> handleDataAccessException(DataAccessException e) {
-        return ApiResponse.fail("DB_ACCESS_ERROR", "데이터베이스 오류 발생: " + e.getMessage());
+    public ResponseEntity<ApiResponse<?>> handleDataAccessException(DataAccessException ex) {
+        String message = "데이터베이스 오류 발생: " + ex.getMessage();
+        log.error(message, ex);
+        return ResponseEntity.status(ErrorCode.DB_ACCESS_ERROR.getHttpStatus()).body(ApiResponse.fail(ErrorCode.DB_ACCESS_ERROR, message));
+
     }
 
     // 요구되는 값이 비어있을 때
     @ExceptionHandler(NullPointerException.class)
     public ResponseEntity<ApiResponse<?>> handleNullPointerException(NullPointerException ex) {
-        ApiResponse<?> response = ApiResponse.fail("NULL_POINTER", "필수 데이터가 누락되었습니다.");
-        return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
+        String message = "필수 데이터가 누락되었습니다 : " + ex.getMessage();
+        log.error(ex.getMessage(), ex);
+        return ResponseEntity.status(ErrorCode.NULL_POINTER.getHttpStatus()).body(ApiResponse.fail(ErrorCode.NULL_POINTER, message));
+
     }
 
     // 유효하지 않은 요청 파라미터
     @ExceptionHandler(IllegalArgumentException.class)
     public ResponseEntity<ApiResponse<?>> handleIllegalArgumentException(IllegalArgumentException ex) {
-        ApiResponse<?> response = ApiResponse.fail("INVALID_ARGUMENT", "잘못된 요청: " + ex.getMessage());
-        return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
+        String message = "잘못된 요청: " + ex.getMessage();
+        log.error(message, ex);
+        return ResponseEntity.status(ErrorCode.INVALID_ARGUMENT.getHttpStatus()).body(ApiResponse.fail(ErrorCode.INVALID_ARGUMENT));
     }
 
     // 특정 예외를 명확히 처리
     @ExceptionHandler(NoResultException.class)
     public ResponseEntity<ApiResponse<?>> handleNoResultException(NoResultException ex) {
-        ApiResponse<?> response = ApiResponse.fail("NO_RESULT", "데이터를 찾을 수 없습니다.");
-        return new ResponseEntity<>(response, HttpStatus.NOT_FOUND);
+        log.error(ex.getMessage(), ex);
+        return ResponseEntity.status(ErrorCode.NO_RESULT.getHttpStatus()).body(ApiResponse.fail(ErrorCode.NO_RESULT));
     }
 
     @ExceptionHandler(EmptyResultDataAccessException.class)
     public ResponseEntity<ApiResponse<?>> handleEmptyResultException(EmptyResultDataAccessException ex) {
-        ApiResponse<?> response = ApiResponse.fail("EMPTY_RESULT", "결과가 존재하지 않습니다.");
-        return new ResponseEntity<>(response, HttpStatus.NOT_FOUND);
+        String message = "결과가 존재하지 않습니다 : " + ex.getMessage();
+        log.error(message, ex);
+        return ResponseEntity.status(ErrorCode.EMPTY_RESULT.getHttpStatus()).body(ApiResponse.fail(ErrorCode.EMPTY_RESULT));
     }
 
     // --------- 커스텀 예외 아래 작성 ------------- //
@@ -84,14 +93,16 @@ public class GlobalExceptionHandler {
     // 예시 예외를 캐치
     @ExceptionHandler(ExampleException.class)
     public ResponseEntity<ApiResponse<?>> handleExampleException(ExampleException ex) {
-        ApiResponse<?> response = ApiResponse.fail("EXAMPLE_EXCEPTION", ex.getMessage());
-        return new ResponseEntity<>(response, HttpStatus.INTERNAL_SERVER_ERROR);
+        String message = "예시 예외 발생 : " + ex.getMessage();
+        log.error(message, ex);
+        return ResponseEntity.status(ErrorCode.EXAMPLE_EXCEPTION.getHttpStatus()).body(ApiResponse.fail(ErrorCode.EXAMPLE_EXCEPTION));
     }
 
     // UserException 캐치
     @ExceptionHandler(UserException.class)
     public ResponseEntity<ApiResponse<?>> handleUserException(UserException ex) {
-        ApiResponse<?> response = ApiResponse.fail("USER_EXCEPTION", ex.getMessage());
-        return new ResponseEntity<>(response, HttpStatus.INTERNAL_SERVER_ERROR);
+        String message = "유저 예외 발생 : " + ex.getMessage();
+        log.error(message, ex);
+        return ResponseEntity.status(ErrorCode.USER_EXCEPTION.getHttpStatus()).body(ApiResponse.fail(ErrorCode.USER_EXCEPTION));
     }
 }

--- a/src/main/java/com/even/zaro/healthcheck/HealthCheckController.java
+++ b/src/main/java/com/even/zaro/healthcheck/HealthCheckController.java
@@ -15,14 +15,14 @@ public class HealthCheckController {
 
     @GetMapping("/health")
     public ResponseEntity<ApiResponse<String>> healthCheck() {
-        return ResponseEntity.ok(ApiResponse.success(null, "서버 정상 작동 중"));
+        return ResponseEntity.ok(ApiResponse.success("서버 정상 작동 중", null));
     }
 
     @GetMapping("/health/db")
     public ResponseEntity<ApiResponse<String>> dbHealth() {
         try {
             mockRepository.count(); // 실제 쿼리로 DB 연결 확인
-            return ResponseEntity.ok(ApiResponse.success(null, "DB 연결 성공"));
+            return ResponseEntity.ok(ApiResponse.success("DB 연결 성공",null));
         } catch (Exception e) {
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
                     .body(ApiResponse.fail("INTERNAL_SERVER_ERROR", "DB 연결 실패"));

--- a/src/main/java/com/even/zaro/healthcheck/HealthCheckController.java
+++ b/src/main/java/com/even/zaro/healthcheck/HealthCheckController.java
@@ -15,17 +15,17 @@ public class HealthCheckController {
 
     @GetMapping("/health")
     public ResponseEntity<ApiResponse<String>> healthCheck() {
-        return ResponseEntity.ok(ApiResponse.success("OK", "서버 정상 작동 중"));
+        return ResponseEntity.ok(ApiResponse.success(null, "서버 정상 작동 중"));
     }
 
     @GetMapping("/health/db")
     public ResponseEntity<ApiResponse<String>> dbHealth() {
         try {
             mockRepository.count(); // 실제 쿼리로 DB 연결 확인
-            return ResponseEntity.ok(ApiResponse.success("DB 연결 성공"));
+            return ResponseEntity.ok(ApiResponse.success(null, "DB 연결 성공"));
         } catch (Exception e) {
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                    .body(ApiResponse.fail("DB 연결 실패"));
+                    .body(ApiResponse.fail("INTERNAL_SERVER_ERROR", "DB 연결 실패"));
         }
     }
 }

--- a/src/main/java/com/even/zaro/healthcheck/HealthCheckController.java
+++ b/src/main/java/com/even/zaro/healthcheck/HealthCheckController.java
@@ -1,6 +1,7 @@
 package com.even.zaro.healthcheck;
 
 import com.even.zaro.global.ApiResponse;
+import com.even.zaro.global.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -25,7 +26,7 @@ public class HealthCheckController {
             return ResponseEntity.ok(ApiResponse.success("DB 연결 성공",null));
         } catch (Exception e) {
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                    .body(ApiResponse.fail("INTERNAL_SERVER_ERROR", "DB 연결 실패"));
+                    .body(ApiResponse.fail(ErrorCode.DB_ACCESS_ERROR, "DB 연결 실패"));
         }
     }
 }


### PR DESCRIPTION
## 📌 작업 개요

- API 응답객체 변경
     
---

## ✨ 주요 변경 사항
- 변경된 파일 및 폴더 구조
- 구현한 주요 기능 및 변경점
- GlobalException.java : 실패 코드 기본값 설정
- ApiResponse.java : 응답의 성공, 실패 형태 변경
- HealthCheck, ApiTest 컨트롤러 예시 응답 변경

피드백 사항
- ApiResponse 인자 순서 변경
- ErrorCode 파일로 오류 코드 관리 
- GlobalException 대거 수정 (응답형식 통일)
---

## 🖼️ 기능 살펴 보기

> ![image](https://github.com/user-attachments/assets/cfde45d2-20a2-410a-82b1-6fe70206fd03)
- 성공 시 

> ![image](https://github.com/user-attachments/assets/641538ce-fadc-4d0b-9582-4002eb17d00e)
- 잘못된 url 요청 

> ![image](https://github.com/user-attachments/assets/6b12f4c2-eb27-42f5-913d-ae4f5401ec53)
- 사용자 예외 예시

> ![image](https://github.com/user-attachments/assets/080953a3-5f74-4b04-b391-f0d7d1bdfb41)
- 예시 예외 



---

## ✅ 작업 체크리스트
- [x] API 테스트 완료 (POSTMAN)

---

## 📂 테스트 방법
- ApiTestController 
- HealthCheckController

---

## 💬 기타 참고 사항


---

## 📎 관련 이슈 / 문서

