### PR TITLE
ref/favorite 즐겨찾기 API 리팩토링

### DIFF
--- a/src/main/java/com/even/zaro/entity/Favorite.java
+++ b/src/main/java/com/even/zaro/entity/Favorite.java
@@ -2,16 +2,13 @@ package com.even.zaro.entity;
 
 
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 
 import java.time.LocalDateTime;
 
-@Data
+@Getter
 @Entity
 @AllArgsConstructor
 @NoArgsConstructor
@@ -37,6 +34,7 @@ public class Favorite {
     private Place place;
 
     @Column(name = "memo")
+    @Setter
     private String memo;
 
     @CreationTimestamp
@@ -49,4 +47,9 @@ public class Favorite {
 
     @Column(name = "is_deleted", nullable = false)
     private boolean isDeleted;
+
+
+    public void setDeleteTrue() {
+        isDeleted = true;
+    }
 }

--- a/src/main/java/com/even/zaro/entity/Place.java
+++ b/src/main/java/com/even/zaro/entity/Place.java
@@ -45,4 +45,12 @@ public class Place {
 
     @Column(name = "favorite_count", nullable = false)
     private int favoriteCount = 0;
+
+    public void incrementFavoriteCount() {
+        favoriteCount++;
+    }
+
+    public void decrementFavoriteCount() {
+        favoriteCount--;
+    }
 }

--- a/src/main/java/com/even/zaro/global/ErrorCode.java
+++ b/src/main/java/com/even/zaro/global/ErrorCode.java
@@ -36,7 +36,7 @@ public enum ErrorCode {
     EMAIL_NOT_FOUND(HttpStatus.NOT_FOUND, "가입된 이메일이 아닙니다."),
     INCORRECT_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
 
-        // 이메일 인증
+    // 이메일 인증
     EMAIL_TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "유효하지 않은 인증 요청입니다."),
     EMAIL_TOKEN_EXPIRED(HttpStatus.BAD_REQUEST, "인증 유효시간이 만료되었습니다."),
     EMAIL_TOKEN_ALREADY_VERIFIED(HttpStatus.BAD_REQUEST, "이미 인증이 완료된 요청입니다."),
@@ -61,10 +61,12 @@ public enum ErrorCode {
     GROUP_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 그룹을 찾지 못했습니다."),
     GROUP_ALREADY_DELETE(HttpStatus.NOT_FOUND, "이미 삭제한 그룹입니다."),
     GROUP_ALREADY_EXIST(HttpStatus.NOT_FOUND, "이미 존재하는 그룹 이름입니다."),
-
-    FAVORITE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 즐겨찾기를 찾지 못했습니다."),
     UNAUTHORIZED_GROUP_DELETE(HttpStatus.UNAUTHORIZED, "다른 사용자의 그룹 삭제 시도입니다."),
     UNAUTHORIZED_GROUP_UPDATE(HttpStatus.UNAUTHORIZED, "다른 사용자의 그룹 수정 시도입니다."),
+
+    // 즐겨찾기 favorite
+    FAVORITE_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 즐겨찾기에 존재하는 장소는 추가할 수 없습니다."),
+    FAVORITE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 즐겨찾기를 찾지 못했습니다."),
     UNAUTHORIZED_FAVORITE_UPDATE(HttpStatus.UNAUTHORIZED, "다른 사용자의 즐겨찾기 메모 수정 시도입니다."),
     UNAUTHORIZED_FAVORITE_DELETE(HttpStatus.UNAUTHORIZED, "다른 사용자의 즐겨찾기 삭제 시도입니다."),
 

--- a/src/main/java/com/even/zaro/global/ErrorCode.java
+++ b/src/main/java/com/even/zaro/global/ErrorCode.java
@@ -36,7 +36,7 @@ public enum ErrorCode {
     EMAIL_NOT_FOUND(HttpStatus.NOT_FOUND, "가입된 이메일이 아닙니다."),
     INCORRECT_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
 
-    // 이메일 인증
+        // 이메일 인증
     EMAIL_TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "유효하지 않은 인증 요청입니다."),
     EMAIL_TOKEN_EXPIRED(HttpStatus.BAD_REQUEST, "인증 유효시간이 만료되었습니다."),
     EMAIL_TOKEN_ALREADY_VERIFIED(HttpStatus.BAD_REQUEST, "이미 인증이 완료된 요청입니다."),

--- a/src/main/java/com/even/zaro/repository/FavoriteRepository.java
+++ b/src/main/java/com/even/zaro/repository/FavoriteRepository.java
@@ -2,10 +2,13 @@ package com.even.zaro.repository;
 
 import com.even.zaro.entity.Favorite;
 import com.even.zaro.entity.FavoriteGroup;
+import com.even.zaro.entity.Place;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
 public interface FavoriteRepository extends JpaRepository<Favorite, Long> {
     List<Favorite> findAllByGroup(FavoriteGroup group);
+
+    List<Favorite> findByPlace(Place place);
 }

--- a/src/main/java/com/even/zaro/service/FavoriteService.java
+++ b/src/main/java/com/even/zaro/service/FavoriteService.java
@@ -52,10 +52,9 @@ public class FavoriteService {
                 .build();
 
         // 즐겨찾기 개수 1 증가
-        place.setFavoriteCount(place.getFavoriteCount() + 1);
+        place.incrementFavoriteCount();
 
         favoriteRepository.save(favorite);
-        placeRepository.save(place);
 
         FavoriteAddResponse favoriteAddResponse = FavoriteAddResponse.builder()
                 .placeId(favorite.getPlace().getId())
@@ -105,8 +104,6 @@ public class FavoriteService {
         }
 
         favorite.setMemo(request.getMemo());
-
-        favoriteRepository.save(favorite);
     }
 
     // 해당 즐겨찾기를 soft 삭제
@@ -119,18 +116,14 @@ public class FavoriteService {
             throw new FavoriteException(ErrorCode.UNAUTHORIZED_FAVORITE_DELETE);
         }
 
-
         long placeId = favorite.getPlace().getId();
 
         Place place = placeRepository.findById(placeId)
                 .orElseThrow(() -> new MapException(ErrorCode.PLACE_NOT_FOUND));
 
         // 즐겨찾기 개수 1 감소
-        place.setFavoriteCount(place.getFavoriteCount() - 1);
-
-        favorite.setDeleted(true);
-
-        favoriteRepository.save(favorite);
-        placeRepository.save(place);
+        place.decrementFavoriteCount();
+        // 삭제 상태 변경
+        favorite.setDeleteTrue();
     }
 }

