### PR TITLE
Feat/comment ud 댓글 수정 및 삭제 API 

### DIFF
--- a/src/main/java/com/even/zaro/controller/CommentController.java
+++ b/src/main/java/com/even/zaro/controller/CommentController.java
@@ -61,4 +61,16 @@ public class CommentController {
         CommentResponseDto responseDto = commentService.updateComment(commentId, requestDto, userInfoDto);
         return ResponseEntity.ok(ApiResponse.success("댓글을 수정했습니다.", responseDto));
     }
+
+    @Operation(summary = "댓글 삭제", description = "{commentId}에 해당하는 댓글을 삭제합니다.",
+            security = {@SecurityRequirement(name = "bearer-key")})
+    @DeleteMapping("comments/{commentId}")
+    public ResponseEntity<ApiResponse<Void>> softDeleteComment(
+            @Parameter(description = "댓글 ID", example = "1") @PathVariable Long commentId,
+            @AuthenticationPrincipal JwtUserInfoDto userInfoDto) {
+        commentService.softDeleteComment(commentId, userInfoDto);
+        return ResponseEntity.ok(ApiResponse.success("댓글을 삭제했습니다."));
+    }
+
+
 }

--- a/src/main/java/com/even/zaro/controller/CommentController.java
+++ b/src/main/java/com/even/zaro/controller/CommentController.java
@@ -1,5 +1,6 @@
 package com.even.zaro.controller;
 
+import com.even.zaro.dto.PageResponse;
 import com.even.zaro.dto.comment.CommentRequestDto;
 import com.even.zaro.dto.comment.CommentResponseDto;
 import com.even.zaro.dto.jwt.JwtUserInfoDto;
@@ -38,12 +39,12 @@ public class CommentController {
     }
 
     @GetMapping("/posts/{postId}/comments")
-    public ResponseEntity<ApiResponse<Page<CommentResponseDto>>> readAllComments(
+    public ResponseEntity<ApiResponse<PageResponse<CommentResponseDto>>> readAllComments(
             @PathVariable Long postId,
             @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.ASC) Pageable pageable,
             @AuthenticationPrincipal JwtUserInfoDto userInfoDto
     ) {
-        Page<CommentResponseDto> responseDto = commentService.readAllComments(postId, pageable, userInfoDto);
+        PageResponse<CommentResponseDto> responseDto = commentService.readAllComments(postId, pageable, userInfoDto);
         return ResponseEntity.ok(ApiResponse.success("댓글 리스트를 불러왔습니다.", responseDto));
     }
 }

--- a/src/main/java/com/even/zaro/controller/CommentController.java
+++ b/src/main/java/com/even/zaro/controller/CommentController.java
@@ -50,4 +50,14 @@ public class CommentController {
         PageResponse<CommentResponseDto> responseDto = commentService.readAllComments(postId, pageable, userInfoDto);
         return ResponseEntity.ok(ApiResponse.success("댓글 리스트를 불러왔습니다.", responseDto));
     }
+
+    @PatchMapping("comments/{commentId}")
+    public ResponseEntity<ApiResponse<CommentResponseDto>> updateComment(
+            @PathVariable Long commentId,
+            @RequestBody CommentRequestDto requestDto,
+            @AuthenticationPrincipal JwtUserInfoDto userInfoDto
+    ) {
+        CommentResponseDto responseDto = commentService.updateComment(commentId, requestDto, userInfoDto);
+        return ResponseEntity.ok(ApiResponse.success("댓글을 수정했습니다.", responseDto));
+    }
 }

--- a/src/main/java/com/even/zaro/controller/CommentController.java
+++ b/src/main/java/com/even/zaro/controller/CommentController.java
@@ -11,6 +11,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -38,10 +39,12 @@ public class CommentController {
         return ResponseEntity.ok(ApiResponse.success("댓글을 작성했습니다.", responseDto));
     }
 
