### PR TITLE
Ref/group @Data 어노테이션 관련 리팩토링

### DIFF
--- a/src/main/java/com/even/zaro/controller/GroupController.java
+++ b/src/main/java/com/even/zaro/controller/GroupController.java
@@ -1,9 +1,9 @@
 package com.even.zaro.controller;
 
 import com.even.zaro.dto.jwt.JwtUserInfoDto;
-import com.even.zaro.dto.profile.GroupCreateRequest;
-import com.even.zaro.dto.profile.GroupEditRequest;
-import com.even.zaro.dto.profile.GroupResponse;
+import com.even.zaro.dto.group.GroupCreateRequest;
+import com.even.zaro.dto.group.GroupEditRequest;
+import com.even.zaro.dto.group.GroupResponse;
 import com.even.zaro.global.ApiResponse;
 import com.even.zaro.service.GroupService;
 import io.swagger.v3.oas.annotations.Operation;

--- a/src/main/java/com/even/zaro/dto/group/GroupCreateRequest.java
+++ b/src/main/java/com/even/zaro/dto/group/GroupCreateRequest.java
@@ -1,4 +1,4 @@
-package com.even.zaro.dto.profile;
+package com.even.zaro.dto.group;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;

--- a/src/main/java/com/even/zaro/dto/group/GroupEditRequest.java
+++ b/src/main/java/com/even/zaro/dto/group/GroupEditRequest.java
@@ -1,4 +1,4 @@
-package com.even.zaro.dto.profile;
+package com.even.zaro.dto.group;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;

--- a/src/main/java/com/even/zaro/dto/group/GroupResponse.java
+++ b/src/main/java/com/even/zaro/dto/group/GroupResponse.java
@@ -1,4 +1,4 @@
-package com.even.zaro.dto.profile;
+package com.even.zaro.dto.group;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;

--- a/src/main/java/com/even/zaro/entity/FavoriteGroup.java
+++ b/src/main/java/com/even/zaro/entity/FavoriteGroup.java
@@ -1,16 +1,13 @@
 package com.even.zaro.entity;
 
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 
 import java.time.LocalDateTime;
 
-@Data
+@Getter
 @Entity
 @AllArgsConstructor
 @NoArgsConstructor
@@ -29,6 +26,7 @@ public class FavoriteGroup {
 
     // Group 이름
     @Column(name = "name", nullable = false)
+    @Setter
     private String name;
 
     @Column(name = "is_deleted", nullable = false)
@@ -41,4 +39,8 @@ public class FavoriteGroup {
     @Column(name = "updated_at")
     @UpdateTimestamp
     private LocalDateTime updatedAt;
+
+    public void setIsDeleted() {
+        this.isDeleted = true;
+    }
 }

--- a/src/main/java/com/even/zaro/service/GroupService.java
+++ b/src/main/java/com/even/zaro/service/GroupService.java
@@ -37,9 +37,10 @@ public class GroupService {
             throw new GroupException(ErrorCode.GROUP_ALREADY_EXIST);
         }
 
-        FavoriteGroup favoriteGroup = FavoriteGroup.builder().user(user) // 유저 설정
+        FavoriteGroup favoriteGroup = FavoriteGroup.builder()
+                .user(user) // 유저 설정
                 .name(request.getName()) // Group 이름 설정
-                .updatedAt(LocalDateTime.now()).build();
+                .build();
 
         favoriteGroupRepository.save(favoriteGroup);
     }

--- a/src/main/java/com/even/zaro/service/GroupService.java
+++ b/src/main/java/com/even/zaro/service/GroupService.java
@@ -100,8 +100,6 @@ public class GroupService {
             throw new GroupException(ErrorCode.GROUP_ALREADY_EXIST);
         }
         group.setName(request.getName());
-
-        favoriteGroupRepository.save(group);
     }
 
 

--- a/src/main/java/com/even/zaro/service/GroupService.java
+++ b/src/main/java/com/even/zaro/service/GroupService.java
@@ -79,7 +79,7 @@ public class GroupService {
             throw new GroupException(ErrorCode.GROUP_ALREADY_DELETE);
         }
 
-        group.setDeleted(true);
+        group.setIsDeleted();
 
         favoriteGroupRepository.save(group);
     }

--- a/src/main/java/com/even/zaro/service/GroupService.java
+++ b/src/main/java/com/even/zaro/service/GroupService.java
@@ -1,8 +1,8 @@
 package com.even.zaro.service;
 
-import com.even.zaro.dto.profile.GroupCreateRequest;
-import com.even.zaro.dto.profile.GroupEditRequest;
-import com.even.zaro.dto.profile.GroupResponse;
+import com.even.zaro.dto.group.GroupCreateRequest;
+import com.even.zaro.dto.group.GroupEditRequest;
+import com.even.zaro.dto.group.GroupResponse;
 import com.even.zaro.entity.FavoriteGroup;
 import com.even.zaro.entity.User;
 import com.even.zaro.global.ErrorCode;
@@ -27,7 +27,6 @@ public class GroupService {
     private final FavoriteGroupRepository favoriteGroupRepository;
 
     public void createGroup(GroupCreateRequest request, long userid) {
-
 
         User user = userRepository.findById(userid).orElseThrow(() -> new UserException(ErrorCode.EXAMPLE_USER_NOT_FOUND));
 


### PR DESCRIPTION
## 📌 작업 개요
- Group API 관련 @Data 남용 문제 수정
---

## ✨ 주요 변경 사항
- /dto/profile 에 있던 group 요청, 응답 객체 /dto/group 으로 이동
- @Data 어노테이션 삭제
- 업데이트가 필요한 필드에 대해서 엔티티에 메서드 추가

---

## 🖼️ 기능 살펴 보기

---

## ✅ 작업 체크리스트
- [x] API 테스트 완료 (POSTMAN)
- [ ] 스웨거 ui 관련 코드 추가
- [ ] 기능별 예외 케이스 고려
- [ ] log.info / 불필요한 주석 제거
- [ ] 변수명, 클래스명, 메서드명 의미있게 작성
- [x] 반복 코드 메서드로 분리

---

## 📂 테스트 방법


---

## 💬 기타 참고 사항
- 이전에 나현님이 남겨줬던 @Data 남용문제 해결
- 지은님 코드 리뷰 진행하며 다시 각인됐습니다 @Data를 남발하지 않도록 하겠습니다. . 

---

## 📎 관련 이슈 / 문서
