### PR TITLE
Hotfix/presigned-url post 이미지 업로드 시 postId 생성 전 이미지 업로드로 postId 삭제

### DIFF
--- a/src/main/java/com/even/zaro/controller/S3Controller.java
+++ b/src/main/java/com/even/zaro/controller/S3Controller.java
@@ -37,15 +37,12 @@ public class S3Controller {
             @Parameter(description = "사용자 ID (type=profile일 때 필수)", example = "1")
             @RequestParam(required = false) Long userId,
 
-            @Parameter(description = "게시글 ID (type=post일 때 필수)", example = "10")
-            @RequestParam(required = false) Long postId,
-
             @Parameter(description = "파일 확장자 (jpg, png, webp)", example = "jpg")
             @RequestParam String ext,
 
             @AuthenticationPrincipal JwtUserInfoDto user
             ) {
-        PresignedUrlResponse response = s3Service.issuePresignedUrl(type, userId, postId, ext, user.getUserId());
+        PresignedUrlResponse response = s3Service.issuePresignedUrl(type, userId, ext, user.getUserId());
         return ResponseEntity.ok(ApiResponse.success("presignedUrl을 발급했습니다.", response));
     }
 

--- a/src/main/java/com/even/zaro/service/S3Service.java
+++ b/src/main/java/com/even/zaro/service/S3Service.java
@@ -31,8 +31,8 @@ public class S3Service {
         return "images/profile/" + userId + "-" + UUID.randomUUID() + "." + ext;
     }
 
-    public String generatePostImageKey(Long postId, String ext) {
-        return "images/post/" + postId + "-" + UUID.randomUUID() + "." + ext;
+    public String generatePostImageKey(String ext) {
+        return "images/post/" + UUID.randomUUID() + "." + ext;
     }
 
     public String generatePresignedUrl(String key) {
@@ -57,7 +57,7 @@ public class S3Service {
         s3Client.deleteObject(bucket, key);
     }
 
-    public PresignedUrlResponse issuePresignedUrl(String type, Long userId, Long postId, String ext, Long currentUserId) {
+    public PresignedUrlResponse issuePresignedUrl(String type, Long userId, String ext, Long currentUserId) {
         validateExtension(ext);
 
         String key = switch (type) {
@@ -69,8 +69,7 @@ public class S3Service {
                 yield generateProfileKey(userId, ext);
             }
             case "post" -> {
-                if (postId == null) throw new CustomException(ErrorCode.INVALID_POST_ID);
-                yield generatePostImageKey(postId, ext);
+                yield generatePostImageKey(ext);
             }
             default -> throw new CustomException(ErrorCode.INVALID_UPLOAD_TYPE);
         };


### PR DESCRIPTION
## 📌 작업 개요
- post 이미지 업로드 시 postId 생성 전 이미지 업로드로 postId 삭제

---

## ✨ 주요 변경 사항
- post 이미지 업로드 시 postId 생성 전 이미지 업로드로 서비스, 컨트롤러에서 postId 삭제
- 스웨거 반영

---

## 🖼️ 기능 살펴 보기
> 포스트맨 요청 응답 스크린샷
- [x] API 문서(요청, 응답)와 일치하는지 확인 - 필요시 API 문서 수정 가능
![image](https://github.com/user-attachments/assets/0d7e21dc-575c-4280-b285-18ca48afa3b4)


---

## ✅ 작업 체크리스트
- [x] API 테스트 완료 (POSTMAN)
- [x] 스웨거 ui 관련 코드 추가
- [x] 기능별 예외 케이스 고려
- [ ] log.info / 불필요한 주석 제거
- [ ] 변수명, 클래스명, 메서드명 의미있게 작성
- [ ] 반복 코드 메서드로 분리

---

## 📂 테스트 방법
- [ ] 테스트 코드 작성
- [ ] 시나리오 기반 테스트 유무
    - ex: ID 중복 시 예외 처리 발생

---

## 💬 기타 참고 사항
- 오전 프론트 요청으로 수정합니다.
- post도 카테고리로 구분해볼까 하다가, 프론트에서 단순하게 처리하는 게 좋을 것 같다는 의견과, 시연시 게시물이 그렇게 많지 않고 사용자가 많아진 후에(상상 속?) 구분해보는 것도 나쁘지 않을 것 같다는 의견입니다.

---

## 📎 관련 이슈 / 문서
- [노션](https://www.notion.so/nahyuk/presigned-url-1f47ef37c243802e87b9d4e6a44e05d3)