+    @Operation(summary = "댓글 리스트 조회", description = "{postId} 게시글에 댓글 리스트를 조회합니다.",
+            security = {@SecurityRequirement(name = "bearer-key")})
     @GetMapping("/posts/{postId}/comments")
     public ResponseEntity<ApiResponse<PageResponse<CommentResponseDto>>> readAllComments(
-            @PathVariable Long postId,
-            @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.ASC) Pageable pageable,
+            @Parameter(description = "게시글 ID", example = "1") @PathVariable Long postId,
+            @ParameterObject @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.ASC) Pageable pageable,
             @AuthenticationPrincipal JwtUserInfoDto userInfoDto
     ) {
         PageResponse<CommentResponseDto> responseDto = commentService.readAllComments(postId, pageable, userInfoDto);

--- a/src/main/java/com/even/zaro/controller/CommentController.java
+++ b/src/main/java/com/even/zaro/controller/CommentController.java
@@ -10,6 +10,10 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -31,5 +35,15 @@ public class CommentController {
             @AuthenticationPrincipal JwtUserInfoDto userInfoDto) {
         CommentResponseDto responseDto = commentService.createComment(postId, requestDto, userInfoDto);
         return ResponseEntity.ok(ApiResponse.success("댓글을 작성했습니다.", responseDto));
+    }
+
+    @GetMapping("/posts/{postId}/comments")
+    public ResponseEntity<ApiResponse<Page<CommentResponseDto>>> readAllComments(
+            @PathVariable Long postId,
+            @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.ASC) Pageable pageable,
+            @AuthenticationPrincipal JwtUserInfoDto userInfoDto
+    ) {
+        Page<CommentResponseDto> responseDto = commentService.readAllComments(postId, pageable, userInfoDto);
+        return ResponseEntity.ok(ApiResponse.success("댓글 리스트를 불러왔습니다.", responseDto));
     }
 }

--- a/src/main/java/com/even/zaro/controller/CommentController.java
+++ b/src/main/java/com/even/zaro/controller/CommentController.java
@@ -12,7 +12,6 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springdoc.core.annotations.ParameterObject;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
@@ -51,9 +50,11 @@ public class CommentController {
         return ResponseEntity.ok(ApiResponse.success("댓글 리스트를 불러왔습니다.", responseDto));
     }
 
