### PR TITLE
Ref/favorite auth Profile API에서 Group,Favorite API 분리, 토큰 인증 처리 추가

### DIFF
--- a/src/main/java/com/even/zaro/controller/FavoriteController.java
+++ b/src/main/java/com/even/zaro/controller/FavoriteController.java
@@ -26,8 +26,6 @@ import java.util.List;
 @Tag(name = "즐겨찾기", description = "즐겨찾기 API")
 public class FavoriteController {
     private final FavoriteService favoriteService;
-    private final ProfileService profileService;
-
 
     @Operation(summary = "즐겨찾기 추가", description = "그룹에 즐겨찾기를 추가합니다.", security = {@SecurityRequirement(name = "bearer-key")})
     @PostMapping("/groups/{groupId}/favorites")

--- a/src/main/java/com/even/zaro/controller/FavoriteController.java
+++ b/src/main/java/com/even/zaro/controller/FavoriteController.java
@@ -1,0 +1,74 @@
+package com.even.zaro.controller;
+
+import com.even.zaro.dto.favorite.FavoriteAddRequest;
+import com.even.zaro.dto.favorite.FavoriteAddResponse;
+import com.even.zaro.dto.favorite.FavoriteEditRequest;
+import com.even.zaro.dto.favorite.FavoriteResponse;
+import com.even.zaro.dto.jwt.JwtUserInfoDto;
+import com.even.zaro.global.ApiResponse;
+import com.even.zaro.service.FavoriteService;
+import com.even.zaro.service.ProfileService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/favorite")
+@Slf4j
+@RequiredArgsConstructor
+@Tag(name = "즐겨찾기", description = "즐겨찾기 API")
+public class FavoriteController {
+    private final FavoriteService favoriteService;
+    private final ProfileService profileService;
+
+
+    @Operation(summary = "즐겨찾기 추가", description = "그룹에 즐겨찾기를 추가합니다.", security = {@SecurityRequirement(name = "bearer-key")})
+    @PostMapping("/groups/{groupId}/favorites")
+    public ResponseEntity<ApiResponse<FavoriteAddResponse>> addFavorite(@PathVariable("groupId") long groupId,
+                                                                        @RequestBody FavoriteAddRequest request,
+                                                                        @AuthenticationPrincipal JwtUserInfoDto userInfoDto) {
+        FavoriteAddResponse favoriteAddResponse = favoriteService.addFavorite(groupId, request, userInfoDto.getUserId());
+
+        return ResponseEntity.ok(ApiResponse.success("즐겨찾기가 해당 그룹에 성공적으로 추가되었습니다.", favoriteAddResponse));
+    }
+
+
+    @Operation(summary = "그룹의 즐겨찾기 리스트 조회", description = "해당 그룹의 즐겨찾기 리스트를 조회합니다.", security = {@SecurityRequirement(name = "bearer-key")})
+    @GetMapping("/favorite/{groupId}/items")
+    public ResponseEntity<ApiResponse<List<FavoriteResponse>>> getGroupItems(
+            @PathVariable("groupId") long groupId,
+            @AuthenticationPrincipal JwtUserInfoDto userInfoDto) {
+        List<FavoriteResponse> groupItems = favoriteService.getGroupItems(groupId);
+
+        return ResponseEntity.ok(ApiResponse.success("즐겨찾기 그룹의 장소 목록을 성공적으로 조회했습니다.", groupItems));
+    }
+
+
+    @Operation(summary = "즐겨찾기의 메모 수정", description = "해당 즐겨찾기의 메모를 수정합니다.", security = {@SecurityRequirement(name = "bearer-key")})
+    @PatchMapping("/favorite/{favoriteId}")
+    public ResponseEntity<ApiResponse<String>> editFavoriteMemo(
+            @PathVariable("favoriteId") long favoriteId,
+            @RequestBody FavoriteEditRequest request,
+            @AuthenticationPrincipal JwtUserInfoDto userInfoDto) {
+        favoriteService.editFavoriteMemo(favoriteId, request, userInfoDto.getUserId());
+
+        return ResponseEntity.ok(ApiResponse.success("즐겨찾기 메모가 성공적으로 수정되었습니다."));
+    }
+
+    @Operation(summary = "즐겨찾기 삭제", description = "해당 즐겨찾기를 삭제합니다.", security = {@SecurityRequirement(name = "bearer-key")})
+    @DeleteMapping("/favorite/{favoriteId}")
+    public ResponseEntity<ApiResponse<String>> deleteFavorite(
+            @PathVariable("favoriteId") long favoriteId,
+            @AuthenticationPrincipal JwtUserInfoDto userInfoDto) {
+        favoriteService.deleteFavorite(favoriteId, userInfoDto.getUserId());
+
+        return ResponseEntity.ok(ApiResponse.success("즐겨찾기가 성공적으로 삭제되었습니다."));
+    }
+}

--- a/src/main/java/com/even/zaro/controller/FavoriteController.java
+++ b/src/main/java/com/even/zaro/controller/FavoriteController.java
@@ -39,7 +39,7 @@ public class FavoriteController {
 
 
     @Operation(summary = "그룹의 즐겨찾기 리스트 조회", description = "해당 그룹의 즐겨찾기 리스트를 조회합니다.", security = {@SecurityRequirement(name = "bearer-key")})
-    @GetMapping("/favorite/{groupId}/items")
+    @GetMapping("/{groupId}/items")
     public ResponseEntity<ApiResponse<List<FavoriteResponse>>> getGroupItems(
             @PathVariable("groupId") long groupId,
             @AuthenticationPrincipal JwtUserInfoDto userInfoDto) {
@@ -50,7 +50,7 @@ public class FavoriteController {
 
 
     @Operation(summary = "즐겨찾기의 메모 수정", description = "해당 즐겨찾기의 메모를 수정합니다.", security = {@SecurityRequirement(name = "bearer-key")})
-    @PatchMapping("/favorite/{favoriteId}")
+    @PatchMapping("/{favoriteId}")
     public ResponseEntity<ApiResponse<String>> editFavoriteMemo(
             @PathVariable("favoriteId") long favoriteId,
             @RequestBody FavoriteEditRequest request,
@@ -61,7 +61,7 @@ public class FavoriteController {
     }
 
     @Operation(summary = "즐겨찾기 삭제", description = "해당 즐겨찾기를 삭제합니다.", security = {@SecurityRequirement(name = "bearer-key")})
-    @DeleteMapping("/favorite/{favoriteId}")
+    @DeleteMapping("/{favoriteId}")
     public ResponseEntity<ApiResponse<String>> deleteFavorite(
             @PathVariable("favoriteId") long favoriteId,
             @AuthenticationPrincipal JwtUserInfoDto userInfoDto) {

--- a/src/main/java/com/even/zaro/controller/GroupController.java
+++ b/src/main/java/com/even/zaro/controller/GroupController.java
@@ -1,0 +1,78 @@
+package com.even.zaro.controller;
+
+import com.even.zaro.dto.jwt.JwtUserInfoDto;
+import com.even.zaro.dto.profile.GroupCreateRequest;
+import com.even.zaro.dto.profile.GroupEditRequest;
+import com.even.zaro.dto.profile.GroupResponse;
+import com.even.zaro.global.ApiResponse;
+import com.even.zaro.service.GroupService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/group")
+@Slf4j
+@RequiredArgsConstructor
+@Tag(name = "그룹", description = "그룹 API")
+public class GroupController {
+
+    private final GroupService groupService;
+
+
+    @Operation(summary = "사용자의 그룹 리스트 조회", description = "해당 유저의 그룹 리스트를 조회합니다.", security = {@SecurityRequirement(name = "bearer-key")})
+    @GetMapping("/user/{userId}/group")
+    public ResponseEntity<ApiResponse<List<GroupResponse>>> getFavoriteGroupsByUserId(
+            @PathVariable("userId") long userId,
+            @AuthenticationPrincipal JwtUserInfoDto userInfoDto) {
+        List<GroupResponse> groupList = groupService.getFavoriteGroups(userId);
+
+        return ResponseEntity.ok(ApiResponse.success("해당 유저의 즐겨찾기 그룹 리스트를 조회했습니다.", groupList));
+    }
+
+
+    @Operation(summary = "나의 즐겨찾기 그룹 리스트 조회", description = "나의 즐겨찾기 그룹 리스트를 조회합니다.", security = {@SecurityRequirement(name = "bearer-key")})
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<GroupResponse>>> getMyFavoriteGroups(
+            @AuthenticationPrincipal JwtUserInfoDto userInfoDto) {
+        List<GroupResponse> groupList = groupService.getFavoriteGroups(userInfoDto.getUserId());
+
+        return ResponseEntity.ok(ApiResponse.success("나의 즐겨찾기 그룹 리스트를 조회했습니다.", groupList));
+    }
+
+    @Operation(summary = "즐겨찾기 그룹 추가", description = "그룹 이름을 입력받아 그룹을 추가합니다.", security = {@SecurityRequirement(name = "bearer-key")})
+    @PostMapping
+    public ResponseEntity<ApiResponse<String>> createGroup(@RequestBody GroupCreateRequest request,
+                                                           @AuthenticationPrincipal JwtUserInfoDto userInfoDto) {
+        long userId = userInfoDto.getUserId();
+        groupService.createGroup(request, userId);
+
+        return ResponseEntity.ok(ApiResponse.success("성공적으로 즐겨찾기 그룹이 생성되었습니다."));
+    }
+
+    @Operation(summary = "즐겨찾기 그룹 삭제", description = "groupId로 즐겨찾기 그룹 리스트를 삭제합니다.", security = {@SecurityRequirement(name = "bearer-key")})
+    @DeleteMapping("/{groupId}")
+    public ResponseEntity<ApiResponse<String>> deleteGroup(@PathVariable("groupId") long groupId,
+                                                           @AuthenticationPrincipal JwtUserInfoDto userInfoDto) {
+        groupService.deleteGroup(groupId, userInfoDto.getUserId());
+
+        return ResponseEntity.ok(ApiResponse.success("성공적으로 그룹을 삭제했습니다."));
+    }
+
+    @Operation(summary = "즐겨찾기 그룹 수정", description = "그룹 이름을 수정합니다.", security = {@SecurityRequirement(name = "bearer-key")})
+    @PatchMapping("/{groupId}")
+    public ResponseEntity<ApiResponse<String>> editGroup(@PathVariable("groupId") long groupId,
+                                                         @RequestBody GroupEditRequest request,
+                                                         @AuthenticationPrincipal JwtUserInfoDto userInfoDto) {
+        groupService.editGroup(groupId, request, userInfoDto.getUserId());
+
+        return ResponseEntity.ok(ApiResponse.success("성공적으로 그룹 이름을 수정했습니다."));
+    }
+}

--- a/src/main/java/com/even/zaro/controller/ProfileController.java
+++ b/src/main/java/com/even/zaro/controller/ProfileController.java
@@ -83,16 +83,17 @@ public class ProfileController {
             @AuthenticationPrincipal JwtUserInfoDto userInfoDto) {
         List<GroupResponse> groupList = profileService.getFavoriteGroups(userId);
 
-        return ResponseEntity.ok(ApiResponse.success("그룹 리스트를 조회했습니다.", groupList));
+        return ResponseEntity.ok(ApiResponse.success("해당 유저의 즐겨찾기 그룹 리스트를 조회했습니다.", groupList));
     }
 
 
     @Operation(summary = "나의 즐겨찾기 그룹 리스트 조회", description = "나의 즐겨찾기 그룹 리스트를 조회합니다.", security = {@SecurityRequirement(name = "bearer-key")})
     @GetMapping("/group")
-    public ResponseEntity<ApiResponse<List<GroupResponse>>> getMyFavoriteGroups(@RequestParam("userId") long userId) {
-        List<GroupResponse> groupList = profileService.getFavoriteGroups(userId);
+    public ResponseEntity<ApiResponse<List<GroupResponse>>> getMyFavoriteGroups(
+            @AuthenticationPrincipal JwtUserInfoDto userInfoDto) {
+        List<GroupResponse> groupList = profileService.getFavoriteGroups(userInfoDto.getUserId());
 
-        return ResponseEntity.ok(ApiResponse.success("그룹 리스트를 조회했습니다.", groupList));
+        return ResponseEntity.ok(ApiResponse.success("나의 즐겨찾기 그룹 리스트를 조회했습니다.", groupList));
     }
 
     @Operation(summary = "즐겨찾기 그룹 추가", description = "userId와 그룹이름을 입력받아 그룹을 추가합니다.")

--- a/src/main/java/com/even/zaro/controller/ProfileController.java
+++ b/src/main/java/com/even/zaro/controller/ProfileController.java
@@ -6,8 +6,11 @@ import com.even.zaro.dto.favorite.FavoriteAddRequest;
 import com.even.zaro.dto.favorite.FavoriteAddResponse;
 import com.even.zaro.dto.favorite.FavoriteEditRequest;
 import com.even.zaro.dto.favorite.FavoriteResponse;
+import com.even.zaro.dto.jwt.JwtUserInfoDto;
 import com.even.zaro.global.ApiResponse;
 import com.even.zaro.service.ProfileService;
+import com.nimbusds.openid.connect.sdk.claims.UserInfo;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -18,6 +21,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -30,7 +34,7 @@ import java.util.Map;
 @Tag(name = "프로필 페이지", description = "프로필 페이지 API")
 public class ProfileController {
     private final ProfileService profileService;
-  
+
     // 유저 기본 프로필 조회
     @GetMapping("/{userID}")
     public ResponseEntity<?> getUserProfile(@PathVariable("userID") Long userID) {
@@ -68,9 +72,24 @@ public class ProfileController {
         )));
     }
 
-    @Operation(summary = "즐겨찾기 그룹 리스트 조회", description = "userId로 즐겨찾기 그룹 리스트를 조회합니다.")
+
+
+    // -------------------------------------------------------------------------------------------------- //
+
+    @Operation(summary = "사용자의 그룹 리스트 조회", description = "해당 유저의 그룹 리스트를 조회합니다.", security = {@SecurityRequirement(name = "bearer-key")})
+    @GetMapping("/user/{userId}/group")
+    public ResponseEntity<ApiResponse<List<GroupResponse>>> getFavoriteGroupsByUserId (
+            @PathVariable("userId") long userId,
+            @AuthenticationPrincipal JwtUserInfoDto userInfoDto) {
+        List<GroupResponse> groupList = profileService.getFavoriteGroups(userId);
+
+        return ResponseEntity.ok(ApiResponse.success("그룹 리스트를 조회했습니다.", groupList));
+    }
+
+
+    @Operation(summary = "나의 즐겨찾기 그룹 리스트 조회", description = "나의 즐겨찾기 그룹 리스트를 조회합니다.", security = {@SecurityRequirement(name = "bearer-key")})
     @GetMapping("/group")
-    public ResponseEntity<ApiResponse<List<GroupResponse>>> getFavoriteGroups(@RequestParam("userId") long userId) {
+    public ResponseEntity<ApiResponse<List<GroupResponse>>> getMyFavoriteGroups(@RequestParam("userId") long userId) {
         List<GroupResponse> groupList = profileService.getFavoriteGroups(userId);
 
         return ResponseEntity.ok(ApiResponse.success("그룹 리스트를 조회했습니다.", groupList));

--- a/src/main/java/com/even/zaro/controller/ProfileController.java
+++ b/src/main/java/com/even/zaro/controller/ProfileController.java
@@ -115,10 +115,12 @@ public class ProfileController {
         return ResponseEntity.ok(ApiResponse.success("성공적으로 그룹을 삭제했습니다."));
     }
 
-    @Operation(summary = "즐겨찾기 그룹 수정", description = "userId와 그룹이름을 입력받아 그룹을 수정합니다.")
+    @Operation(summary = "즐겨찾기 그룹 수정", description = "그룹 이름을 수정합니다.")
     @PatchMapping("/group/{groupId}")
-    public ResponseEntity<ApiResponse<String>> editGroup(@PathVariable("groupId") long groupId, @RequestBody GroupEditRequest request) {
-        profileService.editGroup(groupId, request);
+    public ResponseEntity<ApiResponse<String>> editGroup(@PathVariable("groupId") long groupId,
+                                                         @RequestBody GroupEditRequest request,
+                                                         @AuthenticationPrincipal JwtUserInfoDto userInfoDto) {
+        profileService.editGroup(groupId, request, userInfoDto.getUserId());
 
         return ResponseEntity.ok(ApiResponse.success("성공적으로 그룹 이름을 수정했습니다."));
     }

--- a/src/main/java/com/even/zaro/controller/ProfileController.java
+++ b/src/main/java/com/even/zaro/controller/ProfileController.java
@@ -2,29 +2,16 @@ package com.even.zaro.controller;
 
 import com.even.zaro.dto.UserPostDto;
 import com.even.zaro.dto.UserProfileDto;
-import com.even.zaro.dto.favorite.FavoriteAddRequest;
-import com.even.zaro.dto.favorite.FavoriteAddResponse;
-import com.even.zaro.dto.favorite.FavoriteEditRequest;
-import com.even.zaro.dto.favorite.FavoriteResponse;
-import com.even.zaro.dto.jwt.JwtUserInfoDto;
 import com.even.zaro.global.ApiResponse;
 import com.even.zaro.service.ProfileService;
-import com.nimbusds.openid.connect.sdk.claims.UserInfo;
-import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
-import com.even.zaro.dto.profile.GroupCreateRequest;
-import com.even.zaro.dto.profile.GroupEditRequest;
-import com.even.zaro.dto.profile.GroupResponse;
-import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
 import java.util.Map;
 
 @RestController
@@ -70,58 +57,5 @@ public class ProfileController {
                 "content", likedPosts.getContent(),
                 "totalPages", likedPosts.getTotalPages()
         )));
-    }
-
-
-
-    // -------------------------------------------------------------------------------------------------- //
-
-    @Operation(summary = "사용자의 그룹 리스트 조회", description = "해당 유저의 그룹 리스트를 조회합니다.", security = {@SecurityRequirement(name = "bearer-key")})
-    @GetMapping("/user/{userId}/group")
-    public ResponseEntity<ApiResponse<List<GroupResponse>>> getFavoriteGroupsByUserId (
-            @PathVariable("userId") long userId,
-            @AuthenticationPrincipal JwtUserInfoDto userInfoDto) {
-        List<GroupResponse> groupList = profileService.getFavoriteGroups(userId);
-
-        return ResponseEntity.ok(ApiResponse.success("해당 유저의 즐겨찾기 그룹 리스트를 조회했습니다.", groupList));
-    }
-
-
-    @Operation(summary = "나의 즐겨찾기 그룹 리스트 조회", description = "나의 즐겨찾기 그룹 리스트를 조회합니다.", security = {@SecurityRequirement(name = "bearer-key")})
-    @GetMapping("/group")
-    public ResponseEntity<ApiResponse<List<GroupResponse>>> getMyFavoriteGroups(
-            @AuthenticationPrincipal JwtUserInfoDto userInfoDto) {
-        List<GroupResponse> groupList = profileService.getFavoriteGroups(userInfoDto.getUserId());
-
-        return ResponseEntity.ok(ApiResponse.success("나의 즐겨찾기 그룹 리스트를 조회했습니다.", groupList));
-    }
-
-    @Operation(summary = "즐겨찾기 그룹 추가", description = "그룹 이름을 입력받아 그룹을 추가합니다.")
-    @PostMapping("/group")
-    public ResponseEntity<ApiResponse<String>> createGroup(@RequestBody GroupCreateRequest request,
-                                                           @AuthenticationPrincipal JwtUserInfoDto userInfoDto) {
-        long userId = userInfoDto.getUserId();
-        profileService.createGroup(request, userId);
-
-        return ResponseEntity.ok(ApiResponse.success("성공적으로 즐겨찾기 그룹이 생성되었습니다."));
-    }
-
-    @Operation(summary = "즐겨찾기 그룹 삭제", description = "groupId로 즐겨찾기 그룹 리스트를 삭제합니다.", security = {@SecurityRequirement(name = "bearer-key")})
-    @DeleteMapping("/group/{groupId}")
-    public ResponseEntity<ApiResponse<String>> deleteGroup(@PathVariable("groupId") long groupId,
-                                                           @AuthenticationPrincipal JwtUserInfoDto userInfoDto) {
-        profileService.deleteGroup(groupId, userInfoDto.getUserId());
-
-        return ResponseEntity.ok(ApiResponse.success("성공적으로 그룹을 삭제했습니다."));
-    }
-
-    @Operation(summary = "즐겨찾기 그룹 수정", description = "그룹 이름을 수정합니다.")
-    @PatchMapping("/group/{groupId}")
-    public ResponseEntity<ApiResponse<String>> editGroup(@PathVariable("groupId") long groupId,
-                                                         @RequestBody GroupEditRequest request,
-                                                         @AuthenticationPrincipal JwtUserInfoDto userInfoDto) {
-        profileService.editGroup(groupId, request, userInfoDto.getUserId());
-
-        return ResponseEntity.ok(ApiResponse.success("성공적으로 그룹 이름을 수정했습니다."));
     }
 }

--- a/src/main/java/com/even/zaro/controller/ProfileController.java
+++ b/src/main/java/com/even/zaro/controller/ProfileController.java
@@ -124,47 +124,4 @@ public class ProfileController {
 
         return ResponseEntity.ok(ApiResponse.success("성공적으로 그룹 이름을 수정했습니다."));
     }
-
-    @Operation(summary = "즐겨찾기 추가", description = "그룹에 즐겨찾기를 추가합니다.", security = {@SecurityRequirement(name = "bearer-key")})
-    @PostMapping("/groups/{groupId}/favorites")
-    public ResponseEntity<ApiResponse<FavoriteAddResponse>> addFavorite(@PathVariable("groupId") long groupId,
-                                                                        @RequestBody FavoriteAddRequest request,
-                                                                        @AuthenticationPrincipal JwtUserInfoDto userInfoDto) {
-        FavoriteAddResponse favoriteAddResponse = profileService.addFavorite(groupId, request, userInfoDto.getUserId());
-
-        return ResponseEntity.ok(ApiResponse.success("즐겨찾기가 해당 그룹에 성공적으로 추가되었습니다.", favoriteAddResponse));
-    }
-
-
-    @Operation(summary = "그룹의 즐겨찾기 리스트 조회", description = "해당 그룹의 즐겨찾기 리스트를 조회합니다.", security = {@SecurityRequirement(name = "bearer-key")})
-    @GetMapping("/favorite/{groupId}/items")
-    public ResponseEntity<ApiResponse<List<FavoriteResponse>>> getGroupItems(
-            @PathVariable("groupId") long groupId,
-            @AuthenticationPrincipal JwtUserInfoDto userInfoDto) {
-        List<FavoriteResponse> groupItems = profileService.getGroupItems(groupId);
-
-        return ResponseEntity.ok(ApiResponse.success("즐겨찾기 그룹의 장소 목록을 성공적으로 조회했습니다.", groupItems));
-    }
-
-
-    @Operation(summary = "즐겨찾기의 메모 수정", description = "해당 즐겨찾기의 메모를 수정합니다.", security = {@SecurityRequirement(name = "bearer-key")})
-    @PatchMapping("/favorite/{favoriteId}")
-    public ResponseEntity<ApiResponse<String>> editFavoriteMemo(
-            @PathVariable("favoriteId") long favoriteId,
-            @RequestBody FavoriteEditRequest request,
-            @AuthenticationPrincipal JwtUserInfoDto userInfoDto) {
-        profileService.editFavoriteMemo(favoriteId, request, userInfoDto.getUserId());
-
-        return ResponseEntity.ok(ApiResponse.success("즐겨찾기 메모가 성공적으로 수정되었습니다."));
-    }
-
-    @Operation(summary = "즐겨찾기 삭제", description = "해당 즐겨찾기를 삭제합니다.", security = {@SecurityRequirement(name = "bearer-key")})
-    @DeleteMapping("/favorite/{favoriteId}")
-    public ResponseEntity<ApiResponse<String>> deleteFavorite(
-            @PathVariable("favoriteId") long favoriteId,
-            @AuthenticationPrincipal JwtUserInfoDto userInfoDto) {
-        profileService.deleteFavorite(favoriteId, userInfoDto.getUserId());
-
-        return ResponseEntity.ok(ApiResponse.success("즐겨찾기가 성공적으로 삭제되었습니다."));
-    }
 }

--- a/src/main/java/com/even/zaro/controller/ProfileController.java
+++ b/src/main/java/com/even/zaro/controller/ProfileController.java
@@ -125,7 +125,7 @@ public class ProfileController {
         return ResponseEntity.ok(ApiResponse.success("성공적으로 그룹 이름을 수정했습니다."));
     }
 
-    @Operation(summary = "즐겨찾기 추가", description = "그룹에 즐겨찾기를 추가합니다.")
+    @Operation(summary = "즐겨찾기 추가", description = "그룹에 즐겨찾기를 추가합니다.", security = {@SecurityRequirement(name = "bearer-key")})
     @PostMapping("/groups/{groupId}/favorites")
     public ResponseEntity<ApiResponse<FavoriteAddResponse>> addFavorite(@PathVariable("groupId") long groupId,
                                                                         @RequestBody FavoriteAddRequest request,
@@ -136,9 +136,11 @@ public class ProfileController {
     }
 
 
-    @Operation(summary = "그룹의 즐겨찾기 리스트 조회", description = "해당 그룹의 즐겨찾기 리스트를 조회합니다.")
+    @Operation(summary = "그룹의 즐겨찾기 리스트 조회", description = "해당 그룹의 즐겨찾기 리스트를 조회합니다.", security = {@SecurityRequirement(name = "bearer-key")})
     @GetMapping("/favorite/{groupId}/items")
-    public ResponseEntity<ApiResponse<List<FavoriteResponse>>> getGroupItems(@PathVariable("groupId") long groupId) {
+    public ResponseEntity<ApiResponse<List<FavoriteResponse>>> getGroupItems(
+            @PathVariable("groupId") long groupId,
+            @AuthenticationPrincipal JwtUserInfoDto userInfoDto) {
         List<FavoriteResponse> groupItems = profileService.getGroupItems(groupId);
 
         return ResponseEntity.ok(ApiResponse.success("즐겨찾기 그룹의 장소 목록을 성공적으로 조회했습니다.", groupItems));

--- a/src/main/java/com/even/zaro/controller/ProfileController.java
+++ b/src/main/java/com/even/zaro/controller/ProfileController.java
@@ -158,10 +158,12 @@ public class ProfileController {
         return ResponseEntity.ok(ApiResponse.success("즐겨찾기 메모가 성공적으로 수정되었습니다."));
     }
 
-    @Operation(summary = "즐겨찾기 삭제", description = "해당 즐겨찾기를 삭제합니다.")
+    @Operation(summary = "즐겨찾기 삭제", description = "해당 즐겨찾기를 삭제합니다.", security = {@SecurityRequirement(name = "bearer-key")})
     @DeleteMapping("/favorite/{favoriteId}")
-    public ResponseEntity<ApiResponse<String>> deleteFavorite(@PathVariable("favoriteId") long favoriteId) {
-        profileService.deleteFavorite(favoriteId);
+    public ResponseEntity<ApiResponse<String>> deleteFavorite(
+            @PathVariable("favoriteId") long favoriteId,
+            @AuthenticationPrincipal JwtUserInfoDto userInfoDto) {
+        profileService.deleteFavorite(favoriteId, userInfoDto.getUserId());
 
         return ResponseEntity.ok(ApiResponse.success("즐겨찾기가 성공적으로 삭제되었습니다."));
     }

--- a/src/main/java/com/even/zaro/controller/ProfileController.java
+++ b/src/main/java/com/even/zaro/controller/ProfileController.java
@@ -126,9 +126,11 @@ public class ProfileController {
     }
 
     @Operation(summary = "즐겨찾기 추가", description = "그룹에 즐겨찾기를 추가합니다.")
-    @PostMapping("/favorite/{groupId}")
-    public ResponseEntity<ApiResponse<FavoriteAddResponse>> addFavorite(@PathVariable("groupId") long groupId, @RequestBody FavoriteAddRequest request) {
-        FavoriteAddResponse favoriteAddResponse = profileService.addFavorite(groupId, request);
+    @PostMapping("/groups/{groupId}/favorites")
+    public ResponseEntity<ApiResponse<FavoriteAddResponse>> addFavorite(@PathVariable("groupId") long groupId,
+                                                                        @RequestBody FavoriteAddRequest request,
+                                                                        @AuthenticationPrincipal JwtUserInfoDto userInfoDto) {
+        FavoriteAddResponse favoriteAddResponse = profileService.addFavorite(groupId, request, userInfoDto.getUserId());
 
         return ResponseEntity.ok(ApiResponse.success("즐겨찾기가 해당 그룹에 성공적으로 추가되었습니다.", favoriteAddResponse));
     }

--- a/src/main/java/com/even/zaro/controller/ProfileController.java
+++ b/src/main/java/com/even/zaro/controller/ProfileController.java
@@ -147,10 +147,13 @@ public class ProfileController {
     }
 
 
-    @Operation(summary = "즐겨찾기의 메모 수정", description = "해당 즐겨찾기의 메모를 수정합니다.")
+    @Operation(summary = "즐겨찾기의 메모 수정", description = "해당 즐겨찾기의 메모를 수정합니다.", security = {@SecurityRequirement(name = "bearer-key")})
     @PatchMapping("/favorite/{favoriteId}")
-    public ResponseEntity<ApiResponse<String>> editFavoriteMemo(@PathVariable("favoriteId") long favoriteId, @RequestBody FavoriteEditRequest request) {
-        profileService.editFavoriteMemo(favoriteId, request);
+    public ResponseEntity<ApiResponse<String>> editFavoriteMemo(
+            @PathVariable("favoriteId") long favoriteId,
+            @RequestBody FavoriteEditRequest request,
+            @AuthenticationPrincipal JwtUserInfoDto userInfoDto) {
+        profileService.editFavoriteMemo(favoriteId, request, userInfoDto.getUserId());
 
         return ResponseEntity.ok(ApiResponse.success("즐겨찾기 메모가 성공적으로 수정되었습니다."));
     }

--- a/src/main/java/com/even/zaro/controller/ProfileController.java
+++ b/src/main/java/com/even/zaro/controller/ProfileController.java
@@ -106,10 +106,11 @@ public class ProfileController {
         return ResponseEntity.ok(ApiResponse.success("성공적으로 즐겨찾기 그룹이 생성되었습니다."));
     }
 
-    @Operation(summary = "즐겨찾기 그룹 삭제", description = "groupId로 즐겨찾기 그룹 리스트를 삭제합니다.")
+    @Operation(summary = "즐겨찾기 그룹 삭제", description = "groupId로 즐겨찾기 그룹 리스트를 삭제합니다.", security = {@SecurityRequirement(name = "bearer-key")})
     @DeleteMapping("/group/{groupId}")
-    public ResponseEntity<ApiResponse<String>> deleteGroup(@PathVariable("groupId") long groupId) {
-        profileService.deleteGroup(groupId);
+    public ResponseEntity<ApiResponse<String>> deleteGroup(@PathVariable("groupId") long groupId,
+                                                           @AuthenticationPrincipal JwtUserInfoDto userInfoDto) {
+        profileService.deleteGroup(groupId, userInfoDto.getUserId());
 
         return ResponseEntity.ok(ApiResponse.success("성공적으로 그룹을 삭제했습니다."));
     }

--- a/src/main/java/com/even/zaro/controller/ProfileController.java
+++ b/src/main/java/com/even/zaro/controller/ProfileController.java
@@ -96,12 +96,14 @@ public class ProfileController {
         return ResponseEntity.ok(ApiResponse.success("나의 즐겨찾기 그룹 리스트를 조회했습니다.", groupList));
     }
 
-    @Operation(summary = "즐겨찾기 그룹 추가", description = "userId와 그룹이름을 입력받아 그룹을 추가합니다.")
+    @Operation(summary = "즐겨찾기 그룹 추가", description = "그룹 이름을 입력받아 그룹을 추가합니다.")
     @PostMapping("/group")
-    public ResponseEntity<ApiResponse<String>> createGroup(@RequestBody GroupCreateRequest request) {
-        profileService.createGroup(request);
+    public ResponseEntity<ApiResponse<String>> createGroup(@RequestBody GroupCreateRequest request,
+                                                           @AuthenticationPrincipal JwtUserInfoDto userInfoDto) {
+        long userId = userInfoDto.getUserId();
+        profileService.createGroup(request, userId);
 
-        return ResponseEntity.ok(ApiResponse.success("성공적으로 그룹이 생성되었습니다."));
+        return ResponseEntity.ok(ApiResponse.success("성공적으로 즐겨찾기 그룹이 생성되었습니다."));
     }
 
     @Operation(summary = "즐겨찾기 그룹 삭제", description = "groupId로 즐겨찾기 그룹 리스트를 삭제합니다.")

--- a/src/main/java/com/even/zaro/dto/favorite/FavoriteAddRequest.java
+++ b/src/main/java/com/even/zaro/dto/favorite/FavoriteAddRequest.java
@@ -5,10 +5,6 @@ import lombok.Getter;
 
 @Getter
 public class FavoriteAddRequest {
-
-    @Schema(description = "사용자 ID", example = "1")
-    private long userId;
-
     @Schema(description = "장소 ID", example = "3")
     private long placeId;
 

--- a/src/main/java/com/even/zaro/dto/profile/GroupCreateRequest.java
+++ b/src/main/java/com/even/zaro/dto/profile/GroupCreateRequest.java
@@ -5,10 +5,6 @@ import lombok.Data;
 
 @Data
 public class GroupCreateRequest {
-
-    @Schema(description = "유저 id", example = "1")
-    private long userId;
-
     // Group 이름
     @Schema(description = "그룹 이름", example = "강릉 맛집!!")
     private String name;

--- a/src/main/java/com/even/zaro/global/ErrorCode.java
+++ b/src/main/java/com/even/zaro/global/ErrorCode.java
@@ -39,6 +39,7 @@ public enum ErrorCode {
 
     FAVORITE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 즐겨찾기를 찾지 못했습니다."),
     UNAUTHORIZED_GROUP_DELETE(HttpStatus.UNAUTHORIZED, "다른 사용자의 그룹 삭제 시도입니다."),
+    UNAUTHORIZED_GROUP_UPDATE(HttpStatus.UNAUTHORIZED, "다른 사용자의 그룹 수정 시도입니다."),
 
 
 

--- a/src/main/java/com/even/zaro/global/ErrorCode.java
+++ b/src/main/java/com/even/zaro/global/ErrorCode.java
@@ -38,6 +38,7 @@ public enum ErrorCode {
     GROUP_ALREADY_EXIST(HttpStatus.NOT_FOUND, "이미 존재하는 그룹 이름입니다."),
 
     FAVORITE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 즐겨찾기를 찾지 못했습니다."),
+    UNAUTHORIZED_GROUP_DELETE(HttpStatus.UNAUTHORIZED, "다른 사용자의 그룹 삭제 시도입니다."),
 
 
 

--- a/src/main/java/com/even/zaro/global/ErrorCode.java
+++ b/src/main/java/com/even/zaro/global/ErrorCode.java
@@ -40,6 +40,7 @@ public enum ErrorCode {
     FAVORITE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 즐겨찾기를 찾지 못했습니다."),
     UNAUTHORIZED_GROUP_DELETE(HttpStatus.UNAUTHORIZED, "다른 사용자의 그룹 삭제 시도입니다."),
     UNAUTHORIZED_GROUP_UPDATE(HttpStatus.UNAUTHORIZED, "다른 사용자의 그룹 수정 시도입니다."),
+    UNAUTHORIZED_FAVORITE_UPDATE(HttpStatus.UNAUTHORIZED, "다른 사용자의 즐겨찾기 메모 수정 시도입니다."),
 
 
 

--- a/src/main/java/com/even/zaro/global/ErrorCode.java
+++ b/src/main/java/com/even/zaro/global/ErrorCode.java
@@ -41,7 +41,7 @@ public enum ErrorCode {
     UNAUTHORIZED_GROUP_DELETE(HttpStatus.UNAUTHORIZED, "다른 사용자의 그룹 삭제 시도입니다."),
     UNAUTHORIZED_GROUP_UPDATE(HttpStatus.UNAUTHORIZED, "다른 사용자의 그룹 수정 시도입니다."),
     UNAUTHORIZED_FAVORITE_UPDATE(HttpStatus.UNAUTHORIZED, "다른 사용자의 즐겨찾기 메모 수정 시도입니다."),
-
+    UNAUTHORIZED_FAVORITE_DELETE(HttpStatus.UNAUTHORIZED, "다른 사용자의 즐겨찾기 삭제 시도입니다."),
 
 
 

--- a/src/main/java/com/even/zaro/global/exception/favorite/FavoriteException.java
+++ b/src/main/java/com/even/zaro/global/exception/favorite/FavoriteException.java
@@ -1,0 +1,10 @@
+package com.even.zaro.global.exception.favorite;
+
+import com.even.zaro.global.ErrorCode;
+import com.even.zaro.global.exception.CustomException;
+
+public class FavoriteException extends CustomException {
+    public FavoriteException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/even/zaro/global/exception/group/GroupException.java
+++ b/src/main/java/com/even/zaro/global/exception/group/GroupException.java
@@ -1,0 +1,10 @@
+package com.even.zaro.global.exception.group;
+
+import com.even.zaro.global.ErrorCode;
+import com.even.zaro.global.exception.CustomException;
+
+public class GroupException extends CustomException {
+    public GroupException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/even/zaro/service/FavoriteService.java
+++ b/src/main/java/com/even/zaro/service/FavoriteService.java
@@ -1,0 +1,135 @@
+package com.even.zaro.service;
+
+import com.even.zaro.dto.favorite.FavoriteAddRequest;
+import com.even.zaro.dto.favorite.FavoriteAddResponse;
+import com.even.zaro.dto.favorite.FavoriteEditRequest;
+import com.even.zaro.dto.favorite.FavoriteResponse;
+import com.even.zaro.entity.Favorite;
+import com.even.zaro.entity.FavoriteGroup;
+import com.even.zaro.entity.Place;
+import com.even.zaro.entity.User;
+import com.even.zaro.global.ErrorCode;
+import com.even.zaro.global.exception.map.MapException;
+import com.even.zaro.global.exception.profile.ProfileException;
+import com.even.zaro.global.exception.user.UserException;
+import com.even.zaro.repository.*;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Slf4j
+@AllArgsConstructor
+@Transactional
+public class FavoriteService {
+    private final FavoriteRepository favoriteRepository;
+    private final UserRepository userRepository;
+    private final PlaceRepository placeRepository;
+    private final FavoriteGroupRepository favoriteGroupRepository;
+
+    // 그룹에 즐겨찾기를 추가
+    public FavoriteAddResponse addFavorite(long groupId, FavoriteAddRequest request, long userId) {
+
+        FavoriteGroup group = favoriteGroupRepository.findById(groupId)
+                .orElseThrow(() -> new ProfileException(ErrorCode.GROUP_NOT_FOUND));
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserException(ErrorCode.EXAMPLE_USER_NOT_FOUND));
+
+        Place place = placeRepository.findById(request.getPlaceId())
+                .orElseThrow(() -> new MapException(ErrorCode.PLACE_NOT_FOUND));
+
+        Favorite favorite = Favorite.builder()
+                .user(user)
+                .group(group)
+                .place(place)
+                .memo(request.getMemo())
+                .isDeleted(false)
+                .build();
+
+        // 즐겨찾기 개수 1 증가
+        place.setFavoriteCount(place.getFavoriteCount() + 1);
+
+        favoriteRepository.save(favorite);
+        placeRepository.save(place);
+
+        FavoriteAddResponse favoriteAddResponse = FavoriteAddResponse.builder()
+                .placeId(favorite.getPlace().getId())
+                .memo(favorite.getMemo())
+                .lat(favorite.getPlace().getLat())
+                .lng(favorite.getPlace().getLng())
+                .address(favorite.getPlace().getAddress())
+                .build();
+
+        return favoriteAddResponse;
+    }
+
+    // 해당 그룹의 즐겨찾기 리스트를 조회
+    public List<FavoriteResponse> getGroupItems(long groupId) {
+        FavoriteGroup group = favoriteGroupRepository.findById(groupId)
+                .orElseThrow(() -> new ProfileException(ErrorCode.GROUP_NOT_FOUND));
+
+        List<Favorite> favoriteList = favoriteRepository.findAllByGroup(group);
+
+        List<FavoriteResponse> favoriteResponseList = favoriteList.stream().map(favorite ->
+                FavoriteResponse.builder()
+                        .id(favorite.getId())
+                        .userId(favorite.getUser().getId())
+                        .groupId(favorite.getGroup().getId())
+                        .placeId(favorite.getPlace().getId())
+                        .memo(favorite.getMemo())
+                        .createdAt(favorite.getCreatedAt())
+                        .updatedAt(favorite.getUpdatedAt())
+                        .isDeleted(favorite.isDeleted())
+                        .lat(favorite.getPlace().getLat())
+                        .lng(favorite.getPlace().getLng())
+                        .address(favorite.getPlace().getAddress())
+                        .build()
+        ).toList();
+
+        return favoriteResponseList;
+    }
+
+    // 해당 즐겨찾기의 메모를 수정
+    public void editFavoriteMemo(long favoriteId, FavoriteEditRequest request, long userId) {
+        Favorite favorite = favoriteRepository.findById(favoriteId)
+                .orElseThrow(() -> new ProfileException(ErrorCode.FAVORITE_NOT_FOUND));
+
+        // 로그인한 사용자와 즐겨찾기의 userId가 일치하는지 검증
+        if (favorite.getUser().getId() != userId) {
+            throw new ProfileException(ErrorCode.UNAUTHORIZED_FAVORITE_UPDATE);
+        }
+
+        favorite.setMemo(request.getMemo());
+
+        favoriteRepository.save(favorite);
+    }
+
+    // 해당 즐겨찾기를 soft 삭제
+    public void deleteFavorite(long favoriteId, long userId) {
+        Favorite favorite = favoriteRepository.findById(favoriteId)
+                .orElseThrow(() -> new ProfileException(ErrorCode.FAVORITE_NOT_FOUND));
+
+        // 즐겨찾기의 userId와 로그인한 사용자의 userId 일치 여부 검증
+        if (favorite.getUser().getId() != userId) {
+            throw new ProfileException(ErrorCode.UNAUTHORIZED_FAVORITE_DELETE);
+        }
+
+
+        long placeId = favorite.getPlace().getId();
+
+        Place place = placeRepository.findById(placeId)
+                .orElseThrow(() -> new ProfileException(ErrorCode.PLACE_NOT_FOUND));
+
+        // 즐겨찾기 개수 1 감소
+        place.setFavoriteCount(place.getFavoriteCount() - 1);
+
+        favorite.setDeleted(true);
+
+        favoriteRepository.save(favorite);
+        placeRepository.save(place);
+    }
+}

--- a/src/main/java/com/even/zaro/service/FavoriteService.java
+++ b/src/main/java/com/even/zaro/service/FavoriteService.java
@@ -9,8 +9,9 @@ import com.even.zaro.entity.FavoriteGroup;
 import com.even.zaro.entity.Place;
 import com.even.zaro.entity.User;
 import com.even.zaro.global.ErrorCode;
+import com.even.zaro.global.exception.favorite.FavoriteException;
+import com.even.zaro.global.exception.group.GroupException;
 import com.even.zaro.global.exception.map.MapException;
-import com.even.zaro.global.exception.profile.ProfileException;
 import com.even.zaro.global.exception.user.UserException;
 import com.even.zaro.repository.*;
 import lombok.AllArgsConstructor;
@@ -34,7 +35,7 @@ public class FavoriteService {
     public FavoriteAddResponse addFavorite(long groupId, FavoriteAddRequest request, long userId) {
 
         FavoriteGroup group = favoriteGroupRepository.findById(groupId)
-                .orElseThrow(() -> new ProfileException(ErrorCode.GROUP_NOT_FOUND));
+                .orElseThrow(() -> new GroupException(ErrorCode.GROUP_NOT_FOUND));
 
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new UserException(ErrorCode.EXAMPLE_USER_NOT_FOUND));
@@ -70,7 +71,7 @@ public class FavoriteService {
     // 해당 그룹의 즐겨찾기 리스트를 조회
     public List<FavoriteResponse> getGroupItems(long groupId) {
         FavoriteGroup group = favoriteGroupRepository.findById(groupId)
-                .orElseThrow(() -> new ProfileException(ErrorCode.GROUP_NOT_FOUND));
+                .orElseThrow(() -> new GroupException(ErrorCode.GROUP_NOT_FOUND));
 
         List<Favorite> favoriteList = favoriteRepository.findAllByGroup(group);
 
@@ -96,11 +97,11 @@ public class FavoriteService {
     // 해당 즐겨찾기의 메모를 수정
     public void editFavoriteMemo(long favoriteId, FavoriteEditRequest request, long userId) {
         Favorite favorite = favoriteRepository.findById(favoriteId)
-                .orElseThrow(() -> new ProfileException(ErrorCode.FAVORITE_NOT_FOUND));
+                .orElseThrow(() -> new FavoriteException(ErrorCode.FAVORITE_NOT_FOUND));
 
         // 로그인한 사용자와 즐겨찾기의 userId가 일치하는지 검증
         if (favorite.getUser().getId() != userId) {
-            throw new ProfileException(ErrorCode.UNAUTHORIZED_FAVORITE_UPDATE);
+            throw new FavoriteException(ErrorCode.UNAUTHORIZED_FAVORITE_UPDATE);
         }
 
         favorite.setMemo(request.getMemo());
@@ -111,18 +112,18 @@ public class FavoriteService {
     // 해당 즐겨찾기를 soft 삭제
     public void deleteFavorite(long favoriteId, long userId) {
         Favorite favorite = favoriteRepository.findById(favoriteId)
-                .orElseThrow(() -> new ProfileException(ErrorCode.FAVORITE_NOT_FOUND));
+                .orElseThrow(() -> new FavoriteException(ErrorCode.FAVORITE_NOT_FOUND));
 
         // 즐겨찾기의 userId와 로그인한 사용자의 userId 일치 여부 검증
         if (favorite.getUser().getId() != userId) {
-            throw new ProfileException(ErrorCode.UNAUTHORIZED_FAVORITE_DELETE);
+            throw new FavoriteException(ErrorCode.UNAUTHORIZED_FAVORITE_DELETE);
         }
 
 
         long placeId = favorite.getPlace().getId();
 
         Place place = placeRepository.findById(placeId)
-                .orElseThrow(() -> new ProfileException(ErrorCode.PLACE_NOT_FOUND));
+                .orElseThrow(() -> new MapException(ErrorCode.PLACE_NOT_FOUND));
 
         // 즐겨찾기 개수 1 감소
         place.setFavoriteCount(place.getFavoriteCount() - 1);

--- a/src/main/java/com/even/zaro/service/GroupService.java
+++ b/src/main/java/com/even/zaro/service/GroupService.java
@@ -1,0 +1,112 @@
+package com.even.zaro.service;
+
+import com.even.zaro.dto.profile.GroupCreateRequest;
+import com.even.zaro.dto.profile.GroupEditRequest;
+import com.even.zaro.dto.profile.GroupResponse;
+import com.even.zaro.entity.FavoriteGroup;
+import com.even.zaro.entity.User;
+import com.even.zaro.global.ErrorCode;
+import com.even.zaro.global.exception.group.GroupException;
+import com.even.zaro.global.exception.user.UserException;
+import com.even.zaro.repository.FavoriteGroupRepository;
+import com.even.zaro.repository.UserRepository;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@Slf4j
+@AllArgsConstructor
+@Transactional
+public class GroupService {
+    private final UserRepository userRepository;
+    private final FavoriteGroupRepository favoriteGroupRepository;
+
+    public void createGroup(GroupCreateRequest request, long userid) {
+
+
+        User user = userRepository.findById(userid).orElseThrow(() -> new UserException(ErrorCode.EXAMPLE_USER_NOT_FOUND));
+
+        boolean dupCheck = groupNameDuplicateCheck(request.getName(), userid);
+
+        // 해당 유저가 이미 있는 그룹 이름을 입력했을 때
+        if (dupCheck) {
+            throw new GroupException(ErrorCode.GROUP_ALREADY_EXIST);
+        }
+
+        FavoriteGroup favoriteGroup = FavoriteGroup.builder().user(user) // 유저 설정
+                .name(request.getName()) // Group 이름 설정
+                .updatedAt(LocalDateTime.now()).build();
+
+        favoriteGroupRepository.save(favoriteGroup);
+    }
+
+    @Transactional(readOnly = true)
+    public List<GroupResponse> getFavoriteGroups(long userId) {
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserException(ErrorCode.EXAMPLE_USER_NOT_FOUND));
+
+        // userId 값이 일치하는 데이터 조회
+        List<FavoriteGroup> groupList = favoriteGroupRepository.findByUser(user);
+
+        // GroupResponse 리스트로 변환
+        List<GroupResponse> responseList = groupList.stream().map(group ->
+                        GroupResponse.builder()
+                                .id(group.getId())
+                                .name(group.getName())
+                                .build())
+                .toList();
+
+        return responseList;
+    }
+
+    public void deleteGroup(long groupId, long userId) {
+        FavoriteGroup group = favoriteGroupRepository.findById(groupId)
+                .orElseThrow(() -> new GroupException(ErrorCode.GROUP_NOT_FOUND));
+
+        // 다른 사용자의 그룹 삭제 방지
+        if (group.getUser().getId() != userId) {
+            throw new GroupException(ErrorCode.UNAUTHORIZED_GROUP_DELETE);
+        }
+
+        // 이미 삭제 처리 된 경우
+        if (group.isDeleted()) {
+            throw new GroupException(ErrorCode.GROUP_ALREADY_DELETE);
+        }
+
+        group.setDeleted(true);
+
+        favoriteGroupRepository.save(group);
+    }
+
+    public void editGroup(long groupId, GroupEditRequest request, long userId) {
+        FavoriteGroup group = favoriteGroupRepository.findById(groupId)
+                .orElseThrow(() -> new GroupException(ErrorCode.GROUP_NOT_FOUND));
+
+        // 다른 사용자의 즐겨찾기 그룹 수정 방지
+        if (group.getUser().getId() != userId) {
+            throw new GroupException(ErrorCode.UNAUTHORIZED_GROUP_UPDATE);
+        }
+
+        boolean dupCheck = groupNameDuplicateCheck(request.getName(), group.getUser().getId());
+
+        // 해당 유저가 이미 있는 즐겨찾기 그룹 이름을 입력했을 때
+        if (dupCheck) {
+            throw new GroupException(ErrorCode.GROUP_ALREADY_EXIST);
+        }
+        group.setName(request.getName());
+
+        favoriteGroupRepository.save(group);
+    }
+
+
+    // 입력한 그룹 이름이 이미 해당 userId가 가지고 있는지 확인
+    public boolean groupNameDuplicateCheck(String groupName, long userId) {
+        return favoriteGroupRepository.existsByUser_IdAndName(userId, groupName);
+    }
+}

--- a/src/main/java/com/even/zaro/service/ProfileService.java
+++ b/src/main/java/com/even/zaro/service/ProfileService.java
@@ -137,9 +137,14 @@ public class ProfileService {
         return responseList;
     }
 
-    public void deleteGroup(long groupId) {
+    public void deleteGroup(long groupId, long userId) {
         FavoriteGroup group = favoriteGroupRepository.findById(groupId)
                 .orElseThrow(() -> new ProfileException(ErrorCode.GROUP_NOT_FOUND));
+
+        // 다른 사용자의 그룹 삭제 방지
+        if (group.getUser().getId() != userId) {
+            throw new ProfileException(ErrorCode.UNAUTHORIZED_GROUP_DELETE);
+        }
 
         // 이미 삭제 처리 된 경우
         if (group.isDeleted()) {

--- a/src/main/java/com/even/zaro/service/ProfileService.java
+++ b/src/main/java/com/even/zaro/service/ProfileService.java
@@ -209,9 +209,14 @@ public class ProfileService {
     }
 
     // 해당 즐겨찾기의 메모를 수정
-    public void editFavoriteMemo(long favoriteId, FavoriteEditRequest request) {
+    public void editFavoriteMemo(long favoriteId, FavoriteEditRequest request, long userId) {
         Favorite favorite = favoriteRepository.findById(favoriteId)
                 .orElseThrow(() -> new ProfileException(ErrorCode.FAVORITE_NOT_FOUND));
+
+        // 로그인한 사용자와 즐겨찾기의 userId가 일치하는지 검증
+        if (favorite.getUser().getId() != userId) {
+            throw new ProfileException(ErrorCode.UNAUTHORIZED_FAVORITE_UPDATE);
+        }
 
         favorite.setMemo(request.getMemo());
 

--- a/src/main/java/com/even/zaro/service/ProfileService.java
+++ b/src/main/java/com/even/zaro/service/ProfileService.java
@@ -2,22 +2,9 @@ package com.even.zaro.service;
 
 import com.even.zaro.dto.UserPostDto;
 import com.even.zaro.dto.UserProfileDto;
-import com.even.zaro.dto.favorite.FavoriteAddRequest;
-import com.even.zaro.dto.favorite.FavoriteAddResponse;
-import com.even.zaro.dto.favorite.FavoriteEditRequest;
-import com.even.zaro.dto.favorite.FavoriteResponse;
-import com.even.zaro.dto.profile.GroupCreateRequest;
-import com.even.zaro.dto.profile.GroupEditRequest;
-import com.even.zaro.dto.profile.GroupResponse;
-import com.even.zaro.entity.Favorite;
-import com.even.zaro.entity.FavoriteGroup;
-import com.even.zaro.entity.Place;
 import com.even.zaro.entity.User;
 import com.even.zaro.global.ErrorCode;
 import com.even.zaro.global.exception.CustomException;
-import com.even.zaro.global.exception.map.MapException;
-import com.even.zaro.global.exception.profile.ProfileException;
-import com.even.zaro.global.exception.user.UserException;
 import com.even.zaro.repository.*;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -26,19 +13,12 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
-import java.util.List;
-import java.util.Optional;
-
 @Service
 @Slf4j
 @AllArgsConstructor
 @Transactional
 public class ProfileService {
-    private final FavoriteRepository favoriteRepository;
     private final UserRepository userRepository;
-    private final PlaceRepository placeRepository;
-    private final FavoriteGroupRepository favoriteGroupRepository;
     private final PostRepository postRepository;
     private final PostLikeRepository postLikeRepository;
 
@@ -99,88 +79,7 @@ public class ProfileService {
                         .build());
     }
 
-    public void createGroup(GroupCreateRequest request, long userid) {
 
-        User user = userRepository.findById(userid).orElseThrow(() -> new UserException(ErrorCode.EXAMPLE_USER_NOT_FOUND));
-
-        boolean dupCheck = groupNameDuplicateCheck(request.getName(), userid);
-
-        // 해당 유저가 이미 있는 그룹 이름을 입력했을 때
-        if (dupCheck) {
-            throw new ProfileException(ErrorCode.GROUP_ALREADY_EXIST);
-        }
-
-        FavoriteGroup favoriteGroup = FavoriteGroup.builder().user(user) // 유저 설정
-                .name(request.getName()) // Group 이름 설정
-                .updatedAt(LocalDateTime.now()).build();
-
-        favoriteGroupRepository.save(favoriteGroup);
-    }
-
-    @Transactional(readOnly = true)
-    public List<GroupResponse> getFavoriteGroups(long userId) {
-
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new UserException(ErrorCode.EXAMPLE_USER_NOT_FOUND));
-
-        // userId 값이 일치하는 데이터 조회
-        List<FavoriteGroup> groupList = favoriteGroupRepository.findByUser(user);
-
-        // GroupResponse 리스트로 변환
-        List<GroupResponse> responseList = groupList.stream().map(group ->
-                GroupResponse.builder()
-                        .id(group.getId())
-                        .name(group.getName())
-                        .build())
-                .toList();
-
-        return responseList;
-    }
-
-    public void deleteGroup(long groupId, long userId) {
-        FavoriteGroup group = favoriteGroupRepository.findById(groupId)
-                .orElseThrow(() -> new ProfileException(ErrorCode.GROUP_NOT_FOUND));
-
-        // 다른 사용자의 그룹 삭제 방지
-        if (group.getUser().getId() != userId) {
-            throw new ProfileException(ErrorCode.UNAUTHORIZED_GROUP_DELETE);
-        }
-
-        // 이미 삭제 처리 된 경우
-        if (group.isDeleted()) {
-            throw new ProfileException(ErrorCode.GROUP_ALREADY_DELETE);
-        }
-
-        group.setDeleted(true);
-
-        favoriteGroupRepository.save(group);
-    }
-
-    public void editGroup(long groupId, GroupEditRequest request, long userId) {
-        FavoriteGroup group = favoriteGroupRepository.findById(groupId)
-                .orElseThrow(() -> new ProfileException(ErrorCode.GROUP_NOT_FOUND));
-
-        // 다른 사용자의 즐겨찾기 그룹 수정 방지
-        if (group.getUser().getId() != userId) {
-            throw new ProfileException(ErrorCode.UNAUTHORIZED_GROUP_UPDATE);
-        }
-
-        boolean dupCheck = groupNameDuplicateCheck(request.getName(), group.getUser().getId());
-
-        // 해당 유저가 이미 있는 즐겨찾기 그룹 이름을 입력했을 때
-        if (dupCheck) {
-            throw new ProfileException(ErrorCode.GROUP_ALREADY_EXIST);
-        }
-        group.setName(request.getName());
-
-        favoriteGroupRepository.save(group);
-    }
-
-
-    // 입력한 그룹 이름이 이미 해당 userId가 가지고 있는지 확인
-    public boolean groupNameDuplicateCheck(String groupName, long userId) {
-        return favoriteGroupRepository.existsByUser_IdAndName(userId, groupName);
-    }
 
 
 

--- a/src/main/java/com/even/zaro/service/ProfileService.java
+++ b/src/main/java/com/even/zaro/service/ProfileService.java
@@ -182,106 +182,11 @@ public class ProfileService {
         return favoriteGroupRepository.existsByUser_IdAndName(userId, groupName);
     }
 
-    // 해당 그룹의 즐겨찾기 리스트를 조회
-    public List<FavoriteResponse> getGroupItems(long groupId) {
-        FavoriteGroup group = favoriteGroupRepository.findById(groupId)
-                .orElseThrow(() -> new ProfileException(ErrorCode.GROUP_NOT_FOUND));
-
-        List<Favorite> favoriteList = favoriteRepository.findAllByGroup(group);
-
-        List<FavoriteResponse> favoriteResponseList = favoriteList.stream().map(favorite ->
-                FavoriteResponse.builder()
-                        .id(favorite.getId())
-                        .userId(favorite.getUser().getId())
-                        .groupId(favorite.getGroup().getId())
-                        .placeId(favorite.getPlace().getId())
-                        .memo(favorite.getMemo())
-                        .createdAt(favorite.getCreatedAt())
-                        .updatedAt(favorite.getUpdatedAt())
-                        .isDeleted(favorite.isDeleted())
-                        .lat(favorite.getPlace().getLat())
-                        .lng(favorite.getPlace().getLng())
-                        .address(favorite.getPlace().getAddress())
-                        .build()
-        ).toList();
-
-        return favoriteResponseList;
-    }
-
-    // 해당 즐겨찾기의 메모를 수정
-    public void editFavoriteMemo(long favoriteId, FavoriteEditRequest request, long userId) {
-        Favorite favorite = favoriteRepository.findById(favoriteId)
-                .orElseThrow(() -> new ProfileException(ErrorCode.FAVORITE_NOT_FOUND));
-
-        // 로그인한 사용자와 즐겨찾기의 userId가 일치하는지 검증
-        if (favorite.getUser().getId() != userId) {
-            throw new ProfileException(ErrorCode.UNAUTHORIZED_FAVORITE_UPDATE);
-        }
-
-        favorite.setMemo(request.getMemo());
-
-        favoriteRepository.save(favorite);
-    }
-
-    // 해당 즐겨찾기를 soft 삭제
-    public void deleteFavorite(long favoriteId, long userId) {
-        Favorite favorite = favoriteRepository.findById(favoriteId)
-                .orElseThrow(() -> new ProfileException(ErrorCode.FAVORITE_NOT_FOUND));
-
-        // 즐겨찾기의 userId와 로그인한 사용자의 userId 일치 여부 검증
-        if (favorite.getUser().getId() != userId) {
-            throw new ProfileException(ErrorCode.UNAUTHORIZED_FAVORITE_DELETE);
-        }
 
 
-        long placeId = favorite.getPlace().getId();
 
-        Place place = placeRepository.findById(placeId)
-                .orElseThrow(() -> new ProfileException(ErrorCode.PLACE_NOT_FOUND));
 
-        // 즐겨찾기 개수 1 감소
-        place.setFavoriteCount(place.getFavoriteCount() - 1);
 
-        favorite.setDeleted(true);
 
-        favoriteRepository.save(favorite);
-        placeRepository.save(place);
-    }
 
-    // 그룹에 즐겨찾기를 추가
-    public FavoriteAddResponse addFavorite(long groupId, FavoriteAddRequest request, long userId) {
-
-        FavoriteGroup group = favoriteGroupRepository.findById(groupId)
-                .orElseThrow(() -> new ProfileException(ErrorCode.GROUP_NOT_FOUND));
-
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new UserException(ErrorCode.EXAMPLE_USER_NOT_FOUND));
-
-        Place place = placeRepository.findById(request.getPlaceId())
-                .orElseThrow(() -> new MapException(ErrorCode.PLACE_NOT_FOUND));
-
-        Favorite favorite = Favorite.builder()
-                .user(user)
-                .group(group)
-                .place(place)
-                .memo(request.getMemo())
-                .isDeleted(false)
-                .build();
-
-        // 즐겨찾기 개수 1 증가
-        place.setFavoriteCount(place.getFavoriteCount() + 1);
-
-        favoriteRepository.save(favorite);
-        placeRepository.save(place);
-
-        FavoriteAddResponse favoriteAddResponse = FavoriteAddResponse.builder()
-                .placeId(favorite.getPlace().getId())
-                .memo(favorite.getMemo())
-                .lat(favorite.getPlace().getLat())
-                .lng(favorite.getPlace().getLng())
-                .address(favorite.getPlace().getAddress())
-                .build();
-
-        return favoriteAddResponse;
-    }
 }

--- a/src/main/java/com/even/zaro/service/ProfileService.java
+++ b/src/main/java/com/even/zaro/service/ProfileService.java
@@ -156,13 +156,18 @@ public class ProfileService {
         favoriteGroupRepository.save(group);
     }
 
-    public void editGroup(long groupId, GroupEditRequest request) {
+    public void editGroup(long groupId, GroupEditRequest request, long userId) {
         FavoriteGroup group = favoriteGroupRepository.findById(groupId)
                 .orElseThrow(() -> new ProfileException(ErrorCode.GROUP_NOT_FOUND));
 
+        // 다른 사용자의 즐겨찾기 그룹 수정 방지
+        if (group.getUser().getId() != userId) {
+            throw new ProfileException(ErrorCode.UNAUTHORIZED_GROUP_UPDATE);
+        }
+
         boolean dupCheck = groupNameDuplicateCheck(request.getName(), group.getUser().getId());
 
-        // 해당 유저가 이미 있는 그룹 이름을 입력했을 때
+        // 해당 유저가 이미 있는 즐겨찾기 그룹 이름을 입력했을 때
         if (dupCheck) {
             throw new ProfileException(ErrorCode.GROUP_ALREADY_EXIST);
         }

--- a/src/main/java/com/even/zaro/service/ProfileService.java
+++ b/src/main/java/com/even/zaro/service/ProfileService.java
@@ -99,11 +99,11 @@ public class ProfileService {
                         .build());
     }
 
-    public void createGroup(GroupCreateRequest request) {
+    public void createGroup(GroupCreateRequest request, long userid) {
 
-        User user = userRepository.findById(request.getUserId()).orElseThrow(() -> new UserException(ErrorCode.EXAMPLE_USER_NOT_FOUND));
+        User user = userRepository.findById(userid).orElseThrow(() -> new UserException(ErrorCode.EXAMPLE_USER_NOT_FOUND));
 
-        boolean dupCheck = groupNameDuplicateCheck(request.getName(), request.getUserId());
+        boolean dupCheck = groupNameDuplicateCheck(request.getName(), userid);
 
         // 해당 유저가 이미 있는 그룹 이름을 입력했을 때
         if (dupCheck) {

--- a/src/main/java/com/even/zaro/service/ProfileService.java
+++ b/src/main/java/com/even/zaro/service/ProfileService.java
@@ -238,12 +238,12 @@ public class ProfileService {
     }
 
     // 그룹에 즐겨찾기를 추가
-    public FavoriteAddResponse addFavorite(long groupId, FavoriteAddRequest request) {
+    public FavoriteAddResponse addFavorite(long groupId, FavoriteAddRequest request, long userId) {
 
         FavoriteGroup group = favoriteGroupRepository.findById(groupId)
                 .orElseThrow(() -> new ProfileException(ErrorCode.GROUP_NOT_FOUND));
 
-        User user = userRepository.findById(request.getUserId())
+        User user = userRepository.findById(userId)
                 .orElseThrow(() -> new UserException(ErrorCode.EXAMPLE_USER_NOT_FOUND));
 
         Place place = placeRepository.findById(request.getPlaceId())

--- a/src/main/java/com/even/zaro/service/ProfileService.java
+++ b/src/main/java/com/even/zaro/service/ProfileService.java
@@ -224,9 +224,15 @@ public class ProfileService {
     }
 
     // 해당 즐겨찾기를 soft 삭제
-    public void deleteFavorite(long favoriteId) {
+    public void deleteFavorite(long favoriteId, long userId) {
         Favorite favorite = favoriteRepository.findById(favoriteId)
                 .orElseThrow(() -> new ProfileException(ErrorCode.FAVORITE_NOT_FOUND));
+
+        // 즐겨찾기의 userId와 로그인한 사용자의 userId 일치 여부 검증
+        if (favorite.getUser().getId() != userId) {
+            throw new ProfileException(ErrorCode.UNAUTHORIZED_FAVORITE_DELETE);
+        }
+
 
         long placeId = favorite.getPlace().getId();
 

--- a/src/main/java/com/even/zaro/service/ProfileService.java
+++ b/src/main/java/com/even/zaro/service/ProfileService.java
@@ -127,7 +127,12 @@ public class ProfileService {
         List<FavoriteGroup> groupList = favoriteGroupRepository.findByUser(user);
 
         // GroupResponse 리스트로 변환
-        List<GroupResponse> responseList = groupList.stream().map(group -> GroupResponse.builder().id(group.getId()).name(group.getName()).build()).toList();
+        List<GroupResponse> responseList = groupList.stream().map(group ->
+                GroupResponse.builder()
+                        .id(group.getId())
+                        .name(group.getName())
+                        .build())
+                .toList();
 
         return responseList;
     }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -33,10 +33,11 @@ spring:
     #      schema-locations:
     #        - classpath:db/schema.sql
 
-  # JWT
-  jwt:
-    secret: ${JWT_SECRET}
-    expiration: 86400000
+# JWT
+jwt:
+  secret: ${JWT_SECRET}
+  refresh_secret : ${JWT_REFRESH_SECRET}
+  expiration: 86400000
 
   # SwaggerUI 설정
   springdoc:


### PR DESCRIPTION
## 📌 작업 개요
- Profile API에서 Group,Favorite API 분리, 토큰 인증 처리 추가

---

## ✨ 주요 변경 사항
- Profile API 에서 Group API, Favorite API 분리
- GroupAPI, Favorite API 토큰 인증 처리 추가
- Group, Favorite 예외 분리
- 다른 사용자의 정보를 수정, 삭제하지 못하도록 조건 예외 처리
- JWT 환경변수 못불러오는 문제 수정
- 일부 코드 가독성 향상 위해 들여쓰기 추가

---

## 🖼️ 기능 살펴 보기
> 프로필 API 분리 
![image](https://github.com/user-attachments/assets/f205819a-d434-4373-9e30-3a2b6ae9211c)

> 그룹 API 분리
![image](https://github.com/user-attachments/assets/e5456b5d-3f20-4b8f-ac26-7e7dc47ad899)

> 즐겨찾기 API 분리
![image](https://github.com/user-attachments/assets/6afd5c71-c3bf-4b50-b222-afb0087a29c3)

와  !! 깔끔하다!!! 

---

## ✅ 작업 체크리스트
- [x] API 테스트 완료 (POSTMAN)
- [x] 스웨거 ui 관련 코드 추가
- [x] 기능별 예외 케이스 고려
- [x] log.info / 불필요한 주석 제거
- [x] 변수명, 클래스명, 메서드명 의미있게 작성
- [x] 반복 코드 메서드로 분리

---

## 📂 테스트 방법
PostMan, SwaggerUI
---

## 💬 기타 참고 사항
- 이전보다.. 보기 편할겁니다

---

## 📎 관련 이슈 / 문서

