### PR TITLE
Feat/notification : 알림 개별 읽기 api, 알림 전체읽기 api, 알림 자동삭제 스케줄링 구현

### DIFF
--- a/src/main/java/com/even/zaro/controller/NotificationController.java
+++ b/src/main/java/com/even/zaro/controller/NotificationController.java
@@ -36,7 +36,7 @@ public class NotificationController {
     }
 
     @Operation(
-            summary = "유저 개별 알림 읽음 처리 (인증 필요)",
+            summary = "개별 알림 읽음 처리 (인증 필요)",
             description = "로그인 된 유저의 개별 알림을 읽음 처리합니다.",
             security = {@SecurityRequirement(name = "bearer-key")})
     @PatchMapping("/api/notifications/{notificationId}")
@@ -47,4 +47,17 @@ public class NotificationController {
         notificationService.markAsRead(notificationId, userInfo.getUserId());
         return ResponseEntity.ok(ApiResponse.success("선택한 개별 알림 읽음 처리 성공 !"));
     }
+
+    @Operation(
+            summary = "전체 알림 읽음 처리 (인증 필요)",
+            description = "로그인 된 유저의 전체 알림을 읽음 처리합니다.",
+            security = {@SecurityRequirement(name = "bearer-key")})
+    @PatchMapping("/api/notifications/bulk")
+    public ResponseEntity<ApiResponse<Void>> readAllNotifications(
+            @AuthenticationPrincipal JwtUserInfoDto userInfo
+    ) {
+        notificationService.markAllAsRead(userInfo.getUserId());
+        return ResponseEntity.ok(ApiResponse.success("모든 알림이 읽음 처리되었습니다."));
+    }
+
 }

--- a/src/main/java/com/even/zaro/controller/NotificationController.java
+++ b/src/main/java/com/even/zaro/controller/NotificationController.java
@@ -35,12 +35,16 @@ public class NotificationController {
         return ResponseEntity.ok(ApiResponse.success("로그인 한 사용자의 알림 목록 조회 성공 !", notifications));
     }
 
+    @Operation(
+            summary = "유저 개별 알림 읽음 처리 (인증 필요)",
+            description = "로그인 된 유저의 개별 알림을 읽음 처리합니다.",
+            security = {@SecurityRequirement(name = "bearer-key")})
     @PatchMapping("/api/notifications/{notificationId}")
     public ResponseEntity<ApiResponse<Void>> readNotification(
             @PathVariable Long notificationId,
             @AuthenticationPrincipal JwtUserInfoDto userInfo
     ) {
         notificationService.markAsRead(notificationId, userInfo.getUserId());
-        return ResponseEntity.ok(ApiResponse.success("선택한 알림 읽음 처리 성공 !"));
+        return ResponseEntity.ok(ApiResponse.success("선택한 개별 알림 읽음 처리 성공 !"));
     }
 }

--- a/src/main/java/com/even/zaro/controller/NotificationController.java
+++ b/src/main/java/com/even/zaro/controller/NotificationController.java
@@ -11,9 +11,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -35,5 +33,14 @@ public class NotificationController {
             @AuthenticationPrincipal JwtUserInfoDto userInfoDto) {
         List<NotificationDto> notifications = notificationService.getNotificationsList(userInfoDto.getUserId());
         return ResponseEntity.ok(ApiResponse.success("로그인 한 사용자의 알림 목록 조회 성공 !", notifications));
+    }
+
+    @PatchMapping("/api/notifications/{notificationId}")
+    public ResponseEntity<ApiResponse<Void>> readNotification(
+            @PathVariable Long notificationId,
+            @AuthenticationPrincipal JwtUserInfoDto userInfo
+    ) {
+        notificationService.markAsRead(notificationId, userInfo.getUserId());
+        return ResponseEntity.ok(ApiResponse.success("선택한 알림 읽음 처리 성공 !"));
     }
 }

--- a/src/main/java/com/even/zaro/controller/NotificationController.java
+++ b/src/main/java/com/even/zaro/controller/NotificationController.java
@@ -39,7 +39,7 @@ public class NotificationController {
             summary = "개별 알림 읽음 처리 (인증 필요)",
             description = "로그인 된 유저의 개별 알림을 읽음 처리합니다.",
             security = {@SecurityRequirement(name = "bearer-key")})
