### PR TITLE
Fix/authservice unit test 단위테스트 및 통합테스트 구분

### DIFF
--- a/src/test/java/com/even/zaro/integration/AuthServiceIntegrationTest.java
+++ b/src/test/java/com/even/zaro/integration/AuthServiceIntegrationTest.java
@@ -1,0 +1,49 @@
+package com.even.zaro.integration;
+
+import com.even.zaro.dto.auth.SignUpRequestDto;
+import com.even.zaro.entity.Provider;
+import com.even.zaro.entity.Status;
+import com.even.zaro.entity.User;
+import com.even.zaro.global.ErrorCode;
+import com.even.zaro.global.exception.user.UserException;
+import com.even.zaro.repository.UserRepository;
+import com.even.zaro.service.AuthService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+class AuthServiceIntegrationTest {
+
+    @Autowired
+    private AuthService authService;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Test
+    void nicknameAlreadyExists_shouldThrowException() {
+        //given
+        User user = User.builder()
+                .email("test@even.com")
+                .nickname("이브니")
+                .password("Password1!")
+                .provider(Provider.LOCAL)
+                .status(Status.ACTIVE)
+                .build();
+        userRepository.save(user);
+
+        //when
+        SignUpRequestDto requestDto = new SignUpRequestDto("test2@even.com", "Test1234!", "이브니");
+
+        //then
+        UserException userException = assertThrows(UserException.class, () -> authService.signUp(requestDto));
+        assertEquals(ErrorCode.NICKNAME_ALREADY_EXISTED, userException.getErrorCode());
+    }
+}

--- a/src/test/java/com/even/zaro/service/AuthServiceTest.java
+++ b/src/test/java/com/even/zaro/service/AuthServiceTest.java
@@ -1,42 +1,34 @@
 package com.even.zaro.service;
 
 import com.even.zaro.dto.auth.SignUpRequestDto;
-import com.even.zaro.entity.Provider;
-import com.even.zaro.entity.Status;
-import com.even.zaro.entity.User;
 import com.even.zaro.global.ErrorCode;
 import com.even.zaro.global.exception.user.UserException;
 import com.even.zaro.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.transaction.annotation.Transactional;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
 
-@SpringBootTest
-@ActiveProfiles("test")
-@Transactional
+@ExtendWith(MockitoExtension.class)
 class AuthServiceTest {
 
-    @Autowired
+    @InjectMocks
     private AuthService authService;
 
-    @Autowired
+    @Mock
     private UserRepository userRepository;
 
+    @DisplayName("회원가입시 닉네임 중복 예외처리")
     @Test
     void nicknameAlreadyExists_shouldThrowException() {
         //given
-        User user = User.builder()
-                .email("test@even.com")
-                .nickname("이브니")
-                .password("Password1!")
-                .provider(Provider.LOCAL)
-                .status(Status.ACTIVE)
-                .build();
-        userRepository.save(user);
+        when(userRepository.existsByNickname("이브니")).thenReturn(true);
 
         //when
         SignUpRequestDto requestDto = new SignUpRequestDto("test2@even.com", "Test1234!", "이브니");


### PR DESCRIPTION
## 📌 작업 개요
- 단위테스트 및 통합테스트 구분

---

## ✨ 주요 변경 사항
- 기존에 작성한 닉네임 중복 로직 단위테스트 및 통합테스트 구분

---

## 🖼️ 기능 살펴 보기
> 포스트맨 요청 응답 스크린샷
- [ ] API 문서(요청, 응답)와 일치하는지 확인 - 필요시 API 문서 수정 가능

---

## ✅ 작업 체크리스트
- [ ] API 테스트 완료 (POSTMAN)
- [ ] 스웨거 ui 관련 코드 추가
- [ ] 기능별 예외 케이스 고려
- [ ] log.info / 불필요한 주석 제거
- [ ] 변수명, 클래스명, 메서드명 의미있게 작성
- [ ] 반복 코드 메서드로 분리

---

## 📂 테스트 방법
- [x] 테스트 코드 작성
- [ ] 시나리오 기반 테스트 유무
    - ex: ID 중복 시 예외 처리 발생

---

## 💬 기타 참고 사항
- 제가 이전에 스케줄러 로직 테스트할 때 db(테스트용 h2)를 사용한다고(스케줄러 로직 자체가 db에서 삭제 되는지 테스트하는 것이라..) SpringBootTest를 했었는데 이게 통합 테스트할 때 사용하는 거라고 하더라구요.
- 이번에는 (회원 가입시 닉네임 중복 예외처리) 단순히 서비스 단의 로직 검증용이어서 사실 db까지 쓸 필요 없이 Mock으로 단위테스트만 진행했으면 되는데.. (아주 빠름) 이 사실을 모르고 db 사용하는 테스트를 해버렸습니다. 
- 이번에 기록용으로 구분해서 올리게 되었습니다.
- db 사용하는 테스트 진행시 패키지를 integration 만들었으니 여기에 넣으시면 될 것 같습니다. (자세히 모름. 혹시 자세하고 제대로된 정보 알게 되면 공유 바랍니다.)

---

## 📎 관련 이슈 / 문서
- 디코 정보 방에 블로그 하나 남겼으니 참고 바랍니다.