+    @Operation(summary = "댓글 수정", description = "{commentId}에 해당하는 댓글 내용을 수정합니다.",
+            security = {@SecurityRequirement(name = "bearer-key")})
     @PatchMapping("comments/{commentId}")
     public ResponseEntity<ApiResponse<CommentResponseDto>> updateComment(
-            @PathVariable Long commentId,
+            @Parameter(description = "댓글 ID", example = "1") @PathVariable Long commentId,
             @RequestBody CommentRequestDto requestDto,
             @AuthenticationPrincipal JwtUserInfoDto userInfoDto
     ) {

--- a/src/main/java/com/even/zaro/dto/PageResponse.java
+++ b/src/main/java/com/even/zaro/dto/PageResponse.java
@@ -1,0 +1,29 @@
+package com.even.zaro.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+@Getter
+public class PageResponse<T> {
+
+    private final List<T> content;
+
+    private final int totalPages;
+
+    private final int number;
+
+    public PageResponse(List<T> content, int totalPages, int number) {
+        this.content = content;
+        this.totalPages = totalPages;
+        this.number = number;
+    }
+
+    public PageResponse(Page<T> page) {
+        this.content = page.getContent();
+        this.totalPages = page.getTotalPages();
+        this.number = page.getNumber();
+    }
+}

--- a/src/main/java/com/even/zaro/dto/PageResponse.java
+++ b/src/main/java/com/even/zaro/dto/PageResponse.java
@@ -1,5 +1,7 @@
 package com.even.zaro.dto;
 
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.springframework.data.domain.Page;
@@ -7,12 +9,16 @@ import org.springframework.data.domain.Page;
 import java.util.List;
 
 @Getter
+@Schema(description = "공통 페이징 응답 포맷")
 public class PageResponse<T> {
 
+    @ArraySchema(schema = @Schema(description = "데이터 목록"))
     private final List<T> content;
 
+    @Schema(description = "전체 페이지 수", example = "5")
     private final int totalPages;
 
+    @Schema(description = "현재 페이지 번호 (0부터 시작)", example = "0")
     private final int number;
 
     public PageResponse(List<T> content, int totalPages, int number) {

--- a/src/main/java/com/even/zaro/dto/comment/CommentRequestDto.java
+++ b/src/main/java/com/even/zaro/dto/comment/CommentRequestDto.java
@@ -8,6 +8,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class CommentRequestDto {
 
-    @Schema(description = "댓글 내용", example = "너무 좋네요!!")
+    @Schema(description = "댓글 내용/수정 내용", example = "너무 좋네요!!")
     private String content;
 }

--- a/src/main/java/com/even/zaro/dto/comment/CommentResponseDto.java
+++ b/src/main/java/com/even/zaro/dto/comment/CommentResponseDto.java
@@ -32,6 +32,13 @@ public class CommentResponseDto {
     @Schema(description = "댓글 작성 시간", example = "2025-05-21T14:33:00")
     private LocalDateTime createdAt;
 
+    @Schema(description = "댓글 수정 시간", example = "2025-05-22T08:15:12")
+    private LocalDateTime updatedAt;
+
+    @Schema(description = "수정 여부", example = "true")
+    @JsonProperty("isEdited")
+    private boolean isEdited;
+
     @Schema(description = "댓글 작성자 여부", example = "true")
     @JsonProperty("isMine")
     private boolean isMine;
@@ -39,5 +46,10 @@ public class CommentResponseDto {
     @JsonIgnore
     public boolean getMine() {
         return isMine;
+    }
+
+    @JsonIgnore
+    public boolean getEdited() {
+        return isEdited;
     }
 }

--- a/src/main/java/com/even/zaro/dto/comment/CommentResponseDto.java
+++ b/src/main/java/com/even/zaro/dto/comment/CommentResponseDto.java
@@ -1,5 +1,7 @@
 package com.even.zaro.dto.comment;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -31,5 +33,11 @@ public class CommentResponseDto {
     private LocalDateTime createdAt;
 
     @Schema(description = "댓글 작성자 여부", example = "true")
+    @JsonProperty("isMine")
     private boolean isMine;
+
+    @JsonIgnore
+    public boolean getMine() {
+        return isMine;
+    }
 }

--- a/src/main/java/com/even/zaro/dto/comment/CommentResponseDto.java
+++ b/src/main/java/com/even/zaro/dto/comment/CommentResponseDto.java
@@ -29,4 +29,7 @@ public class CommentResponseDto {
 
     @Schema(description = "댓글 작성 시간", example = "2025-05-21T14:33:00")
     private LocalDateTime createdAt;
+
+    @Schema(description = "댓글 작성자 여부", example = "true")
+    private boolean isMine;
 }

--- a/src/main/java/com/even/zaro/entity/Comment.java
+++ b/src/main/java/com/even/zaro/entity/Comment.java
@@ -59,4 +59,8 @@ public class Comment {
     public void updateContent(String content) {
         this.content = content;
     }
+
+    public void softDelete() {
+        this.isDeleted = true;
+    }
 }

--- a/src/main/java/com/even/zaro/entity/Comment.java
+++ b/src/main/java/com/even/zaro/entity/Comment.java
@@ -55,4 +55,8 @@ public class Comment {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "tagged_user_id")
     private User taggedUser;
+
+    public void updateContent(String content) {
+        this.content = content;
+    }
 }

--- a/src/main/java/com/even/zaro/global/ErrorCode.java
+++ b/src/main/java/com/even/zaro/global/ErrorCode.java
@@ -77,7 +77,10 @@ public enum ErrorCode {
     EMAIL_NOT_VERIFIED_LIKE(HttpStatus.FORBIDDEN, "이메일 인증이 완료되지 않아 좋아요 기능을 이용할 수 없습니다."),
 
     // 댓글 Comments
+    COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "댓글을 찾을 수 없습니다."),
     COMMENT_NO_ASSOCIATED_POST(HttpStatus.INTERNAL_SERVER_ERROR, "댓글에 연결된 게시글이 존재하지 않습니다."),
+    COMMENT_CONTENT_BLANK(HttpStatus.BAD_REQUEST, "댓글 내용을 입력하지 않았습니다."),
+    NOT_COMMENT_OWNER(HttpStatus.BAD_REQUEST, "댓글 작성자가 아닙니다."),
 
     // 프로필 Profile
     FOLLOW_SELF_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "자기 자신을 팔로우할 수 없습니다."),

--- a/src/main/java/com/even/zaro/repository/CommentRepository.java
+++ b/src/main/java/com/even/zaro/repository/CommentRepository.java
@@ -8,6 +8,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface CommentRepository extends JpaRepository<Comment, Long> {
 
@@ -15,4 +17,5 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
 
     Page<Comment> findByPostIdAndIsDeletedFalseOrderByCreatedAtAsc(Long postId, Pageable pageable);
 
+    Optional<Comment> findByIdAndIsDeletedFalse(Long commentId);
 }

--- a/src/main/java/com/even/zaro/repository/PostRepository.java
+++ b/src/main/java/com/even/zaro/repository/PostRepository.java
@@ -25,4 +25,6 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     Optional<Post> findByIdAndIsDeletedFalse(Long postId);
 
     List<Post> findTop5ByCategoryAndIsDeletedFalseOrderByCreatedAtDesc(Post.Category category);
+
+    boolean existsByIdAndIsDeletedFalse(Long postId);
 }

--- a/src/main/java/com/even/zaro/service/CommentService.java
+++ b/src/main/java/com/even/zaro/service/CommentService.java
@@ -13,6 +13,8 @@ import com.even.zaro.repository.CommentRepository;
 import com.even.zaro.repository.PostRepository;
 import com.even.zaro.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -44,7 +46,30 @@ public class CommentService {
                 user.getNickname(),
                 user.getProfileImage(),
                 user.getLiveAloneDate(),
-                comment.getCreatedAt()
+                comment.getCreatedAt(),
+                true
         );
+    }
+
+    @Transactional(readOnly = true)
+    public Page<CommentResponseDto> readAllComments(Long postId, Pageable pageable, JwtUserInfoDto userInfoDto) {
+        Long currentUserId = userInfoDto.getUserId();
+
+        return commentRepository.findByPostIdAndIsDeletedFalseOrderByCreatedAtAsc(postId, pageable)
+                .map(comment -> {
+                    User writer = comment.getUser();
+
+                    boolean isMine = writer.getId().equals(currentUserId);
+
+                    return new CommentResponseDto(
+                            comment.getId(),
+                            comment.getContent(),
+                            comment.getUser().getNickname(),
+                            comment.getUser().getProfileImage(),
+                            comment.getUser().getLiveAloneDate(),
+                            comment.getCreatedAt(),
+                            isMine
+                    );
+                });
     }
 }

