### PR TITLE
Test/notification : 알림 기능 성공/예외 통합 테스트코드 구현

### DIFF
--- a/src/main/java/com/even/zaro/entity/Notification.java
+++ b/src/main/java/com/even/zaro/entity/Notification.java
@@ -1,9 +1,7 @@
 package com.even.zaro.entity;
 
 import jakarta.persistence.*;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
 
 import java.time.LocalDateTime;
@@ -12,7 +10,9 @@ import java.time.LocalDateTime;
 @Table(name = "notification")
 @Getter
 @Setter
+@Builder(toBuilder = true) // testCode용으로 추가 (실제는 Listener에서 자동생성)
 @NoArgsConstructor
+@AllArgsConstructor
 public class Notification {
 
     @Id

--- a/src/main/java/com/even/zaro/global/exception/notification/NotificationException.java
+++ b/src/main/java/com/even/zaro/global/exception/notification/NotificationException.java
@@ -2,9 +2,15 @@ package com.even.zaro.global.exception.notification;
 
 import com.even.zaro.global.ErrorCode;
 import com.even.zaro.global.exception.CustomException;
+import lombok.Getter;
 
+@Getter
 public class NotificationException extends CustomException {
+
+    private final ErrorCode errorCode;
+
     public NotificationException(ErrorCode errorCode) {
         super(errorCode);
+        this.errorCode = errorCode;
     }
 }

--- a/src/main/java/com/even/zaro/global/scheduler/NotificationCleanupScheduler.java
+++ b/src/main/java/com/even/zaro/global/scheduler/NotificationCleanupScheduler.java
@@ -22,4 +22,11 @@ public class NotificationCleanupScheduler {
         notificationRepository.deleteByCreatedAtBefore(deletingDate);
         log.info("[Scheduler] 30일 지난 알림 삭제 완료 ! (deletingDate = {})", deletingDate);
     }
+
+    // 테스트용 오버로딩 메서드
+    public void deleteOldNotifications(LocalDateTime fixedNow) {
+        LocalDateTime deletingDate = fixedNow.minusDays(30);
+        notificationRepository.deleteByCreatedAtBefore(deletingDate);
+        log.info("[Test] 30일 지난 알림 삭제 완료 ! (deletingDate = {})", deletingDate);
+    }
 }

--- a/src/test/java/com/even/zaro/global/scheduler/NotificationCleanupSchedulerTest.java
+++ b/src/test/java/com/even/zaro/global/scheduler/NotificationCleanupSchedulerTest.java
@@ -1,12 +1,72 @@
 package com.even.zaro.global.scheduler;
 
+import com.even.zaro.entity.Notification;
+import com.even.zaro.entity.Provider;
+import com.even.zaro.entity.Status;
+import com.even.zaro.entity.User;
+import com.even.zaro.repository.NotificationRepository;
+import com.even.zaro.repository.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest
 @ActiveProfiles("test")
 @Transactional
 public class NotificationCleanupSchedulerTest {
 
+    @Autowired
+    NotificationCleanupScheduler notificationCleanupScheduler;
+
+    @Autowired
+    NotificationRepository notificationRepository;
+
+    @Autowired
+    UserRepository userRepository;
+
+    @Test
+    void 알림_30일_지나면_스케줄러_삭제_성공() {
+        // given
+        User user = createUser("test@even.com");
+
+        // 기준 시각 : 30일 전 새벽 3시
+        LocalDateTime standard = LocalDateTime.now().minusDays(30).withHour(3).withMinute(0).withSecond(0).withNano(0);
+
+        Notification oldNoti = createNotification(user, false, standard.minusMinutes(1));
+        Notification notOldEnoughNoti = createNotification(user, false, standard.plusMinutes(1));
+
+        // when
+        notificationCleanupScheduler.deleteOldNotifications();
+
+        // then
+        assertThat(notificationRepository.findById(oldNoti.getId())).isEmpty();
+        assertThat(notificationRepository.findById(notOldEnoughNoti.getId())).isPresent();
+    }
+
+    private User createUser(String email) {
+        return userRepository.save(User.builder()
+                .email(email)
+                .password("password")
+                .nickname("닉네임")
+                .provider(Provider.LOCAL)
+                .status(Status.ACTIVE)
+                .build());
+    }
+
+    private Notification createNotification(User user, boolean isRead, LocalDateTime createdAt) {
+        Notification noti = Notification.builder()
+                .user(user)
+                .targetId(1L)
+                .type(Notification.Type.FOLLOW)
+                .isRead(isRead)
+                .createdAt(createdAt)
+                .build();
+        return notificationRepository.save(noti);
+    }
 }

