### PR TITLE
Fix/user nickname unique 

### DIFF
--- a/src/main/java/com/even/zaro/dto/auth/SignUpRequestDto.java
+++ b/src/main/java/com/even/zaro/dto/auth/SignUpRequestDto.java
@@ -2,11 +2,13 @@ package com.even.zaro.dto.auth;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
+@AllArgsConstructor
 @Schema(description = "회원가입 요청")
 public class SignUpRequestDto {
     @Schema(description = "이메일", example = "test@even.com", required = true)

--- a/src/main/java/com/even/zaro/entity/Comment.java
+++ b/src/main/java/com/even/zaro/entity/Comment.java
@@ -36,9 +36,11 @@ public class Comment {
     private String content;
 
     @Column(name = "is_deleted", nullable = false)
+    @Builder.Default
     private boolean isDeleted = false;
 
     @Column(name = "is_reported", nullable = false)
+    @Builder.Default
     private boolean isReported = false;
 
     @Column(name = "created_at", nullable = false)
@@ -50,6 +52,7 @@ public class Comment {
     private LocalDateTime updatedAt;
 
     @Column(name = "like_count", nullable = false)
+    @Builder.Default
     private int likeCount = 0;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/even/zaro/entity/FavoriteGroup.java
+++ b/src/main/java/com/even/zaro/entity/FavoriteGroup.java
@@ -30,6 +30,7 @@ public class FavoriteGroup {
     private String name;
 
     @Column(name = "is_deleted", nullable = false)
+    @Builder.Default
     private boolean isDeleted = false;
 
     @CreationTimestamp

--- a/src/main/java/com/even/zaro/entity/Post.java
+++ b/src/main/java/com/even/zaro/entity/Post.java
@@ -52,17 +52,22 @@ public class Post {
     private String thumbnailUrl;
 
     @Column(name = "is_reported")
+    @Builder.Default
     private boolean isReported = false;
     @Column(name = "is_deleted")
+    @Builder.Default
     private boolean isDeleted = false;
 
     @Column(name = "like_count", nullable = false)
+    @Builder.Default
     private int likeCount = 0;
 
     @Column(name = "comment_count", nullable = false)
+    @Builder.Default
     private int commentCount = 0;
 
     @Column(name = "report_count", nullable = false)
+    @Builder.Default
     private int reportCount = 0;
 
     @CreationTimestamp

--- a/src/main/java/com/even/zaro/entity/User.java
+++ b/src/main/java/com/even/zaro/entity/User.java
@@ -35,7 +35,7 @@ public class User {
     @Column(name = "password")
     private String password;
 
-    @Column(name = "nickname", nullable = false)
+    @Column(name = "nickname", nullable = false, unique = true)
     private String nickname;
 
     @Column(name = "profile_image")

--- a/src/main/java/com/even/zaro/global/ErrorCode.java
+++ b/src/main/java/com/even/zaro/global/ErrorCode.java
@@ -30,6 +30,7 @@ public enum ErrorCode {
 
     NICKNAME_REQUIRED(HttpStatus.BAD_REQUEST, "닉네임은 필수 입력 값입니다."),
     INVALID_NICKNAME(HttpStatus.BAD_REQUEST, "닉네임은 2-12자, 영문, 한글, 숫자, -, _만 가능합니다."),
+    NICKNAME_ALREADY_EXISTED(HttpStatus.CONFLICT, "이미 사용 중인 닉네임입니다."),
 
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
 

--- a/src/main/java/com/even/zaro/global/scheduler/TokenCleanupScheduler.java
+++ b/src/main/java/com/even/zaro/global/scheduler/TokenCleanupScheduler.java
@@ -5,6 +5,7 @@ import com.even.zaro.repository.PasswordResetRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 
@@ -16,12 +17,14 @@ public class TokenCleanupScheduler {
     private final PasswordResetRepository passwordResetRepository;
 
     @Scheduled(cron = "0 30 2 * * *")
+    @Transactional
     public void deleteExpiredEmailTokens() {
         LocalDateTime oneDayAgo = LocalDateTime.now().minusDays(1);
         emailTokenRepository.deleteByExpiredAtBefore(oneDayAgo);
     }
 
     @Scheduled(cron = "0 45 2 * * *")
+    @Transactional
     public void deleteExpiredPasswordTokens() {
         LocalDateTime oneDayAgo = LocalDateTime.now().minusDays(1);
         passwordResetRepository.deleteByExpiredAtBefore(oneDayAgo);

--- a/src/main/java/com/even/zaro/repository/UserRepository.java
+++ b/src/main/java/com/even/zaro/repository/UserRepository.java
@@ -12,4 +12,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmail(String email);
 
     Optional<User> findByProviderAndProviderId(Provider provider, String providerId);
+
+    boolean existsByNickname(String nickname);
 }

--- a/src/main/java/com/even/zaro/service/AuthService.java
+++ b/src/main/java/com/even/zaro/service/AuthService.java
@@ -66,6 +66,9 @@ public class AuthService {
         if (userRepository.existsByEmail(email)) {
             throw new UserException(ErrorCode.EMAIL_ALREADY_EXISTED);
         }
+        if (userRepository.existsByNickname(nickname)) {
+            throw new UserException(ErrorCode.NICKNAME_ALREADY_EXISTED);
+        }
 
         // 저장
         User user = userRepository.save(

--- a/src/test/java/com/even/zaro/service/AuthServiceTest.java
+++ b/src/test/java/com/even/zaro/service/AuthServiceTest.java
@@ -1,0 +1,48 @@
+package com.even.zaro.service;
+
+import com.even.zaro.dto.auth.SignUpRequestDto;
+import com.even.zaro.entity.Provider;
+import com.even.zaro.entity.Status;
+import com.even.zaro.entity.User;
+import com.even.zaro.global.ErrorCode;
+import com.even.zaro.global.exception.user.UserException;
+import com.even.zaro.repository.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+class AuthServiceTest {
+
+    @Autowired
+    private AuthService authService;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Test
+    void nicknameAlreadyExists_shouldThrowException() {
+        //given
+        User user = User.builder()
+                .email("test@even.com")
+                .nickname("이브니")
+                .password("Password1!")
+                .provider(Provider.LOCAL)
+                .status(Status.ACTIVE)
+                .build();
+        userRepository.save(user);
+
+        //when
+        SignUpRequestDto requestDto = new SignUpRequestDto("test2@even.com", "Test1234!", "이브니");
+
+        //then
+        UserException userException = assertThrows(UserException.class, () -> authService.signUp(requestDto));
+        assertEquals(ErrorCode.NICKNAME_ALREADY_EXISTED, userException.getErrorCode());
+    }
+}


### PR DESCRIPTION
## 📌 작업 개요
- 닉네임 중복 가능 -> 불가 엔티티, 서비스 로직 수정

---

## ✨ 주요 변경 사항
- 닉네임 중복 가능 -> 불가 엔티티, 서비스 로직 수정
- @Builder.Default warning 해결
- 이메일 토큰 삭제 스케줄러 오류 수정
     - 어제 새벽 스케줄러 작동 안함 확인(스케줄러에서 JPA delete 실행 중 트랜잭션이 없어서 실패) -> 트랜잭션 추가

---

## 🖼️ 기능 살펴 보기
> 포스트맨 요청 응답 스크린샷
- [x] API 문서(요청, 응답)와 일치하는지 확인 - 필요시 API 문서 수정 가능

---

## ✅ 작업 체크리스트
- [ ] API 테스트 완료 (POSTMAN)
- [ ] 스웨거 ui 관련 코드 추가
- [x] 기능별 예외 케이스 고려
- [ ] log.info / 불필요한 주석 제거
- [ ] 변수명, 클래스명, 메서드명 의미있게 작성
- [ ] 반복 코드 메서드로 분리

---

## 📂 테스트 방법
- [x] 테스트 코드 작성
- [x] 시나리오 기반 테스트 유무
    - nickname 중복 시 예외 처리 발생

---

## 💬 기타 참고 사항
- 댓글 태그 문제로 닉네임 중복 가능에서 중복 불가로 변경

---

## 📎 관련 이슈 / 문서

