### PR TITLE
Feat/comment r 댓글 리스트 조회 API 구현 및 공통 page response 추가

### DIFF
--- a/src/main/java/com/even/zaro/controller/CommentController.java
+++ b/src/main/java/com/even/zaro/controller/CommentController.java
@@ -1,5 +1,6 @@
 package com.even.zaro.controller;
 
+import com.even.zaro.dto.PageResponse;
 import com.even.zaro.dto.comment.CommentRequestDto;
 import com.even.zaro.dto.comment.CommentResponseDto;
 import com.even.zaro.dto.jwt.JwtUserInfoDto;
@@ -38,12 +39,12 @@ public class CommentController {
     }
 
     @GetMapping("/posts/{postId}/comments")
-    public ResponseEntity<ApiResponse<Page<CommentResponseDto>>> readAllComments(
+    public ResponseEntity<ApiResponse<PageResponse<CommentResponseDto>>> readAllComments(
             @PathVariable Long postId,
             @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.ASC) Pageable pageable,
             @AuthenticationPrincipal JwtUserInfoDto userInfoDto
     ) {
-        Page<CommentResponseDto> responseDto = commentService.readAllComments(postId, pageable, userInfoDto);
+        PageResponse<CommentResponseDto> responseDto = commentService.readAllComments(postId, pageable, userInfoDto);
         return ResponseEntity.ok(ApiResponse.success("댓글 리스트를 불러왔습니다.", responseDto));
     }
 }

--- a/src/main/java/com/even/zaro/controller/CommentController.java
+++ b/src/main/java/com/even/zaro/controller/CommentController.java
@@ -11,6 +11,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -38,10 +39,12 @@ public class CommentController {
         return ResponseEntity.ok(ApiResponse.success("댓글을 작성했습니다.", responseDto));
     }
 
+    @Operation(summary = "댓글 리스트 조회", description = "{postId} 게시글에 댓글 리스트를 조회합니다.",
+            security = {@SecurityRequirement(name = "bearer-key")})
     @GetMapping("/posts/{postId}/comments")
     public ResponseEntity<ApiResponse<PageResponse<CommentResponseDto>>> readAllComments(
-            @PathVariable Long postId,
-            @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.ASC) Pageable pageable,
+            @Parameter(description = "게시글 ID", example = "1") @PathVariable Long postId,
+            @ParameterObject @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.ASC) Pageable pageable,
             @AuthenticationPrincipal JwtUserInfoDto userInfoDto
     ) {
         PageResponse<CommentResponseDto> responseDto = commentService.readAllComments(postId, pageable, userInfoDto);

--- a/src/main/java/com/even/zaro/controller/CommentController.java
+++ b/src/main/java/com/even/zaro/controller/CommentController.java
@@ -10,6 +10,10 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -31,5 +35,15 @@ public class CommentController {
             @AuthenticationPrincipal JwtUserInfoDto userInfoDto) {
         CommentResponseDto responseDto = commentService.createComment(postId, requestDto, userInfoDto);
         return ResponseEntity.ok(ApiResponse.success("댓글을 작성했습니다.", responseDto));
+    }
+
+    @GetMapping("/posts/{postId}/comments")
+    public ResponseEntity<ApiResponse<Page<CommentResponseDto>>> readAllComments(
+            @PathVariable Long postId,
+            @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.ASC) Pageable pageable,
+            @AuthenticationPrincipal JwtUserInfoDto userInfoDto
+    ) {
+        Page<CommentResponseDto> responseDto = commentService.readAllComments(postId, pageable, userInfoDto);
+        return ResponseEntity.ok(ApiResponse.success("댓글 리스트를 불러왔습니다.", responseDto));
     }
 }

--- a/src/main/java/com/even/zaro/dto/PageResponse.java
+++ b/src/main/java/com/even/zaro/dto/PageResponse.java
@@ -1,0 +1,29 @@
+package com.even.zaro.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+@Getter
+public class PageResponse<T> {
+
+    private final List<T> content;
+
+    private final int totalPages;
+
+    private final int number;
+
+    public PageResponse(List<T> content, int totalPages, int number) {
+        this.content = content;
+        this.totalPages = totalPages;
+        this.number = number;
+    }
+
+    public PageResponse(Page<T> page) {
+        this.content = page.getContent();
+        this.totalPages = page.getTotalPages();
+        this.number = page.getNumber();
+    }
+}

--- a/src/main/java/com/even/zaro/dto/PageResponse.java
+++ b/src/main/java/com/even/zaro/dto/PageResponse.java
@@ -1,5 +1,7 @@
 package com.even.zaro.dto;
 
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.springframework.data.domain.Page;
@@ -7,12 +9,16 @@ import org.springframework.data.domain.Page;
 import java.util.List;
 
 @Getter
