### PR TITLE
Ref/profile : 기본정보조회 외의 profile api에 로그인 인증추가

### DIFF
--- a/src/main/java/com/even/zaro/config/security/SecurityConfig.java
+++ b/src/main/java/com/even/zaro/config/security/SecurityConfig.java
@@ -40,6 +40,7 @@ public class SecurityConfig {
                         .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll() // 스웨거
                         .requestMatchers("/api/auth/**").permitAll() // auth 인증 없이
                                 .requestMatchers("/api/posts/**").permitAll()
+                                .requestMatchers("/api/profile/{userId}").permitAll()
 //                        .requestMatchers("/**").permitAll() // 전체 인증 없이 개발용
                         .anyRequest().authenticated()
                 )

--- a/src/main/java/com/even/zaro/controller/ProfileController.java
+++ b/src/main/java/com/even/zaro/controller/ProfileController.java
@@ -49,7 +49,8 @@ public class ProfileController {
     public ResponseEntity<?> getUserPosts(
             @Parameter(description = "조회할 유저의 ID") @PathVariable("userId") Long userId,
             @Parameter(description = "페이지 번호 (기본값: 0)") @RequestParam(defaultValue = "0") int page,
-            @Parameter(description = "페이지 크기 (기본값: 10)") @RequestParam(defaultValue = "10") int size) {
+            @Parameter(description = "페이지 크기 (기본값: 10)") @RequestParam(defaultValue = "10") int size,
+            @AuthenticationPrincipal JwtUserInfoDto userInfoDto) {
 
         PageRequest pageRequest = PageRequest.of(page, size);
         Page<UserPostDto> posts = profileService.getUserPosts(userId, pageRequest);
@@ -64,7 +65,8 @@ public class ProfileController {
     public ResponseEntity<?> getUserLikedPosts(
             @Parameter(description = "조회할 유저의 ID") @PathVariable("userId") Long userId,
             @Parameter(description = "페이지 번호 (기본값: 0)") @RequestParam(defaultValue = "0") int page,
-            @Parameter(description = "페이지 크기 (기본값: 10)") @RequestParam(defaultValue = "10") int size) {
+            @Parameter(description = "페이지 크기 (기본값: 10)") @RequestParam(defaultValue = "10") int size,
+            @AuthenticationPrincipal JwtUserInfoDto userInfoDto) {
 
         PageRequest pageRequest = PageRequest.of(page, size);
         Page<UserPostDto> likedPosts = profileService.getUserLikedPosts(userId, pageRequest);
@@ -79,7 +81,8 @@ public class ProfileController {
     public ResponseEntity<?> getUserComments(
             @Parameter(description = "조회할 유저의 ID") @PathVariable("userId") Long userId,
             @Parameter(description = "페이지 번호 (기본값: 0)") @RequestParam(defaultValue = "0") int page,
-            @Parameter(description = "페이지 크기 (기본값: 10)") @RequestParam(defaultValue = "10") int size) {
+            @Parameter(description = "페이지 크기 (기본값: 10)") @RequestParam(defaultValue = "10") int size,
+            @AuthenticationPrincipal JwtUserInfoDto userInfoDto) {
 
         PageRequest pageRequest = PageRequest.of(page, size);
         Page<UserCommentDto> comments = profileService.getUserComments(userId, pageRequest);
@@ -116,7 +119,8 @@ public class ProfileController {
     @Operation(summary = "팔로잉 목록 조회", description = "특정 유저가 팔로우한 사용자 목록을 조회합니다.")
     @GetMapping("/{userId}/followings")
     public ResponseEntity<?> getUserFollowings(
-            @Parameter(description = "조회할 유저의 ID") @PathVariable Long userId) {
+            @Parameter(description = "조회할 유저의 ID") @PathVariable Long userId,
+            @AuthenticationPrincipal JwtUserInfoDto userInfoDto) {
         List<FollowerFollowingListDto> followings = profileService.getUserFollowings(userId);
         return ResponseEntity.ok(ApiResponse.success("유저의 팔로잉 목록 조회 성공 !", followings));
     }
@@ -125,7 +129,8 @@ public class ProfileController {
     @Operation(summary = "팔로워 목록 조회", description = "특정 유저를 팔로우하는 사용자 목록을 조회합니다.")
     @GetMapping("/{userId}/followers")
     public ResponseEntity<?> getUserFollowers(
-            @Parameter(description = "조회할 유저의 ID") @PathVariable Long userId) {
+            @Parameter(description = "조회할 유저의 ID") @PathVariable Long userId,
+            @AuthenticationPrincipal JwtUserInfoDto userInfoDto) {
         List<FollowerFollowingListDto> followers = profileService.getUserFollowers(userId);
         return ResponseEntity.ok(ApiResponse.success("유저의 팔로워 목록 조회 성공 !", followers));
     }

--- a/src/main/java/com/even/zaro/controller/ProfileController.java
+++ b/src/main/java/com/even/zaro/controller/ProfileController.java
@@ -34,8 +34,10 @@ public class ProfileController {
 
     private final JwtUtil jwtUtil;
   
-    // 유저 기본 프로필 조회
-    @Operation(summary = "유저 기본 프로필 조회", description = "특정 유저의 프로필 정보를 조회합니다.")
+    // 유저 기본 프로필 조회 (Profile 기능들 중 유일하게 인증 불필요 !)
+    @Operation(
+            summary = "유저 기본 프로필 조회 (인증 불필요)",
+            description = "특정 유저의 프로필 정보를 조회합니다.")
     @GetMapping("/{userId}")
     public ResponseEntity<?> getUserProfile(
             @Parameter(description = "조회할 유저의 ID") @PathVariable("userId") Long userId) {
@@ -44,7 +46,11 @@ public class ProfileController {
     }
 
     // 유저가 쓴 게시물 list 조회
-    @Operation(summary = "유저가 쓴 게시글 조회", description = "특정 유저가 작성한 게시글 목록을 조회합니다.")
+    @Operation(
+            summary = "유저가 쓴 게시글 list 조회 (인증 필요)",
+            description = "특정 유저가 작성한 게시글 목록을 조회합니다.",
+            security = {@SecurityRequirement(name = "bearer-key")}
+    )
     @GetMapping("/{userId}/posts")
     public ResponseEntity<?> getUserPosts(
             @Parameter(description = "조회할 유저의 ID") @PathVariable("userId") Long userId,
@@ -61,6 +67,11 @@ public class ProfileController {
     }
 
     // 유저가 좋아요 누른 게시물 list 조회
+    @Operation(
+            summary = "유저가 좋아요 한 게시글 list 조회 (인증 필요)",
+            description = "특정 유저가 좋아요 한 게시글 목록을 조회합니다.",
+            security = {@SecurityRequirement(name = "bearer-key")}
+    )
     @GetMapping("/{userId}/likes")
     public ResponseEntity<?> getUserLikedPosts(
             @Parameter(description = "조회할 유저의 ID") @PathVariable("userId") Long userId,
@@ -77,6 +88,11 @@ public class ProfileController {
     }
 
     // 유저가 쓴 댓글 list 조회
+    @Operation(
+            summary = "유저가 쓴 댓글 list 조회 (인증 필요)",
+            description = "특정 유저가 쓴 댓글 목록을 조회합니다.",
+            security = {@SecurityRequirement(name = "bearer-key")}
+    )
     @GetMapping("/{userId}/comments")
     public ResponseEntity<?> getUserComments(
             @Parameter(description = "조회할 유저의 ID") @PathVariable("userId") Long userId,
@@ -94,7 +110,10 @@ public class ProfileController {
     }
 
     // 다른 유저 팔로우 하기
-    @Operation(summary = "(로그인 된 상태) 팔로우 하기", description = "AccessToken 기반으로 다른 사용자를 팔로우합니다.", security = {@SecurityRequirement(name = "bearer-key")})
+    @Operation(
+            summary = "팔로우 하기 (인증 필요)",
+            description = "로그인 된 사용자의 AccessToken 기반으로, 다른 사용자를 팔로우합니다.",
+            security = {@SecurityRequirement(name = "bearer-key")})
     @PostMapping("/{userId}/follow")
     public ResponseEntity<?> followUser(
             @Parameter(description = "팔로우할 유저 ID") @PathVariable("userId") Long userId,
@@ -105,7 +124,10 @@ public class ProfileController {
     }
 
     // 다른 유저 언팔로우 하기
-    @Operation(summary = "(로그인 된 상태) 언팔로우 하기", description = "AccessToken 기반으로 다른 사용자를 언팔로우합니다.", security = {@SecurityRequirement(name = "bearer-key")})
+    @Operation(
+            summary = "언팔로우 하기 (인증 필요)",
+            description = "로그인 된 사용자의 AccessToken 기반으로, 다른 사용자를 언팔로우합니다.",
+            security = {@SecurityRequirement(name = "bearer-key")})
     @DeleteMapping("/{userId}/follow")
     public ResponseEntity<?> unfollowUser(
             @Parameter(description = "언팔로우할 유저 ID") @PathVariable("userId") Long userId,
@@ -116,7 +138,10 @@ public class ProfileController {
     }
 
     // 팔로잉 목록 조회
-    @Operation(summary = "팔로잉 목록 조회", description = "특정 유저가 팔로우한 사용자 목록을 조회합니다.")
+    @Operation(
+            summary = "팔로잉 목록 조회 (인증 필요)",
+            description = "특정 유저가 팔로우한 사용자 목록을 조회합니다.",
+            security = {@SecurityRequirement(name = "bearer-key")})
     @GetMapping("/{userId}/followings")
     public ResponseEntity<?> getUserFollowings(
             @Parameter(description = "조회할 유저의 ID") @PathVariable Long userId,
@@ -126,7 +151,10 @@ public class ProfileController {
     }
 
     // 팔로워 목록 조회
-    @Operation(summary = "팔로워 목록 조회", description = "특정 유저를 팔로우하는 사용자 목록을 조회합니다.")
+    @Operation(
+            summary = "팔로워 목록 조회 (인증 필요)",
+            description = "특정 유저를 팔로우하는 사용자 목록을 조회합니다.",
+            security = {@SecurityRequirement(name = "bearer-key")})
     @GetMapping("/{userId}/followers")
     public ResponseEntity<?> getUserFollowers(
             @Parameter(description = "조회할 유저의 ID") @PathVariable Long userId,


### PR DESCRIPTION
## 📌 작업 개요

- 기본정보조회 외의 profile api에 로그인 인증추가

---

## ✨ 주요 변경 사항
- profile 컨트롤러의 getUserProfile제외한 모든 메서드에 인증 추가
- SecurityConfig 에서 getUserProfile 엔드포인트만 인증해제 설정
- Swagger 문서화 코드 수정

---

## 🖼️ 기능 살펴 보기
> Swagger 프로필 api들 인증 추가된 부분

![image](https://github.com/user-attachments/assets/4eff026c-a300-4354-b161-9ac2e82d6daf)

> 인증 필요 api에 인증토큰 전달하지 않았을 때 (403에러)

![image](https://github.com/user-attachments/assets/637792e0-244c-4af4-be65-56816ec9b090)


> 인증 필요 api에 인증토큰 전달할 경우 (성공)

![image](https://github.com/user-attachments/assets/ee0d06ae-de00-4ab4-84ce-ff1034d19232)

> 프로필 기본정보 조회 메서드는 로그인 유무 관계없이 작동합니다 (성공)

![image](https://github.com/user-attachments/assets/2f0cf4ef-1a55-423b-b60c-4487fa08781e)


---

## ✅ 작업 체크리스트
- [x] API 테스트 완료 (Swagger)
- [x] 스웨거 ui 관련 코드 추가

---

## 📂 테스트 방법
- [x] swagger 로그인 토큰 사용

---

## 💬 기타 참고 사항

