### PR TITLE
Hotfix/image url db 에러 해결

### DIFF
--- a/src/main/java/com/even/zaro/repository/PostRepository.java
+++ b/src/main/java/com/even/zaro/repository/PostRepository.java
@@ -21,7 +21,7 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 
     Page<Post> findByIsDeletedFalse(Pageable pageable);
 
-    @EntityGraph(attributePaths = {"postImages"})
+    @EntityGraph(attributePaths = {"postImageList"})
     Optional<Post> findByIdAndIsDeletedFalse(Long postId);
 
     List<Post> findTop5ByCategoryAndIsDeletedFalseOrderByCreatedAtDesc(Post.Category category);

--- a/src/main/java/com/even/zaro/repository/PostRepository.java
+++ b/src/main/java/com/even/zaro/repository/PostRepository.java
@@ -21,7 +21,7 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 
     Page<Post> findByIsDeletedFalse(Pageable pageable);
 
-    @EntityGraph(attributePaths = {"imageUrlList"})
+    @EntityGraph(attributePaths = {"postImages"})
     Optional<Post> findByIdAndIsDeletedFalse(Long postId);
 
     List<Post> findTop5ByCategoryAndIsDeletedFalseOrderByCreatedAtDesc(Post.Category category);

--- a/src/main/java/com/even/zaro/service/PostService.java
+++ b/src/main/java/com/even/zaro/service/PostService.java
@@ -233,9 +233,9 @@ public class PostService {
     }
 
 
-    private void validateImageRequirement(Post.Category category, List<String> imageUrls) {
+    private void validateImageRequirement(Post.Category category, List<String> postImages) {
         if (category == Post.Category.RANDOM_BUY &&
-                (imageUrls == null || imageUrls.isEmpty())) {
+                (postImages == null || postImages.isEmpty())) {
             throw new PostException(ErrorCode.IMAGE_REQUIRED_FOR_RANDOM_BUY);
         }
     }


### PR DESCRIPTION
## 📌 작업 개요
- 게시글 상세 페이지 조회할 때 500 오류 문제 해결

---

## ✨ 주요 변경 사항
- 게시글 상세 페이지 조회할 때 500 오류 문제 해결
     - 오류 : Unable to locate Attribute with the given name [imageUrlList] on this ManagedType [com.even.zaro.entity.Post]"
     - image url 부분 수정시 PostRespository에 @EntityGraph 부분 코드를 수정하지 않아 발생한 오류입니다. (Post + post_image 테이블을 join해서 한 번에 데이터 가져오는 코드)
- 위와 별개로 변수명 하나 수정했습니다~ 

---

## 🖼️ 기능 살펴 보기
> 포스트맨 요청 응답 스크린샷
- [x] API 문서(요청, 응답)와 일치하는지 확인 - 필요시 API 문서 수정 가능

---

## ✅ 작업 체크리스트
- [ ] API 테스트 완료 (POSTMAN)
- [ ] 스웨거 ui 관련 코드 추가
- [ ] 기능별 예외 케이스 고려
- [ ] log.info / 불필요한 주석 제거
- [ ] 변수명, 클래스명, 메서드명 의미있게 작성
- [ ] 반복 코드 메서드로 분리

---

## 📂 테스트 방법
- [ ] 테스트 코드 작성
- [ ] 시나리오 기반 테스트 유무
    - ex: ID 중복 시 예외 처리 발생

---

## 💬 기타 참고 사항
- 프론트 요청사항입니다.

---

## 📎 관련 이슈 / 문서

