### PR TITLE
Chore/401 error 로그인 안했을 때 401 응답 처리

### DIFF
--- a/src/main/java/com/even/zaro/config/security/SecurityConfig.java
+++ b/src/main/java/com/even/zaro/config/security/SecurityConfig.java
@@ -1,6 +1,7 @@
 package com.even.zaro.config.security;
 
 import com.even.zaro.jwt.JwtAuthFilter;
+import com.even.zaro.jwt.JwtAuthenticationEntryPoint;
 import com.even.zaro.jwt.JwtUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -25,6 +26,7 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 public class SecurityConfig {
 
     private final JwtUtil jwtUtil;
+    private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
 
     @Value("${cors.backend-origin}")
     private String backendOrigin;
@@ -35,6 +37,7 @@ public class SecurityConfig {
                 .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .csrf(AbstractHttpConfigurer::disable) // JWT 사용으로 필요 없음
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .exceptionHandling(e -> e.authenticationEntryPoint(jwtAuthenticationEntryPoint))
                 .authorizeHttpRequests(request -> request
                         .requestMatchers("/health/**").permitAll() // health  
                         .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll() // 스웨거

--- a/src/main/java/com/even/zaro/global/ErrorCode.java
+++ b/src/main/java/com/even/zaro/global/ErrorCode.java
@@ -11,6 +11,9 @@ public enum ErrorCode {
     EXAMPLE_EXCEPTION(HttpStatus.INTERNAL_SERVER_ERROR, "예시 예외 발생"),
     EXAMPLE_USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
 
+    // 인증 Authentication
+    AUTH_REQUIRED(HttpStatus.UNAUTHORIZED, "로그인이 필요합니다."),
+
     // 공통
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버에서 알 수 없는 오류가 발생했습니다."),
     INVALID_USER_ID(HttpStatus.BAD_REQUEST,  "userId는 필수입니다."),

--- a/src/main/java/com/even/zaro/jwt/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/even/zaro/jwt/JwtAuthenticationEntryPoint.java
@@ -1,5 +1,7 @@
 package com.even.zaro.jwt;
 
+import com.even.zaro.global.ApiResponse;
+import com.even.zaro.global.ErrorCode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -22,11 +24,7 @@ public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
         response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
         response.setContentType("application/json");
 
-        Map<String, Object> body = new HashMap<>();
-        body.put("code", "AUTH_REQUIRED");
-        body.put("message", "로그인이 필요합니다.");
-        body.put("data", null);
-
+        ApiResponse<Object> body = ApiResponse.fail(ErrorCode.AUTH_REQUIRED);
         objectMapper.writeValue(response.getWriter(), body);
     }
 }

--- a/src/main/java/com/even/zaro/jwt/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/even/zaro/jwt/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,32 @@
+package com.even.zaro.jwt;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+@Component
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response,
+                         AuthenticationException authException) throws IOException {
+        response.setCharacterEncoding("UTF-8");
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType("application/json");
+
+        Map<String, Object> body = new HashMap<>();
+        body.put("code", "AUTH_REQUIRED");
+        body.put("message", "로그인이 필요합니다.");
+        body.put("data", null);
+
+        objectMapper.writeValue(response.getWriter(), body);
+    }
+}


### PR DESCRIPTION
## 📌 작업 개요
- 로그인 안했을 때 401 응답 처리

---

## ✨ 주요 변경 사항
- 기존 로그인 안했을 때(토큰 없거나 토큰 잘못된 상황) 단순히 403으로 처리되는 것을 401로 내리고, 팀 응답 양식으로 통일했습니다.

---

## 🖼️ 기능 살펴 보기
> 포스트맨 요청 응답 스크린샷
- [x] API 문서(요청, 응답)와 일치하는지 확인 - 필요시 API 문서 수정 가능
![image](https://github.com/user-attachments/assets/c1f581f3-278a-4209-ae58-e2c7263a7eae)


---

## ✅ 작업 체크리스트
- [x] API 테스트 완료 (POSTMAN)
- [ ] 스웨거 ui 관련 코드 추가
- [x] 기능별 예외 케이스 고려
- [ ] log.info / 불필요한 주석 제거
- [ ] 변수명, 클래스명, 메서드명 의미있게 작성
- [ ] 반복 코드 메서드로 분리

---

## 📂 테스트 방법
- [ ] 테스트 코드 작성
- [ ] 시나리오 기반 테스트 유무
    - ex: ID 중복 시 예외 처리 발생

---

## 💬 기타 참고 사항
- http 상태코드 401로 설정했고 커스텀 코드도 설정했습니다.

---

## 📎 관련 이슈 / 문서

