### PR TITLE
Ref/favorite 즐겨찾기 API 리팩토링 

### DIFF
--- a/src/main/java/com/even/zaro/controller/FavoriteController.java
+++ b/src/main/java/com/even/zaro/controller/FavoriteController.java
@@ -38,10 +38,11 @@ public class FavoriteController {
     }
 
 
-    @Operation(summary = "그룹의 즐겨찾기 리스트 조회", description = "해당 그룹의 즐겨찾기 리스트를 조회합니다.")
+    @Operation(summary = "그룹의 즐겨찾기 조회", description = "그룹의 즐겨찾기 리스트를 조회합니다.", security = {@SecurityRequirement(name = "bearer-key")})
     @GetMapping("/{groupId}/items")
     public ResponseEntity<ApiResponse<List<FavoriteResponse>>> getGroupItems(
-            @PathVariable("groupId") long groupId) {
+            @PathVariable("groupId") long groupId,
+            @AuthenticationPrincipal JwtUserInfoDto userInfoDto) {
         List<FavoriteResponse> groupItems = favoriteService.getGroupItems(groupId);
 
         return ResponseEntity.ok(ApiResponse.success("즐겨찾기 그룹의 장소 목록을 성공적으로 조회했습니다.", groupItems));

--- a/src/main/java/com/even/zaro/controller/FavoriteController.java
+++ b/src/main/java/com/even/zaro/controller/FavoriteController.java
@@ -7,7 +7,6 @@ import com.even.zaro.dto.favorite.FavoriteResponse;
 import com.even.zaro.dto.jwt.JwtUserInfoDto;
 import com.even.zaro.global.ApiResponse;
 import com.even.zaro.service.FavoriteService;
-import com.even.zaro.service.ProfileService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;

--- a/src/main/java/com/even/zaro/controller/FavoriteController.java
+++ b/src/main/java/com/even/zaro/controller/FavoriteController.java
@@ -48,7 +48,7 @@ public class FavoriteController {
     }
 
 
-    @Operation(summary = "즐겨찾기의 메모 수정", description = "해당 즐겨찾기의 메모를 수정합니다.", security = {@SecurityRequirement(name = "bearer-key")})
+    @Operation(summary = "즐겨찾기 메모 수정", description = "즐겨찾기의 메모를 수정합니다.", security = {@SecurityRequirement(name = "bearer-key")})
     @PatchMapping("/{favoriteId}")
     public ResponseEntity<ApiResponse<String>> editFavoriteMemo(
             @PathVariable("favoriteId") long favoriteId,
@@ -56,7 +56,7 @@ public class FavoriteController {
             @AuthenticationPrincipal JwtUserInfoDto userInfoDto) {
         favoriteService.editFavoriteMemo(favoriteId, request, userInfoDto.getUserId());
 
-        return ResponseEntity.ok(ApiResponse.success("즐겨찾기 메모가 성공적으로 수정되었습니다."));
+        return ResponseEntity.ok(ApiResponse.success("즐겨찾기 메모가 수정되었습니다."));
     }
 
     @Operation(summary = "즐겨찾기 삭제", description = "해당 즐겨찾기를 삭제합니다.", security = {@SecurityRequirement(name = "bearer-key")})

--- a/src/main/java/com/even/zaro/controller/FavoriteController.java
+++ b/src/main/java/com/even/zaro/controller/FavoriteController.java
@@ -59,7 +59,7 @@ public class FavoriteController {
         return ResponseEntity.ok(ApiResponse.success("즐겨찾기 메모가 수정되었습니다."));
     }
 
-    @Operation(summary = "즐겨찾기 삭제", description = "해당 즐겨찾기를 삭제합니다.", security = {@SecurityRequirement(name = "bearer-key")})
+    @Operation(summary = "즐겨찾기 삭제", description = "즐겨찾기를 삭제합니다.", security = {@SecurityRequirement(name = "bearer-key")})
     @DeleteMapping("/{favoriteId}")
     public ResponseEntity<ApiResponse<String>> deleteFavorite(
             @PathVariable("favoriteId") long favoriteId,

--- a/src/main/java/com/even/zaro/controller/FavoriteController.java
+++ b/src/main/java/com/even/zaro/controller/FavoriteController.java
@@ -27,14 +27,14 @@ import java.util.List;
 public class FavoriteController {
     private final FavoriteService favoriteService;
 
-    @Operation(summary = "즐겨찾기 추가", description = "그룹에 즐겨찾기를 추가합니다.", security = {@SecurityRequirement(name = "bearer-key")})
+    @Operation(summary = "그룹에 즐겨찾기 추가", description = "그룹에 즐겨찾기를 추가합니다.", security = {@SecurityRequirement(name = "bearer-key")})
     @PostMapping("/groups/{groupId}/favorites")
     public ResponseEntity<ApiResponse<FavoriteAddResponse>> addFavorite(@PathVariable("groupId") long groupId,
                                                                         @RequestBody FavoriteAddRequest request,
                                                                         @AuthenticationPrincipal JwtUserInfoDto userInfoDto) {
         FavoriteAddResponse favoriteAddResponse = favoriteService.addFavorite(groupId, request, userInfoDto.getUserId());
 
-        return ResponseEntity.ok(ApiResponse.success("즐겨찾기가 해당 그룹에 성공적으로 추가되었습니다.", favoriteAddResponse));
+        return ResponseEntity.ok(ApiResponse.success("그룹에 즐겨찾기가 추가되었습니다.", favoriteAddResponse));
     }
 
 

--- a/src/main/java/com/even/zaro/controller/GroupController.java
+++ b/src/main/java/com/even/zaro/controller/GroupController.java
@@ -38,7 +38,7 @@ public class GroupController {
     }
 
 
-    @Operation(summary = "나의 즐겨찾기 그룹 리스트 조회", description = "나의 즐겨찾기 그룹 리스트를 조회합니다.", security = {@SecurityRequirement(name = "bearer-key")})
+    @Operation(summary = "내 그룹 리스트 조회", description = "내 그룹 리스트를 조회합니다.", security = {@SecurityRequirement(name = "bearer-key")})
     @GetMapping
     public ResponseEntity<ApiResponse<List<GroupResponse>>> getMyFavoriteGroups(
             @AuthenticationPrincipal JwtUserInfoDto userInfoDto) {

--- a/src/main/java/com/even/zaro/controller/GroupController.java
+++ b/src/main/java/com/even/zaro/controller/GroupController.java
@@ -54,7 +54,7 @@ public class GroupController {
         long userId = userInfoDto.getUserId();
         groupService.createGroup(request, userId);
 
-        return ResponseEntity.ok(ApiResponse.success("성공적으로 즐겨찾기 그룹이 생성되었습니다."));
+        return ResponseEntity.ok(ApiResponse.success("성공적으로 그룹이 생성되었습니다."));
     }
 
     @Operation(summary = "즐겨찾기 그룹 삭제", description = "groupId로 즐겨찾기 그룹 리스트를 삭제합니다.", security = {@SecurityRequirement(name = "bearer-key")})

--- a/src/main/java/com/even/zaro/controller/GroupController.java
+++ b/src/main/java/com/even/zaro/controller/GroupController.java
@@ -27,7 +27,7 @@ public class GroupController {
     private final GroupService groupService;
 
 
-    @Operation(summary = "다른 사용자의 그룹 리스트 조회", description = "사용자는 해당 유저의 프로필에서 그룹 목록을 조회할 수 있다", security = {@SecurityRequirement(name = "bearer-key")})
+    @Operation(summary = "다른 사용자의 그룹 리스트 조회", description = "사용자는 해당 유저의 프로필에서 그룹 목록을 조회할 수 있다")
     @GetMapping("/user/{userId}/group")
     public ResponseEntity<ApiResponse<List<GroupResponse>>> getFavoriteGroupsByUserId(
             @PathVariable("userId") long userId) {

--- a/src/main/java/com/even/zaro/controller/GroupController.java
+++ b/src/main/java/com/even/zaro/controller/GroupController.java
@@ -47,7 +47,7 @@ public class GroupController {
         return ResponseEntity.ok(ApiResponse.success("나의 즐겨찾기 그룹 리스트를 조회했습니다.", groupList));
     }
 
-    @Operation(summary = "즐겨찾기 그룹 추가", description = "그룹 이름을 입력받아 그룹을 추가합니다.", security = {@SecurityRequirement(name = "bearer-key")})
+    @Operation(summary = "그룹 추가", description = "그룹 이름을 입력받고 그룹을 생성합니다.", security = {@SecurityRequirement(name = "bearer-key")})
     @PostMapping
     public ResponseEntity<ApiResponse<String>> createGroup(@RequestBody GroupCreateRequest request,
                                                            @AuthenticationPrincipal JwtUserInfoDto userInfoDto) {

--- a/src/main/java/com/even/zaro/controller/GroupController.java
+++ b/src/main/java/com/even/zaro/controller/GroupController.java
@@ -30,8 +30,7 @@ public class GroupController {
     @Operation(summary = "다른 사용자의 그룹 리스트 조회", description = "사용자는 해당 유저의 프로필에서 그룹 목록을 조회할 수 있다", security = {@SecurityRequirement(name = "bearer-key")})
     @GetMapping("/user/{userId}/group")
     public ResponseEntity<ApiResponse<List<GroupResponse>>> getFavoriteGroupsByUserId(
-            @PathVariable("userId") long userId,
-            @AuthenticationPrincipal JwtUserInfoDto userInfoDto) {
+            @PathVariable("userId") long userId) {
         List<GroupResponse> groupList = groupService.getFavoriteGroups(userId);
 
         return ResponseEntity.ok(ApiResponse.success("해당 유저의 즐겨찾기 그룹 리스트를 조회했습니다.", groupList));

--- a/src/main/java/com/even/zaro/controller/GroupController.java
+++ b/src/main/java/com/even/zaro/controller/GroupController.java
@@ -27,7 +27,7 @@ public class GroupController {
     private final GroupService groupService;
 
 
-    @Operation(summary = "사용자의 그룹 리스트 조회", description = "해당 유저의 그룹 리스트를 조회합니다.")
+    @Operation(summary = "다른 사용자의 그룹 리스트 조회", description = "사용자는 해당 유저의 프로필에서 그룹 목록을 조회할 수 있다")
     @GetMapping("/user/{userId}/group")
     public ResponseEntity<ApiResponse<List<GroupResponse>>> getFavoriteGroupsByUserId(
             @PathVariable("userId") long userId) {

--- a/src/main/java/com/even/zaro/controller/GroupController.java
+++ b/src/main/java/com/even/zaro/controller/GroupController.java
@@ -66,7 +66,7 @@ public class GroupController {
         return ResponseEntity.ok(ApiResponse.success("성공적으로 그룹을 삭제했습니다."));
     }
 
-    @Operation(summary = "즐겨찾기 그룹 수정", description = "그룹 이름을 수정합니다.", security = {@SecurityRequirement(name = "bearer-key")})
+    @Operation(summary = "그룹 수정", description = "그룹 이름을 수정합니다.", security = {@SecurityRequirement(name = "bearer-key")})
     @PatchMapping("/{groupId}")
     public ResponseEntity<ApiResponse<String>> editGroup(@PathVariable("groupId") long groupId,
                                                          @RequestBody GroupEditRequest request,

--- a/src/main/java/com/even/zaro/controller/GroupController.java
+++ b/src/main/java/com/even/zaro/controller/GroupController.java
@@ -1,9 +1,9 @@
 package com.even.zaro.controller;
 
-import com.even.zaro.dto.jwt.JwtUserInfoDto;
 import com.even.zaro.dto.group.GroupCreateRequest;
 import com.even.zaro.dto.group.GroupEditRequest;
 import com.even.zaro.dto.group.GroupResponse;
+import com.even.zaro.dto.jwt.JwtUserInfoDto;
 import com.even.zaro.global.ApiResponse;
 import com.even.zaro.service.GroupService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -27,10 +27,11 @@ public class GroupController {
     private final GroupService groupService;
 
 
-    @Operation(summary = "다른 사용자의 그룹 리스트 조회", description = "사용자는 해당 유저의 프로필에서 그룹 목록을 조회할 수 있다")
+    @Operation(summary = "다른 사용자의 그룹 리스트 조회", description = "사용자는 해당 유저의 프로필에서 그룹 목록을 조회할 수 있다", security = {@SecurityRequirement(name = "bearer-key")})
     @GetMapping("/user/{userId}/group")
     public ResponseEntity<ApiResponse<List<GroupResponse>>> getFavoriteGroupsByUserId(
-            @PathVariable("userId") long userId) {
+            @PathVariable("userId") long userId,
+            @AuthenticationPrincipal JwtUserInfoDto userInfoDto) {
         List<GroupResponse> groupList = groupService.getFavoriteGroups(userId);
 
         return ResponseEntity.ok(ApiResponse.success("해당 유저의 즐겨찾기 그룹 리스트를 조회했습니다.", groupList));

--- a/src/main/java/com/even/zaro/controller/GroupController.java
+++ b/src/main/java/com/even/zaro/controller/GroupController.java
@@ -57,7 +57,7 @@ public class GroupController {
         return ResponseEntity.ok(ApiResponse.success("성공적으로 그룹이 생성되었습니다."));
     }
 
-    @Operation(summary = "즐겨찾기 그룹 삭제", description = "groupId로 즐겨찾기 그룹 리스트를 삭제합니다.", security = {@SecurityRequirement(name = "bearer-key")})
+    @Operation(summary = "그룹 삭제", description = "그룹을 삭제합니다.", security = {@SecurityRequirement(name = "bearer-key")})
     @DeleteMapping("/{groupId}")
     public ResponseEntity<ApiResponse<String>> deleteGroup(@PathVariable("groupId") long groupId,
                                                            @AuthenticationPrincipal JwtUserInfoDto userInfoDto) {

--- a/src/main/java/com/even/zaro/dto/group/GroupCreateRequest.java
+++ b/src/main/java/com/even/zaro/dto/group/GroupCreateRequest.java
@@ -9,5 +9,5 @@ import lombok.Getter;
 public class GroupCreateRequest {
     // Group 이름
     @Schema(description = "그룹 이름", example = "강릉 맛집!!")
-    private String name;
+    private String groupName;
 }

--- a/src/main/java/com/even/zaro/dto/group/GroupEditRequest.java
+++ b/src/main/java/com/even/zaro/dto/group/GroupEditRequest.java
@@ -9,5 +9,5 @@ import lombok.Getter;
 @Builder
 public class GroupEditRequest {
     @Schema(description = "그룹 이름", example = "부산 맛집!~")
-    private String name;
+    private String groupName;
 }

--- a/src/main/java/com/even/zaro/dto/group/GroupResponse.java
+++ b/src/main/java/com/even/zaro/dto/group/GroupResponse.java
@@ -4,6 +4,8 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.time.LocalDateTime;
+
 @Builder
 @Getter
 public class GroupResponse {
@@ -13,4 +15,13 @@ public class GroupResponse {
 
     @Schema(description = "그룹 이름", example = "부산 맛집!~")
     private String name;
+
+    @Schema(description = "삭제 여부", example = "true")
+    private boolean isDeleted;
+
+    @Schema(description = "생성 시각", example = "2025-03-03T08:20:00")
+    private LocalDateTime createdAt;
+
+    @Schema(description = "수정 시각", example = "2025-03-25T05:20:00")
+    private LocalDateTime updatedAt;
 }

--- a/src/main/java/com/even/zaro/dto/group/GroupResponse.java
+++ b/src/main/java/com/even/zaro/dto/group/GroupResponse.java
@@ -11,7 +11,7 @@ import java.time.LocalDateTime;
 public class GroupResponse {
 
     @Schema(description = "그룹 id", example = "1")
-    private long id;
+    private long groupId;
 
     @Schema(description = "그룹 이름", example = "부산 맛집!~")
     private String name;

--- a/src/main/java/com/even/zaro/global/ErrorCode.java
+++ b/src/main/java/com/even/zaro/global/ErrorCode.java
@@ -99,6 +99,7 @@ public enum ErrorCode {
     // 즐겨찾기 favorite
     FAVORITE_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 즐겨찾기에 존재하는 장소는 추가할 수 없습니다."),
     FAVORITE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 즐겨찾기를 찾지 못했습니다."),
+    FAVORITE_LIST_NOT_FOUND(HttpStatus.NOT_FOUND, "그룹에 즐겨찾기가 존재하지 않습니다."),
     UNAUTHORIZED_FAVORITE_UPDATE(HttpStatus.UNAUTHORIZED, "다른 사용자의 즐겨찾기 메모 수정 시도입니다."),
     UNAUTHORIZED_FAVORITE_DELETE(HttpStatus.UNAUTHORIZED, "다른 사용자의 즐겨찾기 삭제 시도입니다."),
 

--- a/src/main/java/com/even/zaro/global/ErrorCode.java
+++ b/src/main/java/com/even/zaro/global/ErrorCode.java
@@ -90,6 +90,7 @@ public enum ErrorCode {
 
     // 그룹 Group
     GROUP_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 그룹을 찾지 못했습니다."),
+    GROUP_LIST_NOT_FOUND(HttpStatus.NOT_FOUND, "그룹 리스트가 존재하지 않습니다"),
     GROUP_ALREADY_DELETE(HttpStatus.NOT_FOUND, "이미 삭제한 그룹입니다."),
     GROUP_ALREADY_EXIST(HttpStatus.NOT_FOUND, "이미 존재하는 그룹 이름입니다."),
     UNAUTHORIZED_GROUP_DELETE(HttpStatus.UNAUTHORIZED, "다른 사용자의 그룹 삭제 시도입니다."),

--- a/src/main/java/com/even/zaro/service/FavoriteService.java
+++ b/src/main/java/com/even/zaro/service/FavoriteService.java
@@ -82,6 +82,10 @@ public class FavoriteService {
 
         List<Favorite> favoriteList = favoriteRepository.findAllByGroup(group);
 
+        if (favoriteList.isEmpty()) {
+            throw new FavoriteException(ErrorCode.FAVORITE_LIST_NOT_FOUND);
+        }
+
         List<FavoriteResponse> favoriteResponseList = favoriteList.stream().map(favorite ->
                 FavoriteResponse.builder()
                         .id(favorite.getId())

--- a/src/main/java/com/even/zaro/service/FavoriteService.java
+++ b/src/main/java/com/even/zaro/service/FavoriteService.java
@@ -38,7 +38,7 @@ public class FavoriteService {
                 .orElseThrow(() -> new GroupException(ErrorCode.GROUP_NOT_FOUND));
 
         User user = userRepository.findById(userId)
-                .orElseThrow(() -> new UserException(ErrorCode.EXAMPLE_USER_NOT_FOUND));
+                .orElseThrow(() -> new UserException(ErrorCode.USER_NOT_FOUND));
 
         Place place = placeRepository.findById(request.getPlaceId())
                 .orElseThrow(() -> new MapException(ErrorCode.PLACE_NOT_FOUND));

--- a/src/main/java/com/even/zaro/service/GroupService.java
+++ b/src/main/java/com/even/zaro/service/GroupService.java
@@ -28,7 +28,7 @@ public class GroupService {
 
     public void createGroup(GroupCreateRequest request, long userid) {
 
-        User user = userRepository.findById(userid).orElseThrow(() -> new UserException(ErrorCode.EXAMPLE_USER_NOT_FOUND));
+        User user = userRepository.findById(userid).orElseThrow(() -> new UserException(ErrorCode.USER_NOT_FOUND));
 
         boolean dupCheck = groupNameDuplicateCheck(request.getGroupName(), userid);
 

--- a/src/main/java/com/even/zaro/service/GroupService.java
+++ b/src/main/java/com/even/zaro/service/GroupService.java
@@ -101,13 +101,13 @@ public class GroupService {
             throw new GroupException(ErrorCode.UNAUTHORIZED_GROUP_UPDATE);
         }
 
-        boolean dupCheck = groupNameDuplicateCheck(request.getName(), group.getUser().getId());
+        boolean dupCheck = groupNameDuplicateCheck(request.getGroupName(), group.getUser().getId());
 
         // 해당 유저가 이미 있는 즐겨찾기 그룹 이름을 입력했을 때
         if (dupCheck) {
             throw new GroupException(ErrorCode.GROUP_ALREADY_EXIST);
         }
-        group.setName(request.getName());
+        group.setName(request.getGroupName());
     }
 
 

--- a/src/main/java/com/even/zaro/service/GroupService.java
+++ b/src/main/java/com/even/zaro/service/GroupService.java
@@ -62,7 +62,7 @@ public class GroupService {
         // GroupResponse 리스트로 변환
         List<GroupResponse> responseList = groupList.stream().map(group ->
                         GroupResponse.builder()
-                                .id(group.getId())
+                                .groupId(group.getId())
                                 .name(group.getName())
                                 .isDeleted(group.isDeleted())
                                 .createdAt(group.getCreatedAt())

--- a/src/main/java/com/even/zaro/service/GroupService.java
+++ b/src/main/java/com/even/zaro/service/GroupService.java
@@ -49,13 +49,13 @@ public class GroupService {
     public List<GroupResponse> getFavoriteGroups(long userId) {
 
         User user = userRepository.findById(userId)
-                .orElseThrow(() -> new UserException(ErrorCode.EXAMPLE_USER_NOT_FOUND));
+                .orElseThrow(() -> new UserException(ErrorCode.USER_NOT_FOUND));
 
         // userId 값이 일치하는 데이터 조회
         List<FavoriteGroup> groupList = favoriteGroupRepository.findByUser(user);
 
         if (groupList.isEmpty()) {
-            throw new GroupException(ErrorCode.GROUP_NOT_FOUND);
+            throw new GroupException(ErrorCode.GROUP_LIST_NOT_FOUND);
         }
 
 
@@ -64,6 +64,9 @@ public class GroupService {
                         GroupResponse.builder()
                                 .id(group.getId())
                                 .name(group.getName())
+                                .isDeleted(group.isDeleted())
+                                .createdAt(group.getCreatedAt())
+                                .updatedAt(group.getUpdatedAt())
                                 .build())
                 .toList();
 

--- a/src/main/java/com/even/zaro/service/GroupService.java
+++ b/src/main/java/com/even/zaro/service/GroupService.java
@@ -30,7 +30,7 @@ public class GroupService {
 
         User user = userRepository.findById(userid).orElseThrow(() -> new UserException(ErrorCode.EXAMPLE_USER_NOT_FOUND));
 
-        boolean dupCheck = groupNameDuplicateCheck(request.getName(), userid);
+        boolean dupCheck = groupNameDuplicateCheck(request.getGroupName(), userid);
 
         // 해당 유저가 이미 있는 그룹 이름을 입력했을 때
         if (dupCheck) {
@@ -39,7 +39,7 @@ public class GroupService {
 
         FavoriteGroup favoriteGroup = FavoriteGroup.builder()
                 .user(user) // 유저 설정
-                .name(request.getName()) // Group 이름 설정
+                .name(request.getGroupName()) // Group 이름 설정
                 .build();
 
         favoriteGroupRepository.save(favoriteGroup);


### PR DESCRIPTION
## 📌 작업 개요
- 즐겨찾기 API 리팩토링 

---

## ✨ 주요 변경 사항
- 필요없는 주석 제거
- 예외 코드 추가
- 스웨거 액셀과 통일
- id, name 등 placeId, placeName 처럼 명확히 수정
- 토큰 인증 처리 로직 추가
---

## 🖼️ 기능 살펴 보기
- 정상 동작합니다.

---

## ✅ 작업 체크리스트
- [x] API 테스트 완료 (POSTMAN)
- [x] 스웨거 ui 관련 코드 추가
- [x] 기능별 예외 케이스 고려
- [x] log.info / 불필요한 주석 제거
- [x] 변수명, 클래스명, 메서드명 의미있게 작성
- [ ] 반복 코드 메서드로 분리

---

## 📂 테스트 방법
- [ ] 테스트 코드 작성
- [ ] 시나리오 기반 테스트 유무
- [x] Swagger UI 테스트

---

## 💬 기타 참고 사항
- 이전 PR에는 언급 안했는데 프론트에서 id 값을 받을 때 그냥 id 보다는 placeId 같이 무슨 데이터의 id인지 나타나면 
더 명확한 느낌이 있어서 리팩토링 진행시 참고만? 부탁드립니다~~~
- 즐겨찾기 추가 API 관련해서 미처 구현하지 못했던 부분이 있어서 이슈 새로 파놨습니다. #70 
이번 pr에는 반영 못할 것 같고, 추후 pr에 해당 이슈 태그하여 해결하도록 하겠습니다.


---

## 📎 관련 이슈 / 문서
- close #69 
- #70 