-    @PatchMapping("/api/notifications/{notificationId}")
+    @PatchMapping("/{notificationId}")
     public ResponseEntity<ApiResponse<Void>> readNotification(
             @PathVariable Long notificationId,
             @AuthenticationPrincipal JwtUserInfoDto userInfo
@@ -52,7 +52,7 @@ public class NotificationController {
             summary = "전체 알림 읽음 처리 (인증 필요)",
             description = "로그인 된 유저의 전체 알림을 읽음 처리합니다.",
             security = {@SecurityRequirement(name = "bearer-key")})
-    @PatchMapping("/api/notifications/bulk")
+    @PatchMapping("/bulk")
     public ResponseEntity<ApiResponse<Void>> readAllNotifications(
             @AuthenticationPrincipal JwtUserInfoDto userInfo
     ) {

--- a/src/main/java/com/even/zaro/entity/Notification.java
+++ b/src/main/java/com/even/zaro/entity/Notification.java
@@ -50,4 +50,8 @@ public class Notification {
     public void setRead(boolean read) {
         this.isRead = read;
     }
+
+    public void markAsRead() {
+        this.isRead = true;
+    }
 }

--- a/src/main/java/com/even/zaro/global/ErrorCode.java
+++ b/src/main/java/com/even/zaro/global/ErrorCode.java
@@ -51,6 +51,9 @@ public enum ErrorCode {
     INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 리프레시 토큰입니다."),
     REFRESH_TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "리프레쉬 토큰을 찾을 수 없습니다."),
 
+    // 알림 Notification
+    NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "조회된 알림이 없습니다."),
+
     // 게시글 Post
     IMAGE_REQUIRED_FOR_RANDOM_BUY(HttpStatus.BAD_REQUEST, "이미지는 필수입니다."),
     INVALID_CATEGORY(HttpStatus.BAD_REQUEST, "올바르지 않은 카테고리입니다."),

--- a/src/main/java/com/even/zaro/global/exception/notification/NotificationException.java
+++ b/src/main/java/com/even/zaro/global/exception/notification/NotificationException.java
@@ -1,0 +1,10 @@
+package com.even.zaro.global.exception.notification;
+
+import com.even.zaro.global.ErrorCode;
+import com.even.zaro.global.exception.CustomException;
+
+public class NotificationException extends CustomException {
+    public NotificationException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/even/zaro/global/scheduler/NotificationCleanupScheduler.java
+++ b/src/main/java/com/even/zaro/global/scheduler/NotificationCleanupScheduler.java
@@ -1,0 +1,25 @@
+package com.even.zaro.global.scheduler;
+
+import com.even.zaro.repository.NotificationRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class NotificationCleanupScheduler {
+
+    private final NotificationRepository notificationRepository;
+
+    // 매일 새벽 3시에, 그때로부터 30일전 새벽 3시 이전으로 만들어진 알림을 삭제
+    @Scheduled(cron = "0 0 3 * * *")
+    public void deleteOldNotifications() {
+        LocalDateTime deletingDate = LocalDateTime.now().minusDays(30);
+        notificationRepository.deleteByCreatedAtBefore(deletingDate);
+        log.info("[Scheduler] 30일 지난 알림 삭제 완료 ! (deletingDate = {})", deletingDate);
+    }
+}

--- a/src/main/java/com/even/zaro/repository/NotificationRepository.java
+++ b/src/main/java/com/even/zaro/repository/NotificationRepository.java
@@ -5,11 +5,14 @@ import com.even.zaro.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
 
     List<Notification> findAllByUserOrderByCreatedAtDesc(User user);
+
+    Optional<Notification> findByIdAndUserId(Long notificationId, Long userId);
+
 }

--- a/src/main/java/com/even/zaro/repository/NotificationRepository.java
+++ b/src/main/java/com/even/zaro/repository/NotificationRepository.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Repository;
 
 import java.util.List;
 import java.util.Optional;
+import java.time.LocalDateTime;
 
 @Repository
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
@@ -16,4 +17,6 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
     Optional<Notification> findByIdAndUserId(Long notificationId, Long userId);
 
     List<Notification> findAllByUserIdAndIsReadFalse(Long userId);
+
+    void deleteByCreatedAtBefore(LocalDateTime deletingDate);
 }

--- a/src/main/java/com/even/zaro/repository/NotificationRepository.java
+++ b/src/main/java/com/even/zaro/repository/NotificationRepository.java
@@ -15,4 +15,5 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
 
     Optional<Notification> findByIdAndUserId(Long notificationId, Long userId);
 
+    List<Notification> findAllByUserIdAndIsReadFalse(Long userId);
 }

--- a/src/main/java/com/even/zaro/service/NotificationService.java
+++ b/src/main/java/com/even/zaro/service/NotificationService.java
@@ -47,4 +47,12 @@ public class NotificationService {
         notification.markAsRead(); // isRead = true
     }
 
+    public void markAllAsRead(Long userId) {
+        List<Notification> notifications = notificationRepository.findAllByUserIdAndIsReadFalse(userId);
+        notifications.forEach(n -> {
+            if (!n.isRead()) {
+                n.setRead(true);
+            }
+        });
+    }
 }

--- a/src/main/java/com/even/zaro/service/NotificationService.java
+++ b/src/main/java/com/even/zaro/service/NotificationService.java
@@ -10,11 +10,9 @@ import com.even.zaro.repository.NotificationRepository;
 import com.even.zaro.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
 import java.util.List;
 
 @Service
@@ -56,13 +54,5 @@ public class NotificationService {
                 n.setRead(true);
             }
         });