+@Schema(description = "공통 페이징 응답 포맷")
 public class PageResponse<T> {
 
+    @ArraySchema(schema = @Schema(description = "데이터 목록"))
     private final List<T> content;
 
+    @Schema(description = "전체 페이지 수", example = "5")
     private final int totalPages;
 
+    @Schema(description = "현재 페이지 번호 (0부터 시작)", example = "0")
     private final int number;
 
     public PageResponse(List<T> content, int totalPages, int number) {

--- a/src/main/java/com/even/zaro/dto/comment/CommentResponseDto.java
+++ b/src/main/java/com/even/zaro/dto/comment/CommentResponseDto.java
@@ -1,5 +1,7 @@
 package com.even.zaro.dto.comment;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -31,5 +33,11 @@ public class CommentResponseDto {
     private LocalDateTime createdAt;
 
     @Schema(description = "댓글 작성자 여부", example = "true")
+    @JsonProperty("isMine")
     private boolean isMine;
+
+    @JsonIgnore
+    public boolean getMine() {
+        return isMine;
+    }
 }

--- a/src/main/java/com/even/zaro/dto/comment/CommentResponseDto.java
+++ b/src/main/java/com/even/zaro/dto/comment/CommentResponseDto.java
@@ -29,4 +29,7 @@ public class CommentResponseDto {
 
     @Schema(description = "댓글 작성 시간", example = "2025-05-21T14:33:00")
     private LocalDateTime createdAt;
+
+    @Schema(description = "댓글 작성자 여부", example = "true")
+    private boolean isMine;
 }

--- a/src/main/java/com/even/zaro/service/CommentService.java
+++ b/src/main/java/com/even/zaro/service/CommentService.java
@@ -13,6 +13,8 @@ import com.even.zaro.repository.CommentRepository;
 import com.even.zaro.repository.PostRepository;
 import com.even.zaro.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -44,7 +46,30 @@ public class CommentService {
                 user.getNickname(),
                 user.getProfileImage(),
                 user.getLiveAloneDate(),
-                comment.getCreatedAt()
+                comment.getCreatedAt(),
+                true
         );
+    }
+
+    @Transactional(readOnly = true)
+    public Page<CommentResponseDto> readAllComments(Long postId, Pageable pageable, JwtUserInfoDto userInfoDto) {
+        Long currentUserId = userInfoDto.getUserId();
+
+        return commentRepository.findByPostIdAndIsDeletedFalseOrderByCreatedAtAsc(postId, pageable)
+                .map(comment -> {
+                    User writer = comment.getUser();
+
+                    boolean isMine = writer.getId().equals(currentUserId);
+
+                    return new CommentResponseDto(
+                            comment.getId(),
+                            comment.getContent(),
+                            comment.getUser().getNickname(),
+                            comment.getUser().getProfileImage(),
+                            comment.getUser().getLiveAloneDate(),
+                            comment.getCreatedAt(),
+                            isMine
+                    );
+                });
     }
 }

--- a/src/main/java/com/even/zaro/service/CommentService.java
+++ b/src/main/java/com/even/zaro/service/CommentService.java
@@ -1,5 +1,6 @@
 package com.even.zaro.service;
 
+import com.even.zaro.dto.PageResponse;
 import com.even.zaro.dto.comment.CommentResponseDto;
 import com.even.zaro.dto.comment.CommentRequestDto;
 import com.even.zaro.dto.jwt.JwtUserInfoDto;
@@ -52,10 +53,10 @@ public class CommentService {
     }
 
     @Transactional(readOnly = true)
-    public Page<CommentResponseDto> readAllComments(Long postId, Pageable pageable, JwtUserInfoDto userInfoDto) {
+    public PageResponse<CommentResponseDto> readAllComments(Long postId, Pageable pageable, JwtUserInfoDto userInfoDto) {
         Long currentUserId = userInfoDto.getUserId();
 
-        return commentRepository.findByPostIdAndIsDeletedFalseOrderByCreatedAtAsc(postId, pageable)
+        Page<CommentResponseDto> page = commentRepository.findByPostIdAndIsDeletedFalseOrderByCreatedAtAsc(postId, pageable)
                 .map(comment -> {
                     User writer = comment.getUser();
 
@@ -71,5 +72,6 @@ public class CommentService {
                             isMine
                     );
                 });
+        return new PageResponse<>(page);
     }
 }

--- a/src/main/java/com/even/zaro/service/CommentService.java
+++ b/src/main/java/com/even/zaro/service/CommentService.java
@@ -56,6 +56,10 @@ public class CommentService {
     public PageResponse<CommentResponseDto> readAllComments(Long postId, Pageable pageable, JwtUserInfoDto userInfoDto) {
         Long currentUserId = userInfoDto.getUserId();
 
+        // 게시글 존재 여부 확인
+        Post post = postRepository.findByIdAndIsDeletedFalse(postId)
+                .orElseThrow(() -> new PostException(ErrorCode.POST_NOT_FOUND));
+
         Page<CommentResponseDto> page = commentRepository.findByPostIdAndIsDeletedFalseOrderByCreatedAtAsc(postId, pageable)
                 .map(comment -> {
                     User writer = comment.getUser();


### PR DESCRIPTION
## 📌 작업 개요
- 댓글 리스트 조회 API 구현 및 공통 page response 추가

---

## ✨ 주요 변경 사항
- 댓글 리스트 조회 API 구현
- 공통 page response 추가
   - 오후에 프론트와 논의 결과 content, totalPages, number 를 내려주기로 했습니다.
---

## 🖼️ 기능 살펴 보기
> 포스트맨 요청 응답 스크린샷
- [x] API 문서(요청, 응답)와 일치하는지 확인 - 필요시 API 문서 수정 가능
![image](https://github.com/user-attachments/assets/711a955e-bb27-4294-8187-97540ba9dfb9)


---

## ✅ 작업 체크리스트
- [x] API 테스트 완료 (POSTMAN)
- [x] 스웨거 ui 관련 코드 추가
- [x] 기능별 예외 케이스 고려
- [x] log.info / 불필요한 주석 제거
- [x] 변수명, 클래스명, 메서드명 의미있게 작성
- [x] 반복 코드 메서드로 분리

---

## 📂 테스트 방법
- [ ] 테스트 코드 작성
- [ ] 시나리오 기반 테스트 유무
    - ex: ID 중복 시 예외 처리 발생

---

## 💬 기타 참고 사항
- 

---

## 📎 관련 이슈 / 문서
- 관련 이슈 번호: #54 - 리팩토링 방법 댓글로 작성해놓겠습니다.
