### PR TITLE
Ref/response fix : 게시글 리스트 조회시 누락된 부분 수정

### DIFF
--- a/src/main/java/com/even/zaro/controller/PostController.java
+++ b/src/main/java/com/even/zaro/controller/PostController.java
@@ -63,11 +63,12 @@ public class PostController {
     @GetMapping
     public ResponseEntity<ApiResponse<PageResponse<PostPreviewDto>>> getPostList(
             @RequestParam(required = false) String category,
+            @RequestParam(required = false) String tag,
             @ParameterObject @PageableDefault(size = 10, sort = "createdAt", direction = org.springframework.data.domain.Sort.Direction.DESC)
             Pageable pageable,
             @AuthenticationPrincipal JwtUserInfoDto userInfoDto
     ){
-        PageResponse<PostPreviewDto> posts = postService.getPostListPage(category, pageable);
+        PageResponse<PostPreviewDto> posts = postService.getPostListPage(category, tag, pageable);
 
         return ResponseEntity.ok(ApiResponse.success("게시글 리스트 조회가 성공했습니다.",posts));
     }

--- a/src/main/java/com/even/zaro/dto/post/PostPreviewDto.java
+++ b/src/main/java/com/even/zaro/dto/post/PostPreviewDto.java
@@ -1,6 +1,7 @@
 package com.even.zaro.dto.post;
 
 import com.even.zaro.entity.Post;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -13,6 +14,7 @@ import java.util.List;
 @AllArgsConstructor
 @Builder
 @Schema(description = "게시글 목록 응답 DTO")
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class PostPreviewDto {
 
     @Schema(description = "게시글 ID", example = "1")
@@ -39,11 +41,15 @@ public class PostPreviewDto {
     @Schema(description = "댓글 수", example = "3")
     private int commentCount;
 
+    private String writerProfileImage;
+    private String writerNickname;
+
+
     @Schema(description = "게시글 생성 일시", example = "2025-05-21T12:34:56")
     private LocalDateTime createdAt;
 
     public static PostPreviewDto from(Post post) {
-        return PostPreviewDto.builder()
+        PostPreviewDto.PostPreviewDtoBuilder builder = PostPreviewDto.builder()
                 .postId(post.getId())
                 .title(post.getTitle())
                 .content(truncate(post.getContent(), 50))
@@ -52,8 +58,15 @@ public class PostPreviewDto {
                 .tag(post.getTag() != null ? post.getTag().name() : null)
                 .likeCount(post.getLikeCount())
                 .commentCount(post.getCommentCount())
-                .createdAt(post.getCreatedAt())
-                .build();
+                .createdAt(post.getCreatedAt());
+
+        if (post.getCategory() == Post.Category.RANDOM_BUY){
+            builder.writerProfileImage(post.getUser().getProfileImage());
+            builder.writerNickname(post.getUser().getNickname());
+        }
+
+        return builder.build();
+
     }
 
     private static String truncate(String content, int maxLength) {

--- a/src/main/java/com/even/zaro/dto/post/PostPreviewDto.java
+++ b/src/main/java/com/even/zaro/dto/post/PostPreviewDto.java
@@ -41,7 +41,10 @@ public class PostPreviewDto {
     @Schema(description = "댓글 수", example = "3")
     private int commentCount;
 
+    @Schema(description = "작성자 프로필 이미지 URL", example = "https://your-cdn.com/default.png", nullable = true)
     private String writerProfileImage;
+
+    @Schema(description = "작성자 닉네임", example = "이브니쨩", nullable = true)
     private String writerNickname;
 
 

--- a/src/main/java/com/even/zaro/repository/PostRepository.java
+++ b/src/main/java/com/even/zaro/repository/PostRepository.java
@@ -27,4 +27,6 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     List<Post> findTop5ByCategoryAndIsDeletedFalseOrderByCreatedAtDesc(Post.Category category);
 
     boolean existsByIdAndIsDeletedFalse(Long postId);
+
+    Page<Post> findByCategoryAndTagAndIsDeletedFalse(Post.Category postCategory, Post.Tag postTag, Pageable pageable);
 }


### PR DESCRIPTION
## 📌 작업 개요
- 게시글 리스트 API 수정

---

## ✨ 주요 변경 사항
- 카테고리가 RANDOM_BUY일때 작성자 정보가 포함 (image, nickname)
- 카테고리 & 태그 필터링

---

## 🖼️ 기능 살펴 보기
>

| 전체조회 | 카테고리만 조회(TOGETHER)| 카테고리만 조회(RANDOM_BUY)|
|-------|-------|-------|
|![전체조회](https://github.com/user-attachments/assets/93e824ec-9b16-4939-9ffd-ce26ed69e81b)|![카테고리만 조회](https://github.com/user-attachments/assets/788a1e7c-d070-4ab0-9cbf-a012f95965f6)|![카테고리만 조회-랜덤바이](https://github.com/user-attachments/assets/05de9a47-9336-4db3-9d63-776df61e19f7)|

| 유효한 태그 조회 | 예외 - 유효하지 않은 태그 조회 | 예외 - 유효하지 않은 카테고리 조회 |
|-------|-------|-------|
|![유효한태그 조회](https://github.com/user-attachments/assets/adbfaaa2-f7ae-45b6-870e-2e529761eae0)|![유효하지 않는 태그 조회](https://github.com/user-attachments/assets/c9e4577c-aa58-45ff-a03b-9a98d12d00ca)|![유효하지않는 카테고리 조회](https://github.com/user-attachments/assets/68f408dd-457d-404f-9c75-6b9d4be96e98)|


---

## ✅ 작업 체크리스트
- [x] API 테스트 완료 (POSTMAN)
- [x] 스웨거 ui 관련 코드 추가
- [x] 기능별 예외 케이스 고

---

## 💬 기타 참고 사항
- #83 PR과 컴플릭 날 예정입니다..! 둘중 하나 머지되면 맞춰서 컴플릭 해결하겠습니다.🙇‍♀️
---

## 📎 관련 이슈 / 문서
- #84 <- 관련 이슈 등록
