### PR TITLE
Feat/comment reply tag 답글 달기 기능 추가

### DIFF
--- a/src/main/java/com/even/zaro/controller/CommentController.java
+++ b/src/main/java/com/even/zaro/controller/CommentController.java
@@ -15,6 +15,7 @@ import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -27,7 +28,14 @@ public class CommentController {
 
     private final CommentService commentService;
 
-    @Operation(summary = "댓글 생성", description = "{postId} 게시글에 댓글을 작성합니다.",
+    @Operation(summary = "댓글 생성(또는 답글 멘션)",
+            description = """
+                {postId} 게시글에 댓글을 작성합니다.
+        
+                - 일반 댓글 또는 답글(멘션)을 작성할 수 있습니다.
+                - 답글의 경우, `taggedNickname` 필드에 멘션할 사용자의 닉네임을 포함해 주세요.
+                - 멘션을 지우거나 일반 댓글인 경우, `taggedNickname`을 null로 보내거나 생략해도 됩니다.
+                """,
             security = {@SecurityRequirement(name = "bearer-key")})
     @PostMapping("/posts/{postId}/comments")
     public ResponseEntity<ApiResponse<CommentResponseDto>> createComment(
@@ -35,7 +43,9 @@ public class CommentController {
             @RequestBody CommentRequestDto requestDto,
             @AuthenticationPrincipal JwtUserInfoDto userInfoDto) {
         CommentResponseDto responseDto = commentService.createComment(postId, requestDto, userInfoDto);
-        return ResponseEntity.ok(ApiResponse.success("댓글을 작성했습니다.", responseDto));
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(ApiResponse.success("댓글을 작성했습니다.", responseDto));
     }
 
     @Operation(summary = "댓글 리스트 조회", description = "{postId} 게시글에 댓글 리스트를 조회합니다.",

--- a/src/main/java/com/even/zaro/dto/comment/CommentRequestDto.java
+++ b/src/main/java/com/even/zaro/dto/comment/CommentRequestDto.java
@@ -10,4 +10,7 @@ public class CommentRequestDto {
 
     @Schema(description = "댓글 내용/수정 내용", example = "너무 좋네요!!")
     private String content;
+
+    @Schema(description = "멘션 대상 닉네임", example = "자취왕")
+    private String mentionedNickname;
 }

--- a/src/main/java/com/even/zaro/dto/comment/CommentResponseDto.java
+++ b/src/main/java/com/even/zaro/dto/comment/CommentResponseDto.java
@@ -43,6 +43,15 @@ public class CommentResponseDto {
     @JsonProperty("isMine")
     private boolean isMine;
 
+    @Schema(description = "멘션된 유저 정보", nullable = true,
+            example = """
+                {
+                  "id": 2,
+                  "nickname": "자취왕"
+                }
+                """)
+    private MentionedUserDto mentionedUser;
+
     @JsonIgnore
     public boolean getMine() {
         return isMine;

--- a/src/main/java/com/even/zaro/dto/comment/MentionedUserDto.java
+++ b/src/main/java/com/even/zaro/dto/comment/MentionedUserDto.java
@@ -1,0 +1,12 @@
+package com.even.zaro.dto.comment;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class MentionedUserDto {
+    private Long id;
+
+    private String nickname;
+}

--- a/src/main/java/com/even/zaro/entity/Comment.java
+++ b/src/main/java/com/even/zaro/entity/Comment.java
@@ -53,8 +53,8 @@ public class Comment {
     private int likeCount = 0;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "tagged_user_id")
-    private User taggedUser;
+    @JoinColumn(name = "mentioned_user_id")
+    private User mentionedUser;
 
     public void updateContent(String content) {
         this.content = content;

--- a/src/main/java/com/even/zaro/global/ErrorCode.java
+++ b/src/main/java/com/even/zaro/global/ErrorCode.java
@@ -81,6 +81,7 @@ public enum ErrorCode {
     COMMENT_NO_ASSOCIATED_POST(HttpStatus.INTERNAL_SERVER_ERROR, "댓글에 연결된 게시글이 존재하지 않습니다."),
     COMMENT_CONTENT_BLANK(HttpStatus.BAD_REQUEST, "댓글 내용을 입력하지 않았습니다."),
     NOT_COMMENT_OWNER(HttpStatus.BAD_REQUEST, "댓글 작성자가 아닙니다."),
+    MENTIONED_USER_NOT_FOUND(HttpStatus.NOT_FOUND, "멘션한 사용자를 찾을 수 없습니다."),
 
     // 프로필 Profile
     FOLLOW_SELF_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "자기 자신을 팔로우할 수 없습니다."),

--- a/src/main/java/com/even/zaro/repository/UserRepository.java
+++ b/src/main/java/com/even/zaro/repository/UserRepository.java
@@ -14,4 +14,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByProviderAndProviderId(Provider provider, String providerId);
 
     boolean existsByNickname(String nickname);
+
+    Optional<User> findByNickname(String nickname);
 }

--- a/src/main/java/com/even/zaro/service/CommentService.java
+++ b/src/main/java/com/even/zaro/service/CommentService.java
@@ -109,6 +109,13 @@ public class CommentService {
         boolean isEdited = !createdAt.truncatedTo(ChronoUnit.SECONDS)
                 .isEqual(updatedAt.truncatedTo(ChronoUnit.SECONDS));
 
+
+        User mentioned = comment.getMentionedUser();
+        MentionedUserDto mentionedUser = null;
+        if (mentioned != null) {
+            mentionedUser = new MentionedUserDto(mentioned.getId(), mentioned.getNickname());
+        }
+
         return new CommentResponseDto(
                 comment.getId(),
                 comment.getContent(),
@@ -118,7 +125,8 @@ public class CommentService {
                 createdAt,
                 updatedAt,
                 isEdited,
-                isMine
+                isMine,
+                mentionedUser
         );
     }
 }

--- a/src/main/java/com/even/zaro/service/CommentService.java
+++ b/src/main/java/com/even/zaro/service/CommentService.java
@@ -3,6 +3,7 @@ package com.even.zaro.service;
 import com.even.zaro.dto.PageResponse;
 import com.even.zaro.dto.comment.CommentResponseDto;
 import com.even.zaro.dto.comment.CommentRequestDto;
+import com.even.zaro.dto.comment.MentionedUserDto;
 import com.even.zaro.dto.jwt.JwtUserInfoDto;
 import com.even.zaro.entity.Comment;
 import com.even.zaro.entity.Post;
@@ -42,10 +43,19 @@ public class CommentService {
                 .orElseThrow(() -> new PostException(ErrorCode.POST_NOT_FOUND));
         User user = userRepository.findById(currentUserId)
                 .orElseThrow(() -> new UserException(ErrorCode.USER_NOT_FOUND));
+
+        User mentionedUser = null;
+        String mentionedNickname = requestDto.getMentionedNickname();
+        if (mentionedNickname != null && !mentionedNickname.isBlank()) {
+            mentionedUser = userRepository.findByNickname(mentionedNickname)
+                    .orElseThrow(() -> new CommentException(ErrorCode.MENTIONED_USER_NOT_FOUND));
+        }
+
         Comment comment = Comment.builder()
                 .post(post)
                 .user(user)
                 .content(requestDto.getContent())
+                .mentionedUser(mentionedUser)
                 .build();
 
         commentRepository.save(comment);


### PR DESCRIPTION
## 📌 작업 개요
- 댓글 생성 API 수정(답글 달기 기능 추가)

---

## ✨ 주요 변경 사항
- 댓글 생성 API 수정(답글 달기 기능 추가)
    - 댓글 엔티티 taggedUser -> mentionedUser 수정 (서버 반영 후 db column 삭제 하겠습니다.)
    - 일반 댓글 및 답글 api 엔드포인트 동일합니다. body에 mentionedNickname 유무로 구분
    - 일반 댓글의 경우 mentionedNickname 값이 null, "", 아예 필드 없음 다 가능합니다. 전부 null로 들어감.


---

## 🖼️ 기능 살펴 보기
> 포스트맨 요청 응답 스크린샷
- [x] API 문서(요청, 응답)와 일치하는지 확인 - 필요시 API 문서 수정 가능

|답글일 경우 | 일반 댓글의 경우(답글이 아님) | 
|-----------|-----------|
|![image](https://github.com/user-attachments/assets/81ef0a10-f959-4062-afcc-06660f60807e)|![image](https://github.com/user-attachments/assets/b1ae8b47-6fba-43f2-9472-e9010090f2c6)|

리스트 조회시 mentionedUser 추가
![image](https://github.com/user-attachments/assets/abaf72ea-3dec-44f6-96be-6b14d6819d90)



---

## ✅ 작업 체크리스트
- [x] API 테스트 완료 (POSTMAN)
- [x] 스웨거 ui 관련 코드 추가
- [x] 기능별 예외 케이스 고려
    - 멘션한 사용자 없음 예외 
- [x] log.info / 불필요한 주석 제거
- [x] 변수명, 클래스명, 메서드명 의미있게 작성
- [x] 반복 코드 메서드로 분리

---

## 📂 테스트 방법
- [ ] 테스트 코드 작성
- [ ] 시나리오 기반 테스트 유무
    - ex: ID 중복 시 예외 처리 발생

---

## 💬 기타 참고 사항
- 

---

## 📎 관련 이슈 / 문서
- 관련 이슈 번호: `close #123`
- 기획서, 디자인, API 문서 등 첨부