--- a/src/test/java/com/even/zaro/global/scheduler/NotificationCleanupSchedulerTest.java
+++ b/src/test/java/com/even/zaro/global/scheduler/NotificationCleanupSchedulerTest.java
@@ -1,0 +1,12 @@
+package com.even.zaro.global.scheduler;
+
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+public class NotificationCleanupSchedulerTest {
+
+}

--- a/src/test/java/com/even/zaro/global/scheduler/NotificationCleanupSchedulerTest.java
+++ b/src/test/java/com/even/zaro/global/scheduler/NotificationCleanupSchedulerTest.java
@@ -34,15 +34,17 @@ public class NotificationCleanupSchedulerTest {
     void 알림_30일_지나면_스케줄러_삭제_성공() {
         // given
         User user = createUser("test@even.com");
+        // 테스트 기준 시간 250526 새벽 3시로 설정
+        LocalDateTime testNow = LocalDateTime.of(2025, 5, 26, 3, 0);
 
         // 기준 시각 : 30일 전 새벽 3시
-        LocalDateTime standard = LocalDateTime.now().minusDays(30).withHour(3).withMinute(0).withSecond(0).withNano(0);
+        LocalDateTime standard = testNow.minusDays(30);
 
         Notification oldNoti = createNotification(user, false, standard.minusMinutes(1));
         Notification notOldEnoughNoti = createNotification(user, false, standard.plusMinutes(1));
 
         // when
-        notificationCleanupScheduler.deleteOldNotifications();
+        notificationCleanupScheduler.deleteOldNotifications(testNow);
 
         // then
         assertThat(notificationRepository.findById(oldNoti.getId())).isEmpty();

--- a/src/test/java/com/even/zaro/notification/notificationApiTest.java
+++ b/src/test/java/com/even/zaro/notification/notificationApiTest.java
@@ -35,7 +35,7 @@ public class notificationApiTest {
     @Test
     void 알림_목록_조회_성공() {
         // given
-        User user = createUser("test@even.com");
+        User user = createUser("test1@even.com");
         Notification noti1 = createNotification(user, false);
         Notification noti2 = createNotification(user, true);
 
@@ -47,6 +47,32 @@ public class notificationApiTest {
         // 최신순 정렬이어야함 !!
         assertThat(list).extracting("isRead").containsExactly(true, false);
     }
+
+    @Test
+    void 알림_1개_읽음_처리_성공() {
+        //
+        User user = createUser("test2@even.com");
+        Notification noti = createNotification(user, false);
+
+        notificationService.markAsRead(noti.getId(), user.getId());
+
+        Notification found = notificationRepository.findById(noti.getId()).orElseThrow();
+        assertThat(found.isRead()).isTrue();
+    }
+
+    @Test
+    void 알림_전체_읽음_처리_성공() {
+        User user = createUser("test3@even.com");
+        createNotification(user, false);
+        createNotification(user, false);
+
+        notificationService.markAllAsRead(user.getId());
+
+        List<Notification> list = notificationRepository.findAllByUserIdAndIsReadFalse(user.getId());
+        assertThat(list).isEmpty(); // 모두 읽음 처리됨
+    }
+
+
 
     private User createUser(String email) {
         return userRepository.save(User.builder()

--- a/src/test/java/com/even/zaro/notification/notificationApiTest.java
+++ b/src/test/java/com/even/zaro/notification/notificationApiTest.java
@@ -1,13 +1,70 @@
 package com.even.zaro.notification;
 
+import com.even.zaro.repository.NotificationRepository;
+import com.even.zaro.repository.UserRepository;
+import com.even.zaro.dto.notification.NotificationDto;
+import com.even.zaro.entity.Notification;
+import com.even.zaro.entity.User;
+import com.even.zaro.entity.Provider;
+import com.even.zaro.entity.Status;
+import com.even.zaro.service.NotificationService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest
 @Transactional
 @ActiveProfiles("test")
 public class notificationApiTest {
 
+    @Autowired
+    private UserRepository userRepository;
 
+    @Autowired
+    private NotificationRepository notificationRepository;
+
+    @Autowired
+    private NotificationService notificationService;
+
+    @Test
+    void 알림_목록_조회_성공() {
+        // given
+        User user = createUser("test@even.com");
+        Notification noti1 = createNotification(user, false);
+        Notification noti2 = createNotification(user, true);
+
+        // when
+        List<NotificationDto> list = notificationService.getNotificationsList(user.getId());
+
+        // then
+        assertThat(list).hasSize(2);
+        // 최신순 정렬이어야함 !!
+        assertThat(list).extracting("isRead").containsExactly(true, false);
+    }
+
+    private User createUser(String email) {
+        return userRepository.save(User.builder()
+                .email(email)
+                .password("password")
+                .nickname("닉네임")
+                .provider(Provider.LOCAL)
+                .status(Status.ACTIVE)
+                .build());
+    }
+
+    private Notification createNotification(User user, boolean isRead) {
+        Notification noti = Notification.builder()
+                .user(user)
+                .targetId(1L)
+                .type(Notification.Type.FOLLOW)
+                .isRead(isRead)
+                .build();
+        return notificationRepository.save(noti);
+    }
 }

--- a/src/test/java/com/even/zaro/notification/notificationApiTest.java
+++ b/src/test/java/com/even/zaro/notification/notificationApiTest.java
@@ -1,0 +1,13 @@
+package com.even.zaro.notification;
+
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@Transactional
+@ActiveProfiles("test")
+public class notificationApiTest {
+
+
+}

--- a/src/test/java/com/even/zaro/notification/notificationApiTest.java
+++ b/src/test/java/com/even/zaro/notification/notificationApiTest.java
@@ -1,5 +1,7 @@
 package com.even.zaro.notification;
 
+import com.even.zaro.global.ErrorCode;
+import com.even.zaro.global.exception.notification.NotificationException;
 import com.even.zaro.repository.NotificationRepository;
 import com.even.zaro.repository.UserRepository;
 import com.even.zaro.dto.notification.NotificationDto;
@@ -17,6 +19,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @SpringBootTest
 @Transactional
@@ -50,28 +53,44 @@ public class notificationApiTest {
 
     @Test
     void 알림_1개_읽음_처리_성공() {
-        //
+        // given
         User user = createUser("test2@even.com");
         Notification noti = createNotification(user, false);
 
+        // when
         notificationService.markAsRead(noti.getId(), user.getId());
 
+        // then
         Notification found = notificationRepository.findById(noti.getId()).orElseThrow();
         assertThat(found.isRead()).isTrue();
     }
 
     @Test
     void 알림_전체_읽음_처리_성공() {
+        // given
         User user = createUser("test3@even.com");
         createNotification(user, false);
         createNotification(user, false);
 
+        // when
         notificationService.markAllAsRead(user.getId());
 
+        // then
         List<Notification> list = notificationRepository.findAllByUserIdAndIsReadFalse(user.getId());
         assertThat(list).isEmpty(); // 모두 읽음 처리됨
     }
 
+    @Test
+    void 존재하지_않는_알림_읽음_처리_실패() {
+        // given
+        User user = createUser("user3@even.com");
+
+        // when & then
+        NotificationException exception = assertThrows(NotificationException.class, () ->
+                notificationService.markAsRead(9999L, user.getId()));
+
+        assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.NOTIFICATION_NOT_FOUND);
+    }
 
 
     private User createUser(String email) {


### PR DESCRIPTION
## 📌 작업 개요
- 알림 기능 성공/예외 통합 테스트코드 구현

---

## ✨ 주요 변경 사항
- NotificationException 에 Getter, errorCode 필드추가
- 알림 기능별 성공 테스트 코드 구현
- 알림 기능별 실패 테스트 코드 구현
- 알림 30일후 자동삭제 스케줄러 테스트 코드 구현

---

## 🖼️ 기능 살펴 보기
> 알림 기본 기능 : 3개의 성공케이스, 1개의 실패케이스 테스트 성공
![image](https://github.com/user-attachments/assets/9ef8fcb4-69d2-4a9d-bc8e-60b3e0bc656f)

> 알림 30일 후 자동삭제 스케줄러 테스트
![image](https://github.com/user-attachments/assets/dff71e0d-800a-4f4f-819b-f7dfca8ca304)
- 사진처럼 Notification 엔티티, created_at 컬럼의 @CreationTimeStamp 주석처리해야 정상통과됩니다
(알림 생성시각 자동주입코드 삭제 필요)

---

## ✅ 작업 체크리스트
- [x] 기능별 테스트케이스 작성
- [x] 기능별 예외 케이스 고려
- [x] 변수명, 클래스명, 메서드명 의미있게 작성
- [x] 반복 코드 메서드로 분리

---

## 📂 테스트 방법
- [x] 테스트 코드 작성
- [x] 시나리오 기반 테스트 유무
    - ex: ID 중복 시 예외 처리 발생

---

## 💬 기타 참고 사항
- listener를 이용한 알림 생성의 테스트는 예정사항입니다 !

---

## 📎 관련 이슈 / 문서