--- a/src/main/java/com/even/zaro/service/FavoriteService.java
+++ b/src/main/java/com/even/zaro/service/FavoriteService.java
@@ -43,6 +43,13 @@ public class FavoriteService {
         Place place = placeRepository.findById(request.getPlaceId())
                 .orElseThrow(() -> new MapException(ErrorCode.PLACE_NOT_FOUND));
 
+        List<Favorite> placeList = favoriteRepository.findByPlace(place);
+
+        // 해당 placeId와 일치하는 장소가 이미 추가되어있다면
+        if (placeList.size() > 0) {
+            throw new FavoriteException(ErrorCode.FAVORITE_ALREADY_EXISTS);
+        }
+
         Favorite favorite = Favorite.builder()
                 .user(user)
                 .group(group)


### PR DESCRIPTION
## 📌 작업 개요
- favorite API @Data 관련 리팩토링 및 중복 즐겨찾기 추가 문제 수정

---

## ✨ 주요 변경 사항
- favorite API의 @Data 삭제 후 @Setter 사용
- 적절히 메소드를 엔티티에 생성 후 사용하도록 수정
- 즐겨찾기 중복 추가 문제 수정
- 

---

## 🖼️ 기능 살펴 보기


---

## ✅ 작업 체크리스트
- [x] API 테스트 완료 (POSTMAN)
- [ ] 스웨거 ui 관련 코드 추가
- [x] 기능별 예외 케이스 고려
- [ ] log.info / 불필요한 주석 제거
- [ ] 변수명, 클래스명, 메서드명 의미있게 작성
- [x] 반복 코드 메서드로 분리

---

## 📂 테스트 방법
- SwaggerUI

---

## 💬 기타 참고 사항
- 

---

## 📎 관련 이슈 / 문서
- 관련 이슈 번호: `close #123`
- 기획서, 디자인, API 문서 등 첨부