--- a/src/main/java/com/even/zaro/service/CommentService.java
+++ b/src/main/java/com/even/zaro/service/CommentService.java
@@ -1,5 +1,6 @@
 package com.even.zaro.service;
 
+import com.even.zaro.dto.PageResponse;
 import com.even.zaro.dto.comment.CommentResponseDto;
 import com.even.zaro.dto.comment.CommentRequestDto;
 import com.even.zaro.dto.jwt.JwtUserInfoDto;
@@ -52,10 +53,10 @@ public class CommentService {
     }
 
     @Transactional(readOnly = true)
-    public Page<CommentResponseDto> readAllComments(Long postId, Pageable pageable, JwtUserInfoDto userInfoDto) {
+    public PageResponse<CommentResponseDto> readAllComments(Long postId, Pageable pageable, JwtUserInfoDto userInfoDto) {
         Long currentUserId = userInfoDto.getUserId();
 
-        return commentRepository.findByPostIdAndIsDeletedFalseOrderByCreatedAtAsc(postId, pageable)
+        Page<CommentResponseDto> page = commentRepository.findByPostIdAndIsDeletedFalseOrderByCreatedAtAsc(postId, pageable)
                 .map(comment -> {
                     User writer = comment.getUser();
 
@@ -71,5 +72,6 @@ public class CommentService {
                             isMine
                     );
                 });
+        return new PageResponse<>(page);
     }
 }

