### PR TITLE
Ref/favorite-add-place 즐겨찾기 추가 API 리팩토링

### DIFF
--- a/src/main/java/com/even/zaro/controller/FavoriteController.java
+++ b/src/main/java/com/even/zaro/controller/FavoriteController.java
@@ -38,10 +38,11 @@ public class FavoriteController {
     }
 
 
-    @Operation(summary = "그룹의 즐겨찾기 리스트 조회", description = "해당 그룹의 즐겨찾기 리스트를 조회합니다.")
+    @Operation(summary = "그룹의 즐겨찾기 조회", description = "그룹의 즐겨찾기 리스트를 조회합니다.", security = {@SecurityRequirement(name = "bearer-key")})
     @GetMapping("/{groupId}/items")
     public ResponseEntity<ApiResponse<List<FavoriteResponse>>> getGroupItems(
-            @PathVariable("groupId") long groupId) {
+            @PathVariable("groupId") long groupId,
+            @AuthenticationPrincipal JwtUserInfoDto userInfoDto) {
         List<FavoriteResponse> groupItems = favoriteService.getGroupItems(groupId);
 
         return ResponseEntity.ok(ApiResponse.success("즐겨찾기 그룹의 장소 목록을 성공적으로 조회했습니다.", groupItems));

--- a/src/main/java/com/even/zaro/controller/FavoriteController.java
+++ b/src/main/java/com/even/zaro/controller/FavoriteController.java
@@ -7,7 +7,6 @@ import com.even.zaro.dto.favorite.FavoriteResponse;
 import com.even.zaro.dto.jwt.JwtUserInfoDto;
 import com.even.zaro.global.ApiResponse;
 import com.even.zaro.service.FavoriteService;
-import com.even.zaro.service.ProfileService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;

--- a/src/main/java/com/even/zaro/controller/FavoriteController.java
+++ b/src/main/java/com/even/zaro/controller/FavoriteController.java
@@ -48,7 +48,7 @@ public class FavoriteController {
     }
 
 
-    @Operation(summary = "즐겨찾기의 메모 수정", description = "해당 즐겨찾기의 메모를 수정합니다.", security = {@SecurityRequirement(name = "bearer-key")})
+    @Operation(summary = "즐겨찾기 메모 수정", description = "즐겨찾기의 메모를 수정합니다.", security = {@SecurityRequirement(name = "bearer-key")})
     @PatchMapping("/{favoriteId}")
     public ResponseEntity<ApiResponse<String>> editFavoriteMemo(
             @PathVariable("favoriteId") long favoriteId,
@@ -56,7 +56,7 @@ public class FavoriteController {
             @AuthenticationPrincipal JwtUserInfoDto userInfoDto) {
         favoriteService.editFavoriteMemo(favoriteId, request, userInfoDto.getUserId());
 
-        return ResponseEntity.ok(ApiResponse.success("즐겨찾기 메모가 성공적으로 수정되었습니다."));
+        return ResponseEntity.ok(ApiResponse.success("즐겨찾기 메모가 수정되었습니다."));
     }
 
     @Operation(summary = "즐겨찾기 삭제", description = "해당 즐겨찾기를 삭제합니다.", security = {@SecurityRequirement(name = "bearer-key")})

--- a/src/main/java/com/even/zaro/controller/FavoriteController.java
+++ b/src/main/java/com/even/zaro/controller/FavoriteController.java
@@ -59,7 +59,7 @@ public class FavoriteController {
         return ResponseEntity.ok(ApiResponse.success("즐겨찾기 메모가 수정되었습니다."));
     }
 
-    @Operation(summary = "즐겨찾기 삭제", description = "해당 즐겨찾기를 삭제합니다.", security = {@SecurityRequirement(name = "bearer-key")})
+    @Operation(summary = "즐겨찾기 삭제", description = "즐겨찾기를 삭제합니다.", security = {@SecurityRequirement(name = "bearer-key")})
     @DeleteMapping("/{favoriteId}")
     public ResponseEntity<ApiResponse<String>> deleteFavorite(
             @PathVariable("favoriteId") long favoriteId,

--- a/src/main/java/com/even/zaro/controller/FavoriteController.java
+++ b/src/main/java/com/even/zaro/controller/FavoriteController.java
@@ -27,14 +27,14 @@ import java.util.List;
 public class FavoriteController {
     private final FavoriteService favoriteService;
 
-    @Operation(summary = "즐겨찾기 추가", description = "그룹에 즐겨찾기를 추가합니다.", security = {@SecurityRequirement(name = "bearer-key")})
+    @Operation(summary = "그룹에 즐겨찾기 추가", description = "그룹에 즐겨찾기를 추가합니다.", security = {@SecurityRequirement(name = "bearer-key")})
     @PostMapping("/groups/{groupId}/favorites")
     public ResponseEntity<ApiResponse<FavoriteAddResponse>> addFavorite(@PathVariable("groupId") long groupId,
                                                                         @RequestBody FavoriteAddRequest request,
                                                                         @AuthenticationPrincipal JwtUserInfoDto userInfoDto) {
         FavoriteAddResponse favoriteAddResponse = favoriteService.addFavorite(groupId, request, userInfoDto.getUserId());
 
-        return ResponseEntity.ok(ApiResponse.success("즐겨찾기가 해당 그룹에 성공적으로 추가되었습니다.", favoriteAddResponse));
+        return ResponseEntity.ok(ApiResponse.success("그룹에 즐겨찾기가 추가되었습니다.", favoriteAddResponse));
     }
 
 

--- a/src/main/java/com/even/zaro/controller/GroupController.java
+++ b/src/main/java/com/even/zaro/controller/GroupController.java
@@ -30,8 +30,7 @@ public class GroupController {
     @Operation(summary = "다른 사용자의 그룹 리스트 조회", description = "사용자는 해당 유저의 프로필에서 그룹 목록을 조회할 수 있다", security = {@SecurityRequirement(name = "bearer-key")})
     @GetMapping("/user/{userId}/group")
     public ResponseEntity<ApiResponse<List<GroupResponse>>> getFavoriteGroupsByUserId(
-            @PathVariable("userId") long userId,
-            @AuthenticationPrincipal JwtUserInfoDto userInfoDto) {
+            @PathVariable("userId") long userId) {
         List<GroupResponse> groupList = groupService.getFavoriteGroups(userId);
 
         return ResponseEntity.ok(ApiResponse.success("해당 유저의 즐겨찾기 그룹 리스트를 조회했습니다.", groupList));

--- a/src/main/java/com/even/zaro/dto/favorite/FavoriteAddRequest.java
+++ b/src/main/java/com/even/zaro/dto/favorite/FavoriteAddRequest.java
@@ -7,9 +7,22 @@ import lombok.Getter;
 @Getter
 @Builder
 public class FavoriteAddRequest {
-    @Schema(description = "장소 ID", example = "3")
-    private long placeId;
+
+    @Schema(description = "카카오지도 장소 Id", example = "314222")
+    private long kakaoPlaceId;
 
     @Schema(description = "메모", example = "친구랑 가보고 싶은 감성카페")
     private String memo;
+
+    @Schema(description = "장소 이름", example = "강남 삼겹살 집")
+    private String placeName;
+
+    @Schema(description = "주소", example = "강남의 삼겹살집 512")
+    private String address;
+
+    @Schema(description = "위도", example = "37.55123")
+    private double lat;
+
+    @Schema(description = "경도", example = "127.1234455")
+    private double lng;
 }

--- a/src/main/java/com/even/zaro/global/ErrorCode.java
+++ b/src/main/java/com/even/zaro/global/ErrorCode.java
@@ -99,6 +99,7 @@ public enum ErrorCode {
     // 즐겨찾기 favorite
     FAVORITE_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 즐겨찾기에 존재하는 장소는 추가할 수 없습니다."),
     FAVORITE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 즐겨찾기를 찾지 못했습니다."),
+    FAVORITE_LIST_NOT_FOUND(HttpStatus.NOT_FOUND, "그룹에 즐겨찾기가 존재하지 않습니다."),
     UNAUTHORIZED_FAVORITE_UPDATE(HttpStatus.UNAUTHORIZED, "다른 사용자의 즐겨찾기 메모 수정 시도입니다."),
     UNAUTHORIZED_FAVORITE_DELETE(HttpStatus.UNAUTHORIZED, "다른 사용자의 즐겨찾기 삭제 시도입니다."),
 

--- a/src/main/java/com/even/zaro/repository/PlaceRepository.java
+++ b/src/main/java/com/even/zaro/repository/PlaceRepository.java
@@ -4,4 +4,5 @@ import com.even.zaro.entity.Place;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PlaceRepository extends JpaRepository<Place, Long> {
+    Place findByKakaoPlaceId(long kakaoPlaceId);
 }

--- a/src/main/java/com/even/zaro/service/FavoriteService.java
+++ b/src/main/java/com/even/zaro/service/FavoriteService.java
@@ -82,6 +82,10 @@ public class FavoriteService {
 
         List<Favorite> favoriteList = favoriteRepository.findAllByGroup(group);
 
+        if (favoriteList.isEmpty()) {
+            throw new FavoriteException(ErrorCode.FAVORITE_LIST_NOT_FOUND);
+        }
+
         List<FavoriteResponse> favoriteResponseList = favoriteList.stream().map(favorite ->
                 FavoriteResponse.builder()
                         .id(favorite.getId())

--- a/src/main/java/com/even/zaro/service/FavoriteService.java
+++ b/src/main/java/com/even/zaro/service/FavoriteService.java
@@ -38,7 +38,7 @@ public class FavoriteService {
                 .orElseThrow(() -> new GroupException(ErrorCode.GROUP_NOT_FOUND));
 
         User user = userRepository.findById(userId)
-                .orElseThrow(() -> new UserException(ErrorCode.EXAMPLE_USER_NOT_FOUND));
+                .orElseThrow(() -> new UserException(ErrorCode.USER_NOT_FOUND));
 
         Place place = placeRepository.findById(request.getPlaceId())
                 .orElseThrow(() -> new MapException(ErrorCode.PLACE_NOT_FOUND));


### PR DESCRIPTION
## 📌 작업 개요
- 즐겨찾기 추가 API 에서 해당 장소가 DB에 등록이 안되어있을 때 새로 DB에 장소를 저장하는 로직 추가
- 이미 등록되어있다면 기존 장소를 즐겨찾기에 추가

---

## ✨ 주요 변경 사항
- 요청 객체 필드 추가 및 @Schema 추가 (장소를 저장하기 위해)

---

## 🖼️ 기능 살펴 보기
> ![image](https://github.com/user-attachments/assets/cf1857a1-6de0-4f48-b5a0-66050e19536c)
> ![image](https://github.com/user-attachments/assets/21a3ef60-d8cd-428d-a47a-d71dc869a07c)
- 이미  즐겨찾기가 추가되어있을 때 요청 및 응답

> ![image](https://github.com/user-attachments/assets/7ab7d463-09ec-455b-8eb6-8bf6fb9f1e26)
> ![image](https://github.com/user-attachments/assets/058f9cf6-396b-465d-b0de-90fa6eb83432)
- 즐겨찾기가 등록되어있지 않았을 때 요청 및 응답

-> API 테스트 문제 X

---

## ✅ 작업 체크리스트
- [x] API 테스트 완료 (POSTMAN)
- [x] 스웨거 ui 관련 코드 추가
- [x] 기능별 예외 케이스 고려
- [ ] log.info / 불필요한 주석 제거
- [x] 변수명, 클래스명, 메서드명 의미있게 작성
- [x] 반복 코드 메서드로 분리

---

## 📂 테스트 방법
- [ ] 테스트 코드 작성
- [ ] 시나리오 기반 테스트 유무
    - ex: ID 중복 시 예외 처리 발생

---

## 💬 기타 참고 사항
- 이미 추가한 즐겨찾기에 대해서는 다른 그룹에 추가 불가능하게 작성되어있습니다~
디스코드에서 얘기했다싶이 같은 장소에 대해서 한 유저가 여러 메모가 추가될 우려가 있기 때문!!
---

## 📎 관련 이슈 / 문서
- close #70 