-    }
-
-    // 매일 새벽 3시에, 그때로부터 30일전 새벽 3시 이전으로 만들어진 알림을 삭제
-    @Scheduled(cron = "0 0 3 * * *")
-    public void deleteOldNotifications() {
-        LocalDateTime deletingDate = LocalDateTime.now().minusDays(30);
-        notificationRepository.deleteByCreatedAtBefore(deletingDate);
-        log.info("[Scheduler] 30일 지난 알림 삭제 완료 ! (deletingDate = {})", deletingDate);
     }
 }

--- a/src/main/java/com/even/zaro/service/NotificationService.java
+++ b/src/main/java/com/even/zaro/service/NotificationService.java
@@ -10,9 +10,11 @@ import com.even.zaro.repository.NotificationRepository;
 import com.even.zaro.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Service
@@ -54,5 +56,13 @@ public class NotificationService {
                 n.setRead(true);
             }
         });
+    }
+
+    // 매일 새벽 3시에, 그때로부터 30일전 새벽 3시 이전으로 만들어진 알림을 삭제
+    @Scheduled(cron = "0 0 3 * * *")
+    public void deleteOldNotifications() {
+        LocalDateTime deletingDate = LocalDateTime.now().minusDays(30);
+        notificationRepository.deleteByCreatedAtBefore(deletingDate);
+        log.info("[Scheduler] 30일 지난 알림 삭제 완료 ! (deletingDate = {})", deletingDate);
     }
 }

--- a/src/main/java/com/even/zaro/service/NotificationService.java
+++ b/src/main/java/com/even/zaro/service/NotificationService.java
@@ -1,8 +1,10 @@
 package com.even.zaro.service;
 
 import com.even.zaro.dto.notification.NotificationDto;
+import com.even.zaro.entity.Notification;
 import com.even.zaro.entity.User;
 import com.even.zaro.global.ErrorCode;
+import com.even.zaro.global.exception.notification.NotificationException;
 import com.even.zaro.global.exception.user.UserException;
 import com.even.zaro.repository.NotificationRepository;
 import com.even.zaro.repository.UserRepository;
@@ -37,4 +39,12 @@ public class NotificationService {
                         .build())
                 .toList();
     }
+
+    public void markAsRead(Long notificationId, Long userId) {
+        Notification notification = notificationRepository.findByIdAndUserId(notificationId, userId)
+                .orElseThrow(() -> new NotificationException(ErrorCode.NOTIFICATION_NOT_FOUND));
+
+        notification.markAsRead(); // isRead = true
+    }
+
 }


### PR DESCRIPTION
## 📌 작업 개요

- 알림 개별 읽기 api, 알림 전체읽기 api, 알림 자동삭제 스케줄링 구현

---

## ✨ 주요 변경 사항
- 새로 생성 된 파일 없습니다 (기존의 Notification 파일들 내부에서 구현)
- 스케줄링은 기존의 SchedulingConfig로 이미 설정 되어있어서, 구현메서드에 @Scheduled 붙여서 사용했습니다

---

## 🖼️ 기능 살펴 보기

- 알림 개별 읽기 api (로그인 필요)
> ![image](https://github.com/user-attachments/assets/c9815579-bb86-465c-aba3-b76d32599cba)

- 알림 전체 읽기 api (로그인 필요)
> ![image](https://github.com/user-attachments/assets/dc3c65e1-c8d5-4cd8-af1d-05331c3f4866)


- 생성된 지 30일 이상 지난 알림 자동삭제 스케줄링
  - 서버시간을 30일 후로 넘기는 것은 너무 헤비한 테스트 방법인지라... 코드를 아래처럼 수정한 후 테스트 진행했습니다
   ![image](https://github.com/user-attachments/assets/e3dbd9c0-0e5c-4cb5-b05e-4777acbc298b)
  **스케줄러 도는 주기 : 매일 새벽 3시 실행 -> (테스트용) 매 분 실행
  deletingDate : 현재시각보다 30일 전 -> (테스트용) 현재 시각보다 5분 전** 

> 1️⃣ DB 초기 상태
![image](https://github.com/user-attachments/assets/af88db4f-a4e6-4215-96e1-162d881128ec)

> 2️⃣ 스케줄러 1차 실행 후 DB : 하루 전에 생성된 알림==스케줄러 실행시각 5분전 보다 전 -> 삭제됨
![image](https://github.com/user-attachments/assets/324d5923-89f0-48ab-98a2-2b363a475595)

> 3️⃣ 나머지 알림들 생성시각보다 5분 지난 후, 가장 첫번째 스케줄러 실행 로그 & DB
![image](https://github.com/user-attachments/assets/522e220c-2fdc-41ed-95a3-9ca30a92a999)
![image](https://github.com/user-attachments/assets/0804dc4f-ad84-43ac-a098-a1089cd0a207)


---

## ✅ 작업 체크리스트
- [x] API 테스트 완료 (POSTMAN)
- [x] 스웨거 ui 관련 코드 추가
- [x] 변수명, 클래스명, 메서드명 의미있게 작성

---

## 📂 테스트 방법
- [x] swagger & DBvear

---

## 💬 기타 참고 사항