--- a/src/main/java/com/even/zaro/service/CommentService.java
+++ b/src/main/java/com/even/zaro/service/CommentService.java
@@ -30,6 +30,10 @@ public class CommentService {
 
     @Transactional
     public CommentResponseDto createComment(Long postId, CommentRequestDto requestDto, JwtUserInfoDto userInfoDto) {
+        if (requestDto.getContent() == null || requestDto.getContent().isBlank()) {
+            throw new CommentException(ErrorCode.COMMENT_CONTENT_BLANK);
+        }
+
         Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new PostException(ErrorCode.POST_NOT_FOUND));
         User user = userRepository.findById(userInfoDto.getUserId())

--- a/src/main/java/com/even/zaro/service/CommentService.java
+++ b/src/main/java/com/even/zaro/service/CommentService.java
@@ -85,6 +85,19 @@ public class CommentService {
         return toDto(comment, currentUserId);
     }
 
+    @Transactional
+    public void softDeleteComment(Long commentId, JwtUserInfoDto userInfoDto) {
+        Long currentUserId = userInfoDto.getUserId();
+        Comment comment = commentRepository.findByIdAndIsDeletedFalse(commentId)
+                .orElseThrow(() -> new CommentException(ErrorCode.COMMENT_NOT_FOUND));
+
+        if (!comment.getUser().getId().equals(currentUserId)) {
+            throw new CommentException(ErrorCode.NOT_COMMENT_OWNER);
+        }
+
+        comment.softDelete();
+    }
+
     // 공통 응답
     private CommentResponseDto toDto(Comment comment, Long currentUserId) {
         User writer = comment.getUser();

--- a/src/main/java/com/even/zaro/service/CommentService.java
+++ b/src/main/java/com/even/zaro/service/CommentService.java
@@ -20,6 +20,9 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+
 @Service
 @RequiredArgsConstructor
 public class CommentService {
@@ -30,13 +33,14 @@ public class CommentService {
 
     @Transactional
     public CommentResponseDto createComment(Long postId, CommentRequestDto requestDto, JwtUserInfoDto userInfoDto) {
+        Long currentUserId = userInfoDto.getUserId();
         if (requestDto.getContent() == null || requestDto.getContent().isBlank()) {
             throw new CommentException(ErrorCode.COMMENT_CONTENT_BLANK);
         }
 
         Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new PostException(ErrorCode.POST_NOT_FOUND));
-        User user = userRepository.findById(userInfoDto.getUserId())
+        User user = userRepository.findById(currentUserId)
                 .orElseThrow(() -> new UserException(ErrorCode.USER_NOT_FOUND));
         Comment comment = Comment.builder()
                 .post(post)
@@ -46,15 +50,7 @@ public class CommentService {
 
         commentRepository.save(comment);
 
-        return new CommentResponseDto(
-                comment.getId(),
-                comment.getContent(),
-                user.getNickname(),
-                user.getProfileImage(),
-                user.getLiveAloneDate(),
-                comment.getCreatedAt(),
-                true
-        );
+        return toDto(comment, currentUserId);
     }
 
     @Transactional(readOnly = true)
@@ -62,30 +58,18 @@ public class CommentService {
         Long currentUserId = userInfoDto.getUserId();
 
         // 게시글 존재 여부 확인
-        Post post = postRepository.findByIdAndIsDeletedFalse(postId)
-                .orElseThrow(() -> new PostException(ErrorCode.POST_NOT_FOUND));
+        if (!postRepository.existsByIdAndIsDeletedFalse(postId)) {
+            throw new PostException(ErrorCode.POST_NOT_FOUND);
+        }
 
         Page<CommentResponseDto> page = commentRepository.findByPostIdAndIsDeletedFalseOrderByCreatedAtAsc(postId, pageable)
-                .map(comment -> {
-                    User writer = comment.getUser();
-
-                    boolean isMine = writer.getId().equals(currentUserId);
-
-                    return new CommentResponseDto(
-                            comment.getId(),
-                            comment.getContent(),
-                            comment.getUser().getNickname(),
-                            comment.getUser().getProfileImage(),
-                            comment.getUser().getLiveAloneDate(),
-                            comment.getCreatedAt(),
-                            isMine
-                    );
-                });
+                .map(comment -> toDto(comment, currentUserId));
         return new PageResponse<>(page);
     }
 
     @Transactional
     public CommentResponseDto updateComment(Long commentId, CommentRequestDto requestDto, JwtUserInfoDto userInfoDto) {
+        Long currentUserId = userInfoDto.getUserId();
         if (requestDto.getContent() == null || requestDto.getContent().isBlank()) {
             throw new CommentException(ErrorCode.COMMENT_CONTENT_BLANK);
         }
@@ -93,18 +77,35 @@ public class CommentService {
         Comment comment = commentRepository.findByIdAndIsDeletedFalse(commentId)
                 .orElseThrow(() -> new CommentException(ErrorCode.COMMENT_NOT_FOUND));
 
-        if (!comment.getUser().getId().equals(userInfoDto.getUserId())) {
+        if (!comment.getUser().getId().equals(currentUserId)) {
             throw new CommentException(ErrorCode.NOT_COMMENT_OWNER);
         }
 
         comment.updateContent(requestDto.getContent());
+        return toDto(comment, currentUserId);
+    }
 
-        return new CommentResponseDto(comment.getId(),
+    // 공통 응답
+    private CommentResponseDto toDto(Comment comment, Long currentUserId) {
+        User writer = comment.getUser();
+
+        boolean isMine = writer.getId().equals(currentUserId);
+        LocalDateTime createdAt = comment.getCreatedAt();
+        LocalDateTime updatedAt = comment.getUpdatedAt();
+
+        boolean isEdited = !createdAt.truncatedTo(ChronoUnit.SECONDS)
+                .isEqual(updatedAt.truncatedTo(ChronoUnit.SECONDS));
+
+        return new CommentResponseDto(
+                comment.getId(),
                 comment.getContent(),
-                comment.getUser().getNickname(),
-                comment.getUser().getProfileImage(),
-                comment.getUser().getLiveAloneDate(),
-                comment.getCreatedAt(),
-                true);
+                writer.getNickname(),
+                writer.getProfileImage(),
+                writer.getLiveAloneDate(),
+                createdAt,
+                updatedAt,
+                isEdited,
+                isMine
+        );
     }
 }

--- a/src/main/java/com/even/zaro/service/CommentService.java
+++ b/src/main/java/com/even/zaro/service/CommentService.java
@@ -56,6 +56,10 @@ public class CommentService {
     public PageResponse<CommentResponseDto> readAllComments(Long postId, Pageable pageable, JwtUserInfoDto userInfoDto) {
         Long currentUserId = userInfoDto.getUserId();
 
+        // 게시글 존재 여부 확인
+        Post post = postRepository.findByIdAndIsDeletedFalse(postId)
+                .orElseThrow(() -> new PostException(ErrorCode.POST_NOT_FOUND));
+
         Page<CommentResponseDto> page = commentRepository.findByPostIdAndIsDeletedFalseOrderByCreatedAtAsc(postId, pageable)
                 .map(comment -> {
                     User writer = comment.getUser();


### PR DESCRIPTION
## 📌 작업 개요
- 댓글 수정 및 삭제 API 

---

## ✨ 주요 변경 사항
- 댓글 수정 및 삭제 API 
- 댓글 생성, 수정 시 댓글 내용 없음 예외처리 추가

---

## 🖼️ 기능 살펴 보기
> 포스트맨 요청 응답 스크린샷
- [x] API 문서(요청, 응답)와 일치하는지 확인 - 필요시 API 문서 수정 가능

댓글 수정
![image](https://github.com/user-attachments/assets/5427f599-e1c0-402f-8254-3cf2d39e297f)

댓글 작성자 아님 예외
![image](https://github.com/user-attachments/assets/006c26d6-95f9-4c61-807e-9bb81201bd57)


댓글 삭제
![image](https://github.com/user-attachments/assets/889aaaae-242e-476d-a615-a3a0f3ea65b1)

댓글 작성자 아님 예외
![image](https://github.com/user-attachments/assets/49fb668c-0ded-48a9-8388-5919175a040c)


댓글 내용 없음 예외
![image](https://github.com/user-attachments/assets/45c3be18-7f9d-470c-835f-c752ac14830b)


---

## ✅ 작업 체크리스트
- [x] API 테스트 완료 (POSTMAN)
- [x] 스웨거 ui 관련 코드 추가
- [x] 기능별 예외 케이스 고려
- [x] log.info / 불필요한 주석 제거
- [x] 변수명, 클래스명, 메서드명 의미있게 작성
- [x] 반복 코드 메서드로 분리

---

## 📂 테스트 방법
- [ ] 테스트 코드 작성
- [ ] 시나리오 기반 테스트 유무
    - ex: ID 중복 시 예외 처리 발생

---

## 💬 기타 참고 사항
- 브랜치 따는 거 깜빡해서.. 이전 pr과 같은 브랜치 입니다.  `add: 댓글 커스텀 에러코드 추가` 커밋부터 작업.
- 지금 생성, 수정, 리스트 응답 모두 같은 dto 사용하고 있는데 프론트에서 어떻게 작업하실지 몰라서 일단은 모든 응답을 동일하게 다 내렸습니다.
- 프론트에서 생성, 수정 후 리스트 다시 조회하지 않고 해당 댓글만 랜더링 하는 쪽으로 간다면 변경되는 것은 없습니다.
- 이후 생성, 수정 후 리스트를 다시 조회한다면 생성, 수정시 commentId만 내려주는 걸로 응답 축소할 예정입니다.

---

## 📎 관련 이슈 / 문서

