### PR TITLE
Feat/social login 카카오 로그인 API 구현

### DIFF
--- a/src/main/java/com/even/zaro/controller/AuthController.java
+++ b/src/main/java/com/even/zaro/controller/AuthController.java
@@ -46,9 +46,15 @@ public class AuthController {
 
     @Operation(summary = "로그인", description = "이메일과 비밀번호로 로그인합니다.")
     @PostMapping("/signin")
-    public ResponseEntity<ApiResponse<SignInResponseDto>> signin(@RequestBody SignInRequestDto requestDto) {
+    public ResponseEntity<ApiResponse<SignInResponseDto>> signIn(@RequestBody SignInRequestDto requestDto) {
         SignInResponseDto responseDto = authService.signIn(requestDto);
         return ResponseEntity.ok(ApiResponse.success("로그인에 성공했습니다.", responseDto));
+    }
+
+    @PostMapping("/signin/kakao")
+    public ResponseEntity<ApiResponse<SignInResponseDto>> signInWithKakao(@RequestBody KakaoSignInRequestDto requestDto) {
+        SignInResponseDto responseDto = authService.SignInWithKakao(requestDto.getKakaoToken());
+        return ResponseEntity.ok(ApiResponse.success("카카오 로그인에 성공했습니다.", responseDto));
     }
 
     @Operation(summary = "Access Token 재발급", description = "Refresh 토큰을 입력해 Access Token을 재발급 받습니다. 상단 Authorize에 Refresh Token을 입력하세요.",

--- a/src/main/java/com/even/zaro/controller/AuthController.java
+++ b/src/main/java/com/even/zaro/controller/AuthController.java
@@ -51,7 +51,7 @@ public class AuthController {
         return ResponseEntity.ok(ApiResponse.success("로그인에 성공했습니다.", responseDto));
     }
 
-    @Operation(summary = "카카오 로그인", description = "카카오 access token을 받아 로그인 처리합니다.")
+    @Operation(summary = "카카오 회원가입/로그인", description = "카카오 access token을 받아 회원가입/로그인 처리합니다.")
     @PostMapping("/signin/kakao")
     public ResponseEntity<ApiResponse<SignInResponseDto>> signInWithKakao(
             @RequestBody @Parameter(description = "카카오 access token") KakaoSignInRequestDto requestDto) {

--- a/src/main/java/com/even/zaro/controller/AuthController.java
+++ b/src/main/java/com/even/zaro/controller/AuthController.java
@@ -51,9 +51,11 @@ public class AuthController {
         return ResponseEntity.ok(ApiResponse.success("로그인에 성공했습니다.", responseDto));
     }
 
+    @Operation(summary = "카카오 로그인", description = "카카오 access token을 받아 로그인 처리합니다.")
     @PostMapping("/signin/kakao")
-    public ResponseEntity<ApiResponse<SignInResponseDto>> signInWithKakao(@RequestBody KakaoSignInRequestDto requestDto) {
-        SignInResponseDto responseDto = authService.SignInWithKakao(requestDto.getKakaoToken());
+    public ResponseEntity<ApiResponse<SignInResponseDto>> signInWithKakao(
+            @RequestBody @Parameter(description = "카카오 access token") KakaoSignInRequestDto requestDto) {
+        SignInResponseDto responseDto = authService.SignInWithKakao(requestDto.getAccessToken());
         return ResponseEntity.ok(ApiResponse.success("카카오 로그인에 성공했습니다.", responseDto));
     }
 

--- a/src/main/java/com/even/zaro/dto/auth/KakaoSignInRequestDto.java
+++ b/src/main/java/com/even/zaro/dto/auth/KakaoSignInRequestDto.java
@@ -1,0 +1,12 @@
+package com.even.zaro.dto.auth;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class KakaoSignInRequestDto {
+    @JsonProperty("accessToken")
+    private String kakaoToken;
+}

--- a/src/main/java/com/even/zaro/dto/auth/KakaoSignInRequestDto.java
+++ b/src/main/java/com/even/zaro/dto/auth/KakaoSignInRequestDto.java
@@ -1,12 +1,14 @@
 package com.even.zaro.dto.auth;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
 public class KakaoSignInRequestDto {
-    @JsonProperty("accessToken")
-    private String kakaoToken;
+
+    @Schema(description = "카카오에서 받은 access token", example = "eyJhbGciOiJIUzI1...")
+    private String accessToken;
 }

--- a/src/main/java/com/even/zaro/dto/auth/KakaoUserInfoDto.java
+++ b/src/main/java/com/even/zaro/dto/auth/KakaoUserInfoDto.java
@@ -1,0 +1,31 @@
+package com.even.zaro.dto.auth;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+public class KakaoUserInfoDto {
+    private Long id;
+    @JsonProperty("kakao_account")
+    private KakaoAccount kakaoAccount;
+
+    @Getter
+    @NoArgsConstructor
+    public static class KakaoAccount {
+        private Profile profile;
+        private String email;
+        private String gender;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    public static class Profile {
+        private String nickname;
+        @JsonProperty("profile_image_url")
+        private String profileImageUrl;
+    }
+}

--- a/src/main/java/com/even/zaro/entity/User.java
+++ b/src/main/java/com/even/zaro/entity/User.java
@@ -78,6 +78,9 @@ public class User {
     @Column(name = "provider", nullable = false)
     private Provider provider;
 
+    @Column(name = "provider_id")
+    private String providerId;
+
     public void updateLastLoginAt(LocalDateTime time) {
         this.lastLoginAt = time;
     }

--- a/src/main/java/com/even/zaro/entity/User.java
+++ b/src/main/java/com/even/zaro/entity/User.java
@@ -18,7 +18,10 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-@Table(name = "`user`")
+@Table(
+    name = "`user`",
+    uniqueConstraints = @UniqueConstraint(columnNames = {"provider", "provider_id"})
+)
 public class User {
 
     @Id

--- a/src/main/java/com/even/zaro/global/ErrorCode.java
+++ b/src/main/java/com/even/zaro/global/ErrorCode.java
@@ -36,6 +36,8 @@ public enum ErrorCode {
     EMAIL_NOT_FOUND(HttpStatus.NOT_FOUND, "가입된 이메일이 아닙니다."),
     INCORRECT_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
 
+    INVALID_OAUTH_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 소셜 인증 토큰입니다."),
+
         // 이메일 인증
     EMAIL_TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "유효하지 않은 인증 요청입니다."),
     EMAIL_TOKEN_EXPIRED(HttpStatus.BAD_REQUEST, "인증 유효시간이 만료되었습니다."),

--- a/src/main/java/com/even/zaro/repository/UserRepository.java
+++ b/src/main/java/com/even/zaro/repository/UserRepository.java
@@ -1,5 +1,6 @@
 package com.even.zaro.repository;
 
+import com.even.zaro.entity.Provider;
 import com.even.zaro.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -9,4 +10,6 @@ import java.util.Optional;
 public interface UserRepository extends JpaRepository<User, Long> {
     boolean existsByEmail(String email);
     Optional<User> findByEmail(String email);
+
+    Optional<User> findByProviderAndProviderId(Provider provider, String providerId);
 }

--- a/src/main/java/com/even/zaro/service/AuthService.java
+++ b/src/main/java/com/even/zaro/service/AuthService.java
@@ -73,7 +73,6 @@ public class AuthService {
                         .email(email)
                         .password(passwordEncoder.encode(password))
                         .nickname(nickname)
-                        .profileImage("https://your-cdn.com/default.png")
                         .provider(Provider.LOCAL)
                         .status(Status.PENDING)
                         .build()
@@ -110,7 +109,6 @@ public class AuthService {
 
         // 이메일, 프로필 사진이 없는 경우 더미로 추가
         String safeEmail = (email != null) ? email : "kakao_" + kakaoId + "@kakao-user.com";
-        String safeProfileImage = (profileImage != null) ? profileImage : "https://your-cdn.com/default.png";
 
         User user = userRepository.findByProviderAndProviderId(Provider.KAKAO, kakaoId.toString())
                 .orElseGet(() -> userRepository.save(User.builder()
@@ -118,7 +116,7 @@ public class AuthService {
                                 .providerId(kakaoId.toString())
                                 .email(safeEmail)
                                 .nickname(nickname)
-                                .profileImage(safeProfileImage)
+                                .profileImage(profileImage)
                                 .gender(gender)
                                 .status(Status.ACTIVE)
                                 .build()));

--- a/src/main/java/com/even/zaro/service/AuthService.java
+++ b/src/main/java/com/even/zaro/service/AuthService.java
@@ -108,8 +108,9 @@ public class AuthService {
         String profileImage = kakaoUser.getKakaoAccount().getProfile().getProfileImageUrl();
         String gender = kakaoUser.getKakaoAccount().getGender();
 
-        // 이메일 없는 경우 더미로 추가
+        // 이메일, 프로필 사진이 없는 경우 더미로 추가
         String safeEmail = (email != null) ? email : "kakao_" + kakaoId + "@kakao-user.com";
+        String safeProfileImage = (profileImage != null) ? profileImage : "https://your-cdn.com/default.png";
 
         User user = userRepository.findByProviderAndProviderId(Provider.KAKAO, kakaoId.toString())
                 .orElseGet(() -> userRepository.save(User.builder()
@@ -117,7 +118,7 @@ public class AuthService {
                                 .providerId(kakaoId.toString())
                                 .email(safeEmail)
                                 .nickname(nickname)
-                                .profileImage(profileImage)
+                                .profileImage(safeProfileImage)
                                 .gender(gender)
                                 .status(Status.ACTIVE)
                                 .build()));

--- a/src/main/java/com/even/zaro/service/AuthService.java
+++ b/src/main/java/com/even/zaro/service/AuthService.java
@@ -100,7 +100,7 @@ public class AuthService {
 
     // 소셜 로그인 (카카오)
     @Transactional
-    public SignInResponseDto loginWithKakao(String kakaoAccessToken) {
+    public SignInResponseDto SignInWithKakao(String kakaoAccessToken) {
         KakaoUserInfoDto kakaoUser = kakaoOAuthService.getUserInfo(kakaoAccessToken);
         Long kakaoId = kakaoUser.getId();
         String email = kakaoUser.getKakaoAccount().getEmail();

--- a/src/main/java/com/even/zaro/service/KakaoOAuthService.java
+++ b/src/main/java/com/even/zaro/service/KakaoOAuthService.java
@@ -1,11 +1,13 @@
 package com.even.zaro.service;
 
 import com.even.zaro.dto.auth.KakaoUserInfoDto;
+import com.even.zaro.global.ErrorCode;
+import com.even.zaro.global.exception.CustomException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.*;
 import org.springframework.stereotype.Component;
+import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestTemplate;
-
 
 @Component
 @RequiredArgsConstructor
@@ -16,17 +18,21 @@ public class KakaoOAuthService {
     public KakaoUserInfoDto getUserInfo(String kakaoAccessToken) {
         HttpHeaders headers = new HttpHeaders();
         headers.setBearerAuth(kakaoAccessToken);
-        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
 
         HttpEntity<Void> entity = new HttpEntity<>(headers);
 
-        ResponseEntity<KakaoUserInfoDto> response = restTemplate.exchange(
-                "https://kapi.kakao.com/v2/user/me",
-                HttpMethod.GET,
-                entity,
-                KakaoUserInfoDto.class
-        );
+        try {
+            ResponseEntity<KakaoUserInfoDto> response = restTemplate.exchange(
+                    "https://kapi.kakao.com/v2/user/me",
+                    HttpMethod.GET,
+                    entity,
+                    KakaoUserInfoDto.class
+            );
 
-        return response.getBody();
+            return response.getBody();
+        } catch (HttpClientErrorException e) {
+            throw new CustomException(ErrorCode.INVALID_OAUTH_TOKEN);
+        }
+
     }
 }

--- a/src/main/java/com/even/zaro/service/KakaoOAuthService.java
+++ b/src/main/java/com/even/zaro/service/KakaoOAuthService.java
@@ -1,0 +1,32 @@
+package com.even.zaro.service;
+
+import com.even.zaro.dto.auth.KakaoUserInfoDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.*;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+
+@Component
+@RequiredArgsConstructor
+public class KakaoOAuthService {
+
+    private final RestTemplate restTemplate = new RestTemplate();
+
+    public KakaoUserInfoDto getUserInfo(String kakaoAccessToken) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(kakaoAccessToken);
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        HttpEntity<Void> entity = new HttpEntity<>(headers);
+
+        ResponseEntity<KakaoUserInfoDto> response = restTemplate.exchange(
+                "https://kapi.kakao.com/v2/user/me",
+                HttpMethod.GET,
+                entity,
+                KakaoUserInfoDto.class
+        );
+
+        return response.getBody();
+    }
+}


### PR DESCRIPTION
## 📌 작업 개요
- 카카오 로그인 API 구현

---

## ✨ 주요 변경 사항
- 카카오 로그인 API 구현
- 일반 로그인, 카카오 로그인 토큰 발급 및 유저 response 빌드 부분 별도 메서드로 분리
- 일반 회원가입시 default profile image 저장되는 부분 삭제 -> Null일 경우 프론트에서 처리

---

## 🖼️ 기능 살펴 보기
> 포스트맨 요청 응답 스크린샷
- [x] API 문서(요청, 응답)와 일치하는지 확인 - 필요시 API 문서 수정 가능
![image](https://github.com/user-attachments/assets/4c4888cb-8cde-47ae-9848-ad7d614e3f40)
토큰 정보 잘못 됐을 때
![image](https://github.com/user-attachments/assets/093db0df-8cae-448c-845b-144fd8c17a2a)

---

## ✅ 작업 체크리스트
- [x] API 테스트 완료 (POSTMAN)
- [x] 스웨거 ui 관련 코드 추가
- [x] 기능별 예외 케이스 고려
- [x] log.info / 불필요한 주석 제거
- [x] 변수명, 클래스명, 메서드명 의미있게 작성
- [x] 반복 코드 메서드로 분리

---

## 📂 테스트 방법
- [ ] 테스트 코드 작성
- [ ] 시나리오 기반 테스트 유무
    - ex: ID 중복 시 예외 처리 발생

---

## 💬 기타 참고 사항
- User 테이블에 profile_image 부분이 제 db에 not null로 되어 있더라구요! 혹시나 이러신 분들 이번에 에러날 수도 있으니 에러가 나신다면 alter table 에서 not null 없애 주시면 되겠습니다. 에러 안나면 패스.

```sql
ALTER TABLE `evenfinal`.`user` 
CHANGE COLUMN `profile_image` `profile_image` VARCHAR(255) NULL ;
```

---

## 📎 관련 이슈 / 문서

