### PR TITLE
Feat/by-cordinate-list 좌표기반 인근 장소 조회 API 구현

### DIFF
--- a/src/main/java/com/even/zaro/config/QueryDslConfig.java
+++ b/src/main/java/com/even/zaro/config/QueryDslConfig.java
@@ -1,0 +1,14 @@
+package com.even.zaro.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QueryDslConfig {
+    @Bean
+    public JPAQueryFactory jpaQueryFactory(EntityManager em) {
+        return new JPAQueryFactory(em);
+    }
+}

--- a/src/main/java/com/even/zaro/controller/MapController.java
+++ b/src/main/java/com/even/zaro/controller/MapController.java
@@ -7,6 +7,7 @@ import com.even.zaro.global.ApiResponse;
 import com.even.zaro.service.MapService;
 import com.nimbusds.openid.connect.sdk.claims.UserInfo;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -42,8 +43,13 @@ public class MapController {
     @Operation(summary = "사용자 위치 기반 인근 맛집? 조회", description = "사용자의 위치를 이용해 인근 맛집 또는 장소를 조회합니다.", security = {@SecurityRequirement(name = "bearer-key")})
     @GetMapping("/place")
     public ResponseEntity<ApiResponse<PlaceResponse>> getPlacesByCoordinate(
+            @Parameter(description = "사용자의 현재 위도", example = "37.554722")
             @RequestParam double lat,
+
+            @Parameter(description = "사용자의 현재 경도", example = "126.970833")
             @RequestParam double lng,
+
+            @Parameter(description = "조회 반경 (단위: km)", example = "1.0")
             @RequestParam double distanceKm,
             @AuthenticationPrincipal JwtUserInfoDto userInfo) {
 

--- a/src/main/java/com/even/zaro/controller/MapController.java
+++ b/src/main/java/com/even/zaro/controller/MapController.java
@@ -2,6 +2,7 @@ package com.even.zaro.controller;
 
 import com.even.zaro.dto.jwt.JwtUserInfoDto;
 import com.even.zaro.dto.map.MarkerInfoResponse;
+import com.even.zaro.dto.map.PlaceResponse;
 import com.even.zaro.global.ApiResponse;
 import com.even.zaro.service.MapService;
 import com.nimbusds.openid.connect.sdk.claims.UserInfo;
@@ -12,10 +13,9 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/map")
@@ -34,5 +34,21 @@ public class MapController {
         MarkerInfoResponse placeInfo = mapService.getPlaceInfo(placeId);
 
         return ResponseEntity.ok(ApiResponse.success("해당 장소의 정보와 유저들의 메모리스트를 조회했습니다.", placeInfo));
+    }
+
+
+
+
+    @Operation(summary = "사용자 위치 기반 인근 맛집? 조회", description = "사용자의 위치를 이용해 인근 맛집 또는 장소를 조회합니다.", security = {@SecurityRequirement(name = "bearer-key")})
+    @GetMapping("/place")
+    public ResponseEntity<ApiResponse<PlaceResponse>> getPlacesByCoordinate(
+            @RequestParam double lat,
+            @RequestParam double lng,
+            @RequestParam double distanceKm,
+            @AuthenticationPrincipal JwtUserInfoDto userInfo) {
+
+        PlaceResponse placesByCoordinate = mapService.getPlacesByCoordinate(lat, lng, distanceKm);
+
+        return ResponseEntity.ok(ApiResponse.success("인근 장소 리스트를 성공적으로 조회했습니다.", placesByCoordinate));
     }
 }

--- a/src/main/java/com/even/zaro/dto/map/PlaceResponse.java
+++ b/src/main/java/com/even/zaro/dto/map/PlaceResponse.java
@@ -1,0 +1,26 @@
+package com.even.zaro.dto.map;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Builder
+@Getter
+public class PlaceResponse {
+
+    int totalCount;
+
+    List<PlaceInfo> placeInfos;
+
+    @Builder
+    @Getter
+    static public class PlaceInfo {
+        long place_id;
+        String name;
+        String address;
+        double lat;
+        double lng;
+    }
+
+}

--- a/src/main/java/com/even/zaro/global/ErrorCode.java
+++ b/src/main/java/com/even/zaro/global/ErrorCode.java
@@ -102,6 +102,8 @@ public enum ErrorCode {
 
     // 지도 Map
     PLACE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 장소를 찾지 못했습니다."),
+    BY_COORDINATE_NOT_FOUND_PLACE_LIST(HttpStatus.NOT_FOUND, "인근에 조회된 장소가 없습니다."),
+
 
 
     // Health

--- a/src/main/java/com/even/zaro/repository/MapQueryRepository.java
+++ b/src/main/java/com/even/zaro/repository/MapQueryRepository.java
@@ -1,0 +1,60 @@
+package com.even.zaro.repository;
+
+import com.even.zaro.entity.Place;
+import com.even.zaro.entity.QPlace;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.NumberExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+
+@RequiredArgsConstructor
+@Repository
+public class MapQueryRepository {
+    private final JPAQueryFactory jpaQueryFactory;
+
+    /**
+     * 주어진 위도/경도 기준으로 반경 distanceKm 이내의 장소를 조회합니다.
+     * 사각형 모양으로 조회 (사용자 중심으로 원형 조회 XXXXXXX)
+     *
+     * @param latitude 사용자의 현재 위도 (예: 37.5665)
+     * @param longitude 사용자의 현재 경도 (예: 126.9780)
+     * @param distanceKm 검색 반경 (단위: km, 예: 1.0 = 1km, 0.5 = 500m)
+     * @return 반경 내의 Place 목록
+     */
+    public List<Place> findPlaceByCoordinate(double latitude, double longitude, double distanceKm) {
+        QPlace place = QPlace.place;
+
+        double latDelta = distanceKm / 111.0; // 경도 계산
+        double lngDelta = distanceKm / (111.0 * Math.cos(Math.toRadians(latitude))); // 위도 계산
+
+        NumberExpression<Double> minLat = Expressions.numberTemplate(Double.class, "{0} - {1}", latitude, latDelta);
+        NumberExpression<Double> maxLat = Expressions.numberTemplate(Double.class, "{0} + {1}", latitude, latDelta);
+
+        NumberExpression<Double> minLng = Expressions.numberTemplate(Double.class, "{0} - {1}", longitude, lngDelta);
+        NumberExpression<Double> maxLng = Expressions.numberTemplate(Double.class, "{0} + {1}", longitude, lngDelta);
+
+
+//        // 원형으로 distance기준으로 조회될 수 있도록 정밀 거리필터 추가
+//        NumberExpression<Double> haversineDistance = Expressions.numberTemplate(
+//                Double.class,
+//                "6371 * acos(cos(radians({0})) * cos(radians({1})) * cos(radians({2}) - radians({3})) + sin(radians({0})) * sin(radians({1})))",
+//                Expressions.constant(latitude),              // 사용자 기준 위도
+//                place.lat,                                   // 대상 place의 위도
+//                place.lng,                                   // 대상 place의 경도
+//                Expressions.constant(longitude)              // 사용자 기준 경도
+//        );
+
+        return jpaQueryFactory
+                .select(place)
+                .from(place)
+                .where(
+                        place.lat.between(minLat, maxLat), // 계산된 경도 범위
+                        place.lng.between(minLng, maxLng) // 계산된 위도 범위
+//                        haversineDistance.loe(distanceKm)
+                ).fetch();
+    }
+}

--- a/src/main/java/com/even/zaro/service/MapService.java
+++ b/src/main/java/com/even/zaro/service/MapService.java
@@ -1,12 +1,13 @@
 package com.even.zaro.service;
 
 import com.even.zaro.dto.map.MarkerInfoResponse;
+import com.even.zaro.dto.map.PlaceResponse;
 import com.even.zaro.entity.Favorite;
 import com.even.zaro.entity.Place;
-import com.even.zaro.entity.User;
 import com.even.zaro.global.ErrorCode;
 import com.even.zaro.global.exception.place.PlaceException;
 import com.even.zaro.repository.FavoriteRepository;
+import com.even.zaro.repository.MapQueryRepository;
 import com.even.zaro.repository.PlaceRepository;
 import com.even.zaro.repository.UserRepository;
 import lombok.AllArgsConstructor;
@@ -14,8 +15,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.IntStream;
 
 @Service
 @Slf4j
@@ -24,7 +25,7 @@ import java.util.stream.IntStream;
 public class MapService {
     private final PlaceRepository placeRepository;
     private final FavoriteRepository favoriteRepository;
-    private final UserRepository userRepository;
+    private MapQueryRepository mapQueryRepository;
 
     public MarkerInfoResponse getPlaceInfo(long placeId) {
 
@@ -57,5 +58,34 @@ public class MapService {
 
 
         return markerInfo;
+    }
+
+    public PlaceResponse getPlacesByCoordinate(double lat, double lng, double distanceKm) {
+
+        List<Place> placeByCoordinate = mapQueryRepository.findPlaceByCoordinate(lat, lng, distanceKm);
+
+        // 조회된 장소가 없을 때
+        if (placeByCoordinate.isEmpty()) {
+            throw new PlaceException(ErrorCode.BY_COORDINATE_NOT_FOUND_PLACE_LIST);
+        }
+
+        List<PlaceResponse.PlaceInfo> placeInfos =  placeByCoordinate.stream()
+                .map(place -> PlaceResponse.PlaceInfo.builder()
+                        .place_id(place.getId())
+                        .name(place.getName())
+                        .address(place.getAddress())
+                        .lat(place.getLat())
+                        .lng(place.getLng())
+                        .build()
+                ).toList();
+
+        int totalCount = placeByCoordinate.size();
+
+        PlaceResponse placeResponse = PlaceResponse.builder()
+                .totalCount(totalCount)
+                .placeInfos(placeInfos)
+                .build();
+
+        return placeResponse;
     }
 }


### PR DESCRIPTION
## 📌 작업 개요
- 좌표기반 인근 장소 조회 API 구현

---

## ✨ 주요 변경 사항
- 에러 코드 추가 : BY_COORDINATE_NOT_FOUND_PLACE_LIST (조회된 장소가 없을 때)
- QueryDsl 설정 파일 추가
- 위도, 경도, 거리를 입력 받아 인근 장소리스트를 조회하는 API 구현
- PlaceResponse DTO 생성

---

## 🖼️ 기능 살펴 보기
> ![image](https://github.com/user-attachments/assets/736cf444-b509-423f-b346-9d302818d14f)
- 예제 Place 테이블 데이터 세팅 

> ![image](https://github.com/user-attachments/assets/3f945030-e056-4203-87f0-f83885035537)

- 서울역 좌표(37.554722, 126.970833) 기준으로 1Km 내 장소 조회 결과 (2개 조회)
- 조회된 장소의 개수와 장소 리스트들이 응답 ( totalCount는 이번에 추가했습니다 액셀 반영완료)

> ![스크린샷 2025-05-22 오후 4 49 36](https://github.com/user-attachments/assets/73185007-9b4d-46cf-b2ea-8c241b78869c)
- 서울역 좌표(37.554722, 126.970833) 기준으로 2Km 내 장소 조회 결과 (8개 조회)

> ![image](https://github.com/user-attachments/assets/38b8b775-2281-4aaf-95ae-76b458496e2c)
- 아예 떨어져있는 의정부의 좌표(37.738569, 127.045147) 기준으로 1km 조회 시 

![image](https://github.com/user-attachments/assets/055f4789-4fb9-40a2-a43c-9da8819404fa)
- 위와 같이 예외 코드가 발생하며 에러 메시지 출력하도록 작성

---

## ✅ 작업 체크리스트
- [x] API 테스트 완료 (POSTMAN)
- [x] 스웨거 ui 관련 코드 추가
- [x] 기능별 예외 케이스 고려
- [ ] log.info / 불필요한 주석 제거
- [x] 변수명, 클래스명, 메서드명 의미있게 작성
- [ ] 반복 코드 메서드로 분리

---

## 📂 테스트 방법
- [ ] 테스트 코드 작성
- [ ] 시나리오 기반 테스트 유무
    - ex: ID 중복 시 예외 처리 발생

---

## 💬 기타 참고 사항
- MapQueryRepository에 보면 크게 주석이 되어있는 부분이 있는데 원형 반경 기준인지 사각형 반경 기준인지 
정해지지 않아 주석처리해놓고 나중에 필요하면 주석 제거 후 사용하려고 해놨습니다.

---

## 📎 관련 이슈 / 문서

