### PR TITLE
Test/group-exception 그룹 API 예외 테스트 케이스 

### DIFF
--- a/src/main/java/com/even/zaro/dto/group/GroupCreateRequest.java
+++ b/src/main/java/com/even/zaro/dto/group/GroupCreateRequest.java
@@ -1,10 +1,11 @@
 package com.even.zaro.dto.group;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.Data;
+import lombok.Builder;
 import lombok.Getter;
 
 @Getter
+@Builder
 public class GroupCreateRequest {
     // Group 이름
     @Schema(description = "그룹 이름", example = "강릉 맛집!!")

--- a/src/main/java/com/even/zaro/dto/group/GroupCreateRequest.java
+++ b/src/main/java/com/even/zaro/dto/group/GroupCreateRequest.java
@@ -2,8 +2,9 @@ package com.even.zaro.dto.group;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
+import lombok.Getter;
 
-@Data
+@Getter
 public class GroupCreateRequest {
     // Group 이름
     @Schema(description = "그룹 이름", example = "강릉 맛집!!")

--- a/src/main/java/com/even/zaro/dto/group/GroupEditRequest.java
+++ b/src/main/java/com/even/zaro/dto/group/GroupEditRequest.java
@@ -1,9 +1,12 @@
 package com.even.zaro.dto.group;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
 import lombok.Data;
+import lombok.Getter;
 
-@Data
+@Getter
+@Builder
 public class GroupEditRequest {
     @Schema(description = "그룹 이름", example = "부산 맛집!~")
     private String name;

--- a/src/main/java/com/even/zaro/global/exception/group/GroupException.java
+++ b/src/main/java/com/even/zaro/global/exception/group/GroupException.java
@@ -2,9 +2,16 @@ package com.even.zaro.global.exception.group;
 
 import com.even.zaro.global.ErrorCode;
 import com.even.zaro.global.exception.CustomException;
+import lombok.Getter;
 
+@Getter
 public class GroupException extends CustomException {
+    private final ErrorCode errorCode;
+
     public GroupException(ErrorCode errorCode) {
         super(errorCode);
+        this.errorCode = errorCode;
     }
+
+
 }

--- a/src/main/java/com/even/zaro/service/GroupService.java
+++ b/src/main/java/com/even/zaro/service/GroupService.java
@@ -54,6 +54,11 @@ public class GroupService {
         // userId 값이 일치하는 데이터 조회
         List<FavoriteGroup> groupList = favoriteGroupRepository.findByUser(user);
 
+        if (groupList.isEmpty()) {
+            throw new GroupException(ErrorCode.GROUP_NOT_FOUND);
+        }
+
+
         // GroupResponse 리스트로 변환
         List<GroupResponse> responseList = groupList.stream().map(group ->
                         GroupResponse.builder()

--- a/src/test/java/com/even/zaro/group/GroupAPITest.java
+++ b/src/test/java/com/even/zaro/group/GroupAPITest.java
@@ -1,7 +1,7 @@
 package com.even.zaro.group;
 
-import com.even.zaro.controller.GroupController;
 import com.even.zaro.dto.group.GroupCreateRequest;
+import com.even.zaro.dto.group.GroupEditRequest;
 import com.even.zaro.dto.group.GroupResponse;
 import com.even.zaro.entity.FavoriteGroup;
 import com.even.zaro.entity.Provider;
@@ -12,7 +12,6 @@ import com.even.zaro.global.exception.group.GroupException;
 import com.even.zaro.repository.FavoriteGroupRepository;
 import com.even.zaro.repository.UserRepository;
 import com.even.zaro.service.GroupService;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -21,7 +20,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -111,6 +109,28 @@ public class GroupAPITest {
         assertThat(group.isDeleted()).isTrue();
     }
 
+
+    @Test
+    void 사용자의_그룹수정_성공_테스트() {
+        // Given
+        User user = createUser();
+        groupService.createGroup(GroupCreateRequest.builder().name("원래 이름").build(), user.getId());
+
+        long groupId = groupService.getFavoriteGroups(user.getId()).getFirst().getId();
+
+        // When
+        GroupEditRequest editRequest = GroupEditRequest.builder().name("수정된 이름").build();
+        groupService.editGroup(groupId, editRequest, user.getId());
+
+        // Then
+        GroupResponse updatedGroup = groupService.getFavoriteGroups(user.getId())
+                .stream()
+                .filter(gr -> gr.getId() == groupId)
+                .findFirst()
+                .orElseThrow();
+
+        assertThat(updatedGroup.getName()).isEqualTo("수정된 이름");
+    }
 
 
     // 임시 유저 생성 메서드

--- a/src/test/java/com/even/zaro/group/GroupAPITest.java
+++ b/src/test/java/com/even/zaro/group/GroupAPITest.java
@@ -214,6 +214,33 @@ public class GroupAPITest {
         assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.UNAUTHORIZED_GROUP_DELETE);
     }
 
+    @Test
+    void 다른_사용자의_그룹_수정_시도_UNAUTHORIZED_GROUP_UPDATE() {
+
+        // When
+        User user1 = createUser("ehdgnstla@naver.com", "Test1234!", "자취왕");
+
+        User user2 = createUser("tlaehdgns@naver.com", "Test1234!", "자취왕2");
+
+
+        // 그룹 생성
+        GroupCreateRequest request = GroupCreateRequest.builder().name("user1의 그룹").build();
+        groupService.createGroup(request, user1.getId());
+
+        // 그룹 리스트를 조회하고 첫번째 그룹의 id를 저장
+        List<GroupResponse> favoriteGroups = groupService.getFavoriteGroups(user1.getId());
+        long firstGroupId = favoriteGroups.getFirst().getId();
+
+        // Given & Then
+        // user2가 user1의 그룹 수정 시도
+        GroupException exception = assertThrows(GroupException.class, () -> {
+            GroupEditRequest editRequest = GroupEditRequest.builder().name("user2가 user1의 그룹이름 수정 시도").build();
+            groupService.editGroup(firstGroupId, editRequest, user2.getId());
+        });
+
+        assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.UNAUTHORIZED_GROUP_UPDATE);
+    }
+
 
 
     // 임시 유저 생성 메서드

--- a/src/test/java/com/even/zaro/group/GroupAPITest.java
+++ b/src/test/java/com/even/zaro/group/GroupAPITest.java
@@ -1,13 +1,24 @@
 package com.even.zaro.group;
 
 import com.even.zaro.controller.GroupController;
+import com.even.zaro.dto.group.GroupResponse;
+import com.even.zaro.entity.FavoriteGroup;
+import com.even.zaro.entity.Provider;
+import com.even.zaro.entity.Status;
+import com.even.zaro.entity.User;
 import com.even.zaro.repository.FavoriteGroupRepository;
 import com.even.zaro.repository.UserRepository;
 import com.even.zaro.service.GroupService;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest
 @Transactional
@@ -15,15 +26,45 @@ import org.springframework.transaction.annotation.Transactional;
 public class GroupAPITest {
 
     @Autowired
-    GroupController groupController;
-
-    @Autowired
     GroupService groupService;
 
+
+    // repository --------
     @Autowired
     UserRepository userRepository;
 
     @Autowired
     FavoriteGroupRepository favoriteGroupRepository;
+
+    @Test
+    void 해당_사용자의_그룹리스트_조회_성공테스트() {
+
+        // Given
+        User user = userRepository.save(User.builder()
+                .email("test@example.com")
+                .password("Password1234!")
+                .nickname("테스트유저")
+                .provider(Provider.LOCAL)
+                .status(Status.PENDING)
+                .build());
+
+        // 즐겨찾기 그룹 예시 데이터
+        FavoriteGroup group1 = FavoriteGroup.builder().user(user).name("맛집 모음").build();
+        FavoriteGroup group2 = FavoriteGroup.builder().user(user).name("데이트 코스").build();
+        FavoriteGroup group3 = FavoriteGroup.builder().user(user).name("가보고 싶은 곳").build();
+
+        favoriteGroupRepository.saveAll(List.of(group1, group2, group3));// 한꺼번에 그룹 리스트 저장
+
+        // When
+        List<GroupResponse> favoriteGroups = groupService.getFavoriteGroups(user.getId());
+
+        // Then
+        assertThat(favoriteGroups.size()).isEqualTo(3); // 개수 검증
+        assertThat(favoriteGroups.stream().map(GroupResponse::getName) // 그룹 이름 리스트 검증
+                .toList()).containsExactlyInAnyOrder("맛집 모음", "데이트 코스", "가보고 싶은 곳");
+    }
+
+
+
 
 }

--- a/src/test/java/com/even/zaro/group/GroupAPITest.java
+++ b/src/test/java/com/even/zaro/group/GroupAPITest.java
@@ -153,8 +153,7 @@ public class GroupAPITest {
         User user = createUser("ehdgnstla@naver.com", "Test1234!", "자취왕");
 
         // 그룹 생성
-        GroupCreateRequest request = GroupCreateRequest.builder().name("의정부 맛집은 여기라던데~?").build();
-        groupService.createGroup(request, user.getId());
+        craeteFavoriteGroup(user.getId(), "의정부 맛집은 여기라던데~?");
 
             // 그룹 리스트를 조회하고 첫번째 그룹의 id를 저장
         List<GroupResponse> favoriteGroups = groupService.getFavoriteGroups(user.getId());
@@ -178,12 +177,11 @@ public class GroupAPITest {
         User user = createUser("ehdgnstla@naver.com", "Test1234!", "자취왕");
 
         // 그룹 생성
-        GroupCreateRequest request = GroupCreateRequest.builder().name("의정부 맛집은 여기라던데~?").build();
-        groupService.createGroup(request, user.getId());
+        craeteFavoriteGroup(user.getId(), "의정부 맛집은 여기라던데~?");
 
         // When & Then : 이미 추가한 그룹이름으로 한번 더 추가
         GroupException exception = assertThrows(GroupException.class, () -> {
-            groupService.createGroup(request, user.getId());
+            craeteFavoriteGroup(user.getId(), "의정부 맛집은 여기라던데~?");
         });
 
         assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.GROUP_ALREADY_EXIST);
@@ -198,10 +196,9 @@ public class GroupAPITest {
 
 
         // 그룹 생성
-        GroupCreateRequest request = GroupCreateRequest.builder().name("user1의 그룹").build();
-        groupService.createGroup(request, user1.getId());
+        craeteFavoriteGroup(user1.getId(), "user1의 그룹");
 
-            // 그룹 리스트를 조회하고 첫번째 그룹의 id를 저장
+        // 그룹 리스트를 조회하고 첫번째 그룹의 id를 저장
         List<GroupResponse> favoriteGroups = groupService.getFavoriteGroups(user1.getId());
         long firstGroupId = favoriteGroups.getFirst().getId();
 
@@ -219,13 +216,11 @@ public class GroupAPITest {
 
         // When
         User user1 = createUser("ehdgnstla@naver.com", "Test1234!", "자취왕");
-
         User user2 = createUser("tlaehdgns@naver.com", "Test1234!", "자취왕2");
 
 
         // 그룹 생성
-        GroupCreateRequest request = GroupCreateRequest.builder().name("user1의 그룹").build();
-        groupService.createGroup(request, user1.getId());
+        craeteFavoriteGroup(user1.getId(), "user1의 그룹");
 
         // 그룹 리스트를 조회하고 첫번째 그룹의 id를 저장
         List<GroupResponse> favoriteGroups = groupService.getFavoriteGroups(user1.getId());
@@ -254,9 +249,9 @@ public class GroupAPITest {
                 .build());
     }
 
-
-
-
-
-
+    // 그룹 추가 메서드
+    void craeteFavoriteGroup(long userId, String groupName) {
+        GroupCreateRequest request = GroupCreateRequest.builder().name(groupName).build();
+        groupService.createGroup(request, userId);
+    }
 }

--- a/src/test/java/com/even/zaro/group/GroupAPITest.java
+++ b/src/test/java/com/even/zaro/group/GroupAPITest.java
@@ -19,7 +19,6 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -30,7 +29,6 @@ public class GroupAPITest {
 
     @Autowired
     GroupService groupService;
-
 
     // repository --------
     @Autowired

--- a/src/test/java/com/even/zaro/group/GroupAPITest.java
+++ b/src/test/java/com/even/zaro/group/GroupAPITest.java
@@ -11,7 +11,9 @@ import com.even.zaro.global.ErrorCode;
 import com.even.zaro.global.exception.group.GroupException;
 import com.even.zaro.repository.FavoriteGroupRepository;
 import com.even.zaro.repository.UserRepository;
+import com.even.zaro.service.FavoriteService;
 import com.even.zaro.service.GroupService;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -29,6 +31,9 @@ public class GroupAPITest {
 
     @Autowired
     GroupService groupService;
+
+    @Autowired
+    FavoriteService favoriteService;
 
     // repository --------
     @Autowired
@@ -130,6 +135,18 @@ public class GroupAPITest {
         assertThat(updatedGroup.getName()).isEqualTo("수정된 이름");
     }
 
+    @Test
+    void 존재하지_않는_그룹_조회시_GROUP_NOT_FOUND_예외_발생() {
+
+        // When & Then : 아직 그룹을 생성하지 않은 유저에 대해서 그룹 조회 요청
+        GroupException groupException = Assertions.assertThrows(GroupException.class, () -> {
+            favoriteService.getGroupItems(1);
+        });
+
+        assertThat(groupException.getErrorCode()).isEqualTo(ErrorCode.GROUP_NOT_FOUND);
+    }
+
+
 
     // 임시 유저 생성 메서드
     User createUser() {
@@ -141,6 +158,8 @@ public class GroupAPITest {
                 .status(Status.PENDING)
                 .build());
     }
+
+
 
 
 

--- a/src/test/java/com/even/zaro/group/GroupAPITest.java
+++ b/src/test/java/com/even/zaro/group/GroupAPITest.java
@@ -169,6 +169,22 @@ public class GroupAPITest {
         assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.GROUP_ALREADY_DELETE);
     }
 
+    @Test
+    void 이미_존재하는_그룹_이름_추가_시도_GROUP_ALREADY_EXIST() {
+        // Given
+        User user = createUser();
+            // 그룹 생성
+        GroupCreateRequest request = GroupCreateRequest.builder().name("의정부 맛집은 여기라던데~?").build();
+        groupService.createGroup(request, user.getId());
+
+        // When & Then : 이미 추가한 그룹이름으로 한번 더 추가
+        GroupException exception = Assertions.assertThrows(GroupException.class, () -> {
+            groupService.createGroup(request, user.getId());
+        });
+
+        assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.GROUP_ALREADY_EXIST);
+    }
+
 
 
     // 임시 유저 생성 메서드

--- a/src/test/java/com/even/zaro/group/GroupAPITest.java
+++ b/src/test/java/com/even/zaro/group/GroupAPITest.java
@@ -146,6 +146,29 @@ public class GroupAPITest {
         assertThat(groupException.getErrorCode()).isEqualTo(ErrorCode.GROUP_NOT_FOUND);
     }
 
+    @Test
+    void 이미_삭제한_그룹_삭제시도_GROUP_ALREADY_DELETE() {
+        // Given
+        User user = createUser();
+            // 그룹 생성
+        GroupCreateRequest request = GroupCreateRequest.builder().name("의정부 맛집은 여기라던데~?").build();
+        groupService.createGroup(request, user.getId());
+            // 그룹 리스트를 조회하고 첫번째 그룹의 id를 저장
+        List<GroupResponse> favoriteGroups = groupService.getFavoriteGroups(user.getId());
+        long firstGroupId = favoriteGroups.getFirst().getId();
+
+            // 삭제 요청
+        groupService.deleteGroup(firstGroupId, user.getId());
+
+        // When & Then
+            // 이미 삭제된 그룹에 대해서 다시 한번 삭제 요청
+        GroupException exception = Assertions.assertThrows(GroupException.class, () -> {
+            groupService.deleteGroup(firstGroupId, user.getId());
+        });
+
+        assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.GROUP_ALREADY_DELETE);
+    }
+
 
 
     // 임시 유저 생성 메서드

--- a/src/test/java/com/even/zaro/group/GroupAPITest.java
+++ b/src/test/java/com/even/zaro/group/GroupAPITest.java
@@ -1,0 +1,29 @@
+package com.even.zaro.group;
+
+import com.even.zaro.controller.GroupController;
+import com.even.zaro.repository.FavoriteGroupRepository;
+import com.even.zaro.repository.UserRepository;
+import com.even.zaro.service.GroupService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@Transactional
+@ActiveProfiles("test")
+public class GroupAPITest {
+
+    @Autowired
+    GroupController groupController;
+
+    @Autowired
+    GroupService groupService;
+
+    @Autowired
+    UserRepository userRepository;
+
+    @Autowired
+    FavoriteGroupRepository favoriteGroupRepository;
+
+}

--- a/src/test/java/com/even/zaro/group/GroupAPITest.java
+++ b/src/test/java/com/even/zaro/group/GroupAPITest.java
@@ -40,13 +40,7 @@ public class GroupAPITest {
     void 해당_사용자의_그룹리스트_조회_성공테스트() {
 
         // Given
-        User user = userRepository.save(User.builder()
-                .email("test@example.com")
-                .password("Password1234!")
-                .nickname("테스트유저")
-                .provider(Provider.LOCAL)
-                .status(Status.PENDING)
-                .build());
+        User user = createUser();
 
         // 즐겨찾기 그룹 예시 데이터
         FavoriteGroup group1 = FavoriteGroup.builder().user(user).name("맛집 모음").build();
@@ -64,6 +58,24 @@ public class GroupAPITest {
                 .toList()).containsExactlyInAnyOrder("맛집 모음", "데이트 코스", "가보고 싶은 곳");
     }
 
+    @Test
+    void 사용자의_그룹추가_성공테스트() {
+
+        //
+    }
+
+
+
+    // 임시 유저 생성 메서드
+    User createUser() {
+        return userRepository.save(User.builder()
+                .email("test@example.com")
+                .password("Password1234!")
+                .nickname("테스트유저")
+                .provider(Provider.LOCAL)
+                .status(Status.PENDING)
+                .build());
+    }
 
 
 

--- a/src/test/java/com/even/zaro/group/GroupAPITest.java
+++ b/src/test/java/com/even/zaro/group/GroupAPITest.java
@@ -49,12 +49,10 @@ public class GroupAPITest {
         // Given : 유저 객체 생성
         User user = createUser("ehdgnstla@naver.com", "Test1234!", "자취왕");
 
-        // 즐겨찾기 그룹 예시 데이터
-        FavoriteGroup group1 = FavoriteGroup.builder().user(user).name("맛집 모음").build();
-        FavoriteGroup group2 = FavoriteGroup.builder().user(user).name("데이트 코스").build();
-        FavoriteGroup group3 = FavoriteGroup.builder().user(user).name("가보고 싶은 곳").build();
-
-        favoriteGroupRepository.saveAll(List.of(group1, group2, group3));// 한꺼번에 그룹 리스트 저장
+        // 즐겨찾기 그룹 예시 데이터 추가
+        craeteFavoriteGroup(user.getId(), "맛집 모음");
+        craeteFavoriteGroup(user.getId(), "데이트 코스");
+        craeteFavoriteGroup(user.getId(), "가보고 싶은 곳");
 
         // When : 유저의 그룹 리스트 조회 요청
         List<GroupResponse> favoriteGroups = groupService.getFavoriteGroups(user.getId());
@@ -71,10 +69,8 @@ public class GroupAPITest {
         // Given : User 객체와 request 생성
         User user = createUser("ehdgnstla@naver.com", "Test1234!", "자취왕");
 
-        GroupCreateRequest request = GroupCreateRequest.builder().name("의정부 맛집은 여기라던데~?").build();
-
         // When : 그룹 생성 요청
-        groupService.createGroup(request, user.getId());
+        craeteFavoriteGroup(user.getId(), "의정부 맛집은 여기라던데~?");
 
         // Then : 그룹이 정상적으로 추가되었는지 확인
         List<GroupResponse> favoriteGroups = groupService.getFavoriteGroups(user.getId()); // 해당 유저의 아이디로 그룹 리스트를 조회
@@ -89,13 +85,9 @@ public class GroupAPITest {
         User user = createUser("ehdgnstla@naver.com", "Test1234!", "자취왕");
 
         // 여러개의 그룹 생성 요청 생성
-        GroupCreateRequest request1 = GroupCreateRequest.builder().name("groupName1").build();
-        GroupCreateRequest request2 = GroupCreateRequest.builder().name("groupName2").build();
-        GroupCreateRequest request3 = GroupCreateRequest.builder().name("groupName3").build();
-
-        groupService.createGroup(request1, user.getId());
-        groupService.createGroup(request2, user.getId());
-        groupService.createGroup(request3, user.getId());
+        craeteFavoriteGroup(user.getId(), "groupName1");
+        craeteFavoriteGroup(user.getId(), "groupName2");
+        craeteFavoriteGroup(user.getId(), "groupName3");
 
         List<GroupResponse> favoriteGroups = groupService.getFavoriteGroups(user.getId()); // 그룹 리스트 조회
         List<Long> favoriteGroupIds = favoriteGroups.stream().map(GroupResponse::getId).toList(); // 그룹 id 리스트

--- a/src/test/java/com/even/zaro/group/GroupAPITest.java
+++ b/src/test/java/com/even/zaro/group/GroupAPITest.java
@@ -1,6 +1,7 @@
 package com.even.zaro.group;
 
 import com.even.zaro.controller.GroupController;
+import com.even.zaro.dto.group.GroupCreateRequest;
 import com.even.zaro.dto.group.GroupResponse;
 import com.even.zaro.entity.FavoriteGroup;
 import com.even.zaro.entity.Provider;
@@ -39,7 +40,7 @@ public class GroupAPITest {
     @Test
     void 해당_사용자의_그룹리스트_조회_성공테스트() {
 
-        // Given
+        // Given : 유저 객체 생성
         User user = createUser();
 
         // 즐겨찾기 그룹 예시 데이터
@@ -49,10 +50,10 @@ public class GroupAPITest {
 
         favoriteGroupRepository.saveAll(List.of(group1, group2, group3));// 한꺼번에 그룹 리스트 저장
 
-        // When
+        // When : 유저의 그룹 리스트 조회 요청
         List<GroupResponse> favoriteGroups = groupService.getFavoriteGroups(user.getId());
 
-        // Then
+        // Then : 그룹 리스트의 개수와 그룹 이름 일치 여부 검증
         assertThat(favoriteGroups.size()).isEqualTo(3); // 개수 검증
         assertThat(favoriteGroups.stream().map(GroupResponse::getName) // 그룹 이름 리스트 검증
                 .toList()).containsExactlyInAnyOrder("맛집 모음", "데이트 코스", "가보고 싶은 곳");
@@ -61,7 +62,19 @@ public class GroupAPITest {
     @Test
     void 사용자의_그룹추가_성공테스트() {
 
-        //
+        // Given : User 객체와 request 생성
+        User user = createUser();
+
+        GroupCreateRequest request = GroupCreateRequest.builder().name("의정부 맛집은 여기라던데~?").build();
+
+        // When : 그룹 생성 요청
+        groupService.createGroup(request, user.getId());
+
+        // Then : 그룹이 정상적으로 추가되었는지 확인
+        List<GroupResponse> favoriteGroups = groupService.getFavoriteGroups(user.getId()); // 해당 유저의 아이디로 그룹 리스트를 조회
+
+        assertThat(favoriteGroups.size()).isEqualTo(1); // 개수 검증
+        assertThat(favoriteGroups.stream().map(GroupResponse::getName)).containsExactlyInAnyOrder("의정부 맛집은 여기라던데~?"); // 그룹 이름 일치 여부
     }
 
 

--- a/src/test/java/com/even/zaro/group/GroupAPITest.java
+++ b/src/test/java/com/even/zaro/group/GroupAPITest.java
@@ -155,6 +155,7 @@ public class GroupAPITest {
         // 그룹 생성
         GroupCreateRequest request = GroupCreateRequest.builder().name("의정부 맛집은 여기라던데~?").build();
         groupService.createGroup(request, user.getId());
+
             // 그룹 리스트를 조회하고 첫번째 그룹의 id를 저장
         List<GroupResponse> favoriteGroups = groupService.getFavoriteGroups(user.getId());
         long firstGroupId = favoriteGroups.getFirst().getId();
@@ -193,7 +194,6 @@ public class GroupAPITest {
 
         // When
         User user1 = createUser("ehdgnstla@naver.com", "Test1234!", "자취왕");
-
         User user2 = createUser("tlaehdgns@naver.com", "Test1234!", "자취왕2");
 
 
@@ -253,6 +253,7 @@ public class GroupAPITest {
                 .status(Status.PENDING)
                 .build());
     }
+
 
 
 


### PR DESCRIPTION
## 📌 작업 개요
- Group API 예외 테스트 케이스 작성

---

## ✨ 주요 변경 사항
- Group API 에서 발생할 수 있는 주요 예외 테스트 케이스 작성
- 기존 그룹 리스트 조회 시 조회 결과가 빈 배열이면 예외를 던지지 않던 문제 수정
- 필요한 부분 @Builder 추가

---

## 🖼️ 기능 살펴 보기
> ![image](https://github.com/user-attachments/assets/30e70a67-cd00-494d-acf6-b9d57b01e287)
- 테스트 모두 성공

---

## ✅ 작업 체크리스트
- [ ] API 테스트 완료 (POSTMAN)
- [ ] 스웨거 ui 관련 코드 추가
- [x] 기능별 예외 케이스 고려
- [ ] log.info / 불필요한 주석 제거
- [x] 변수명, 클래스명, 메서드명 의미있게 작성
- [x] 반복 코드 메서드로 분리

---

## 📂 테스트 방법
- [x] 테스트 코드 작성
- [x] 시나리오 기반 테스트 유무
    - ex: ID 중복 시 예외 처리 발생

---

## 💬 기타 참고 사항
- 그룹 API 관련 테스트 케이스 모두 작성 완료했습니다.

---

## 📎 관련 이슈 / 문서
- close #37 
