### PR TITLE
Feat/search es Elasticsearch 적용 검색 API 구현

### DIFF
--- a/.env.dev.example
+++ b/.env.dev.example
@@ -32,3 +32,5 @@ MAIL_PASSWORD=
 
 # ElasticSearch
 ES_URI=http://localhost:9200
+ES_HOST=localhost
+ES_PORT=9200

--- a/.env.dev.example
+++ b/.env.dev.example
@@ -29,3 +29,6 @@ FRONTEND_URL=
 # 공용 메일 계정
 MAIL_USERNAME=zaro.even.team@gmail.com
 MAIL_PASSWORD=
+
+# ElasticSearch
+ES_URI=http://localhost:9200

--- a/.env.dev.example
+++ b/.env.dev.example
@@ -31,6 +31,6 @@ MAIL_USERNAME=zaro.even.team@gmail.com
 MAIL_PASSWORD=
 
 # ElasticSearch
-ES_URI=http://localhost:9200
-ES_HOST=localhost
+ES_URI=http://elasticsearch:9200
+ES_HOST=elasticsearch
 ES_PORT=9200

--- a/.env.local.example
+++ b/.env.local.example
@@ -34,3 +34,5 @@ MAIL_PASSWORD=
 
 # ElasticSearch
 ES_URI=http://localhost:9200
+ES_HOST=localhost
+ES_PORT=9200

--- a/.env.local.example
+++ b/.env.local.example
@@ -31,3 +31,6 @@ FRONTEND_URL=
 # 공용 메일 계정
 MAIL_USERNAME=zaro.even.team@gmail.com
 MAIL_PASSWORD=
+
+# ElasticSearch
+ES_URI=http://localhost:9200

--- a/.env.prod.example
+++ b/.env.prod.example
@@ -31,3 +31,5 @@ AWS_SECRET_KEY=
 
 # ElasticSearch
 ES_URI=
+ES_HOST=
+ES_PORT=

--- a/.env.prod.example
+++ b/.env.prod.example
@@ -22,9 +22,12 @@ EMAIL_VERIFICATION_URL=
 FRONTEND_URL=
 
 # 공용 메일 계정
-MAIL_USERNAME=evenide.team@gmail.com
+MAIL_USERNAME=zaro.even.team@gmail.com
 MAIL_PASSWORD=
 
 # S3 관련
 AWS_ACCESS_KEY=
 AWS_SECRET_KEY=
+
+# ElasticSearch
+ES_URI=

--- a/build.gradle
+++ b/build.gradle
@@ -60,6 +60,9 @@ dependencies {
 	// 메일 전송
 	implementation 'org.springframework.boot:spring-boot-starter-mail'
 
+	// ElasticSearch
+	implementation 'org.springframework.boot:spring-boot-starter-data-elasticsearch'
+
 }
 
 test {

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -14,11 +14,13 @@ services:
       REDIS_HOST: ${REDIS_HOST}
       REDIS_PORT: ${REDIS_PORT}
       REDIS_PASSWORD: ${REDIS_PASSWORD}
+      ES_URI: ${ES_URI}
     ports:
       - "8080:8080"
     depends_on:
       - db
       - redis
+      - elasticsearch
 
   db:
     image: mysql:8
@@ -42,6 +44,18 @@ services:
     volumes:
       - redis_data:/data
 
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.13.4
+    container_name: even_final_es
+    environment:
+      - discovery.type=single-node
+      - xpack.security.enabled=false
+    ports:
+      - "9200:9200"
+    volumes:
+      - es_dev_data:/usr/share/elasticsearch/data
+
 volumes:
   mysql_data:
   redis_data:
+  es_dev_data:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -50,6 +50,7 @@ services:
     environment:
       - discovery.type=single-node
       - xpack.security.enabled=false
+      - logger.level=warn
     ports:
       - "9200:9200"
     volumes:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -55,6 +55,12 @@ services:
       - "9200:9200"
     volumes:
       - es_dev_data:/usr/share/elasticsearch/data
+    command: >
+      bash -c "
+      if [ ! -d plugins/analysis-nori ]; then
+        elasticsearch-plugin install analysis-nori --batch;
+      fi &&
+      bin/elasticsearch"
 
 volumes:
   mysql_data:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -36,6 +36,7 @@ services:
     environment:
       - discovery.type=single-node
       - xpack.security.enabled=false
+      - logger.level=warn
     ports:
       - "9200:9200"
     volumes:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -41,6 +41,12 @@ services:
       - "9200:9200"
     volumes:
       - es_data:/usr/share/elasticsearch/data
+    command: >
+      bash -c "
+      if [ ! -d plugins/analysis-nori ]; then
+        elasticsearch-plugin install analysis-nori --batch;
+      fi &&
+      bin/elasticsearch"
 
 volumes:
   redis_data:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -14,10 +14,12 @@ services:
       REDIS_HOST: ${REDIS_HOST}
       REDIS_PORT: ${REDIS_PORT}
       REDIS_PASSWORD: ${REDIS_PASSWORD}
+      ES_URI: ${ES_URI}
     ports:
       - "8080:8080"
     depends_on:
       - redis
+      - elasticsearch
 
   redis:
     image: redis:latest
@@ -28,5 +30,17 @@ services:
     volumes:
       - redis_data:/data
 
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.13.4
+    container_name: even_final_es
+    environment:
+      - discovery.type=single-node
+      - xpack.security.enabled=false
+    ports:
+      - "9200:9200"
+    volumes:
+      - es_data:/usr/share/elasticsearch/data
+
 volumes:
   redis_data:
+  es_data:

--- a/src/main/java/com/even/zaro/config/ElasticsearchConfig.java
+++ b/src/main/java/com/even/zaro/config/ElasticsearchConfig.java
@@ -1,0 +1,31 @@
+package com.even.zaro.config;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.json.jackson.JacksonJsonpMapper;
+import co.elastic.clients.transport.ElasticsearchTransport;
+import co.elastic.clients.transport.rest_client.RestClientTransport;
+import org.apache.http.HttpHost;
+import org.elasticsearch.client.RestClient;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ElasticsearchConfig {
+    @Value("${es.host}")
+    private String esHost;
+
+    @Value("${es.port}")
+    private int esPort;
+
+    @Bean
+    public ElasticsearchClient elasticsearchClient() {
+        RestClient restClient = RestClient.builder(
+                new HttpHost(esHost, esPort)).build();
+
+        ElasticsearchTransport transport = new RestClientTransport(
+                restClient, new JacksonJsonpMapper());
+
+        return new ElasticsearchClient(transport);
+    }
+}

--- a/src/main/java/com/even/zaro/config/security/SecurityConfig.java
+++ b/src/main/java/com/even/zaro/config/security/SecurityConfig.java
@@ -45,6 +45,7 @@ public class SecurityConfig {
                                 .requestMatchers("/api/posts/home").permitAll()
                                 .requestMatchers(HttpMethod.GET, "/api/posts").permitAll()
                                 .requestMatchers(HttpMethod.GET, "/api/search").permitAll()
+                                .requestMatchers(HttpMethod.GET, "/api/search/es").permitAll() // search 로 합쳐질 예정
                                 .requestMatchers("/api/profile/{userId}").permitAll()
 //                        .requestMatchers("/**").permitAll() // 전체 인증 없이 개발용
                         .anyRequest().authenticated()

--- a/src/main/java/com/even/zaro/config/security/SecurityConfig.java
+++ b/src/main/java/com/even/zaro/config/security/SecurityConfig.java
@@ -47,6 +47,7 @@ public class SecurityConfig {
                                 .requestMatchers(HttpMethod.GET, "/api/search").permitAll()
                                 .requestMatchers(HttpMethod.GET, "/api/search/es").permitAll() // search 로 합쳐질 예정
                                 .requestMatchers("/api/profile/{userId}").permitAll()
+                                .requestMatchers("/api/es/reindex").permitAll()
 //                        .requestMatchers("/**").permitAll() // 전체 인증 없이 개발용
                         .anyRequest().authenticated()
                 )

--- a/src/main/java/com/even/zaro/controller/PostSearchController.java
+++ b/src/main/java/com/even/zaro/controller/PostSearchController.java
@@ -4,6 +4,7 @@ import com.even.zaro.dto.PageResponse;
 import com.even.zaro.dto.post.PostPreviewDto;
 import com.even.zaro.dto.post.PostSearchDto;
 import com.even.zaro.global.ApiResponse;
+import com.even.zaro.service.PostEsSearchService;
 import com.even.zaro.service.PostSearchService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
@@ -20,6 +21,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.io.IOException;
 import java.util.Map;
 
 @Tag(name = "게시글 검색 API", description = "카테고리 + 키워드 기반 게시글 검색 기능")
@@ -29,6 +31,7 @@ import java.util.Map;
 public class PostSearchController {
 
     private final PostSearchService postSearchService;
+    private final PostEsSearchService postEsSearchService;
 
     @Operation(summary = "게시글 검색", description = "카테고리 및 키워드 기반으로 게시글을 검색합니다.")
     @GetMapping
@@ -42,4 +45,16 @@ public class PostSearchController {
 
         return ResponseEntity.ok(ApiResponse.success("검색 결과입니다.", results));
     }
+    @Operation(summary = "ES 게시글 검색", description = "Elasticsearch 기반의 게시글 검색 결과를 페이징 형태로 제공합니다.")
+    @GetMapping("/es")
+    public ResponseEntity<ApiResponse<PageResponse<PostSearchDto>>> searchEsPosts(
+            @RequestParam("required = false") String category,
+            @RequestParam String keyword,
+            @ParameterObject @PageableDefault(size = 10, sort = "createdAt", direction = org.springframework.data.domain.Sort.Direction.DESC)
+            Pageable pageable
+    ) throws IOException {
+        PageResponse<PostSearchDto> result = postEsSearchService.searchWithPage(category, keyword, pageable);
+        return ResponseEntity.ok(ApiResponse.success("ES 검색 결과입니다." , result));
+    }
+
 }

--- a/src/main/java/com/even/zaro/controller/PostSearchController.java
+++ b/src/main/java/com/even/zaro/controller/PostSearchController.java
@@ -45,10 +45,11 @@ public class PostSearchController {
 
         return ResponseEntity.ok(ApiResponse.success("검색 결과입니다.", results));
     }
+
     @Operation(summary = "ES 게시글 검색", description = "Elasticsearch 기반의 게시글 검색 결과를 페이징 형태로 제공합니다.")
     @GetMapping("/es")
     public ResponseEntity<ApiResponse<PageResponse<PostSearchDto>>> searchEsPosts(
-            @RequestParam("required = false") String category,
+            @RequestParam(required = false) String category,
             @RequestParam String keyword,
             @ParameterObject @PageableDefault(size = 10, sort = "createdAt", direction = org.springframework.data.domain.Sort.Direction.DESC)
             Pageable pageable
@@ -56,5 +57,4 @@ public class PostSearchController {
         PageResponse<PostSearchDto> result = postEsSearchService.searchWithPage(category, keyword, pageable);
         return ResponseEntity.ok(ApiResponse.success("ES 검색 결과입니다." , result));
     }
-
 }

--- a/src/main/java/com/even/zaro/elasticsearch/ReindexController.java
+++ b/src/main/java/com/even/zaro/elasticsearch/ReindexController.java
@@ -1,0 +1,44 @@
+package com.even.zaro.elasticsearch;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import com.even.zaro.elasticsearch.document.PostEsDocument;
+import com.even.zaro.entity.Post;
+import com.even.zaro.repository.PostRepository;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.io.IOException;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/es")
+@RequiredArgsConstructor
+@Tag(name = "개발용입니다.", description = "개발용 API 입니다. 프론트에서 사용하지 않습니다. 메롱 ~:)")
+public class ReindexController {
+
+    private final PostRepository postRepository;
+    private final ElasticsearchClient esClient;
+
+    @Operation(summary = "ES 인덱스 재색인", description = "전체 게시글을 Elasticsearch에 재색인합니다. ES에 이미 존재하는 내용은 다시 들어가지 않습니다.")
+    @PostMapping("/reindex")
+    public ResponseEntity<String> reindex() throws IOException {
+        List<Post> posts = postRepository.findAll();
+
+        for (Post post : posts) {
+            esClient.index(i -> i
+                    .index("posts")
+                    .id(post.getId().toString())
+                    .document(PostEsDocument.from(post))
+            );
+        }
+
+        return ResponseEntity.ok("DB -> ES 복제 완료!");
+    }
+}

--- a/src/main/java/com/even/zaro/elasticsearch/ReindexController.java
+++ b/src/main/java/com/even/zaro/elasticsearch/ReindexController.java
@@ -32,13 +32,12 @@ public class ReindexController {
         List<Post> posts = postRepository.findAll();
 
         for (Post post : posts) {
-            PostEsDocument doc = PostEsDocument.from(post);
-            if (doc == null) continue;
+            if (post.isDeleted() || post.isReported()) continue;
 
             esClient.index(i -> i
                     .index("posts")
                     .id(post.getId().toString())
-                    .document(doc)
+                    .document(PostEsDocument.from(post))
             );
         }
 

--- a/src/main/java/com/even/zaro/elasticsearch/ReindexController.java
+++ b/src/main/java/com/even/zaro/elasticsearch/ReindexController.java
@@ -32,10 +32,13 @@ public class ReindexController {
         List<Post> posts = postRepository.findAll();
 
         for (Post post : posts) {
+            PostEsDocument doc = PostEsDocument.from(post);
+            if (doc == null) continue;
+
             esClient.index(i -> i
                     .index("posts")
                     .id(post.getId().toString())
-                    .document(PostEsDocument.from(post))
+                    .document(doc)
             );
         }
 

--- a/src/main/java/com/even/zaro/elasticsearch/document/PostEsDocument.java
+++ b/src/main/java/com/even/zaro/elasticsearch/document/PostEsDocument.java
@@ -1,0 +1,62 @@
+package com.even.zaro.elasticsearch.document;
+
+import com.even.zaro.entity.Post;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.elasticsearch.annotations.Document;
+import org.springframework.data.elasticsearch.annotations.Field;
+import org.springframework.data.elasticsearch.annotations.FieldType;
+
+import java.time.LocalDateTime;
+
+@Document(indexName = "posts")
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PostEsDocument {
+
+    @Id
+    private Long id;
+
+    @Field(type = FieldType.Text)
+    private String title;
+
+    @Field(type = FieldType.Text)
+    private String content;
+
+    @Field(type = FieldType.Keyword)
+    private String thumbnailImage;
+
+    @Field(type = FieldType.Keyword)
+    private String category;
+
+    @Field(type = FieldType.Keyword)
+    private String tag;
+
+    @Field(type = FieldType.Integer)
+    private int likeCount;
+
+    @Field(type = FieldType.Integer)
+    private int commentCount;
+
+    @Field(type = FieldType.Date)
+    private LocalDateTime createdAt;
+
+    public static PostEsDocument from(Post post) {
+        return PostEsDocument.builder()
+                .id(post.getId())
+                .title(post.getTitle())
+                .content(post.getContent())
+                .thumbnailImage(post.getThumbnailImage())
+                .category(post.getCategory().name())
+                .tag(post.getTag().name())
+                .likeCount(post.getLikeCount())
+                .commentCount(post.getCommentCount())
+                .createdAt(post.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/even/zaro/elasticsearch/document/PostEsDocument.java
+++ b/src/main/java/com/even/zaro/elasticsearch/document/PostEsDocument.java
@@ -10,8 +10,6 @@ import org.springframework.data.elasticsearch.annotations.Document;
 import org.springframework.data.elasticsearch.annotations.Field;
 import org.springframework.data.elasticsearch.annotations.FieldType;
 
-import java.time.LocalDateTime;
-
 @Document(indexName = "posts")
 @Getter
 @Builder
@@ -43,8 +41,8 @@ public class PostEsDocument {
     @Field(type = FieldType.Integer)
     private int commentCount;
 
-    @Field(type = FieldType.Date)
-    private LocalDateTime createdAt;
+    @Field(type = FieldType.Keyword)
+    private String createdAt;
 
     public static PostEsDocument from(Post post) {
         return PostEsDocument.builder()
@@ -56,7 +54,7 @@ public class PostEsDocument {
                 .tag(post.getTag().name())
                 .likeCount(post.getLikeCount())
                 .commentCount(post.getCommentCount())
-                .createdAt(post.getCreatedAt())
+                .createdAt(post.getCreatedAt().toString())
                 .build();
     }
 }

--- a/src/main/java/com/even/zaro/event/PostDeletedEvent.java
+++ b/src/main/java/com/even/zaro/event/PostDeletedEvent.java
@@ -1,0 +1,10 @@
+package com.even.zaro.event;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class PostDeletedEvent {
+    private final Long postId;
+}

--- a/src/main/java/com/even/zaro/event/PostSavedEvent.java
+++ b/src/main/java/com/even/zaro/event/PostSavedEvent.java
@@ -1,0 +1,13 @@
+package com.even.zaro.event;
+
+import com.even.zaro.entity.Post;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class PostSavedEvent {
+
+    private final Post post;
+
+}

--- a/src/main/java/com/even/zaro/global/ErrorCode.java
+++ b/src/main/java/com/even/zaro/global/ErrorCode.java
@@ -75,7 +75,7 @@ public enum ErrorCode {
     ALREADY_LIKED(HttpStatus.BAD_REQUEST, "이미 좋아요를 누른 게시글입니다."),
     LIKE_NOT_POST(HttpStatus.NOT_FOUND, "좋아요 정보가 존재하지 않습니다."),
     EMAIL_NOT_VERIFIED_LIKE(HttpStatus.FORBIDDEN, "이메일 인증이 완료되지 않아 좋아요 기능을 이용할 수 없습니다."),
-    KEYWORD_REQUIRED(HttpStatus.BAD_REQUEST, "검색어는 필수입니다."),
+    SEARCH_KEYWORD_REQUIRED(HttpStatus.BAD_REQUEST, "검색어는 필수입니다."),
     CATEGORY_REQUIRED(HttpStatus.BAD_REQUEST, "카테고리는 필수입니다."),
     SEARCH_POST_NOT_FOUND(HttpStatus.NOT_FOUND, "검색 결과가 없습니다."),
 

--- a/src/main/java/com/even/zaro/listener/PostDeletedEventListener.java
+++ b/src/main/java/com/even/zaro/listener/PostDeletedEventListener.java
@@ -1,0 +1,24 @@
+package com.even.zaro.listener;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import com.even.zaro.event.PostDeletedEvent;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class PostDeletedEventListener {
+
+    private final ElasticsearchClient elasticsearchClient;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handle(PostDeletedEvent event) throws IOException {
+        elasticsearchClient.delete(d -> d
+                .index("posts")
+                .id(event.getPostId().toString()));
+    }
+}

--- a/src/main/java/com/even/zaro/listener/PostSavedEventListener.java
+++ b/src/main/java/com/even/zaro/listener/PostSavedEventListener.java
@@ -1,0 +1,27 @@
+package com.even.zaro.listener;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import com.even.zaro.elasticsearch.document.PostEsDocument;
+import com.even.zaro.entity.Post;
+import com.even.zaro.event.PostSavedEvent;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class PostSavedEventListener {
+    private final ElasticsearchClient elasticsearchClient;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handle(PostSavedEvent event) throws IOException {
+        Post post = event.getPost();
+        elasticsearchClient.index(i -> i
+                .index("posts")
+                .id(post.getId().toString())
+                .document(PostEsDocument.from(post)));
+    }
+}

--- a/src/main/java/com/even/zaro/service/PostEsSearchService.java
+++ b/src/main/java/com/even/zaro/service/PostEsSearchService.java
@@ -17,6 +17,7 @@ import org.springframework.stereotype.Service;
 
 
 import java.io.IOException;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Objects;
 
@@ -63,7 +64,7 @@ public class PostEsSearchService {
                             doc.getTag(),
                             doc.getLikeCount(),
                             doc.getCommentCount(),
-                            doc.getCreatedAt()
+                            LocalDateTime.parse(doc.getCreatedAt())
                     );
                 })
                 .filter(Objects::nonNull)

--- a/src/main/java/com/even/zaro/service/PostEsSearchService.java
+++ b/src/main/java/com/even/zaro/service/PostEsSearchService.java
@@ -2,10 +2,7 @@ package com.even.zaro.service;
 
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
 
-import co.elastic.clients.elasticsearch._types.query_dsl.BoolQuery;
-import co.elastic.clients.elasticsearch._types.query_dsl.MatchQuery;
-import co.elastic.clients.elasticsearch._types.query_dsl.Query;
-import co.elastic.clients.elasticsearch._types.query_dsl.TermQuery;
+import co.elastic.clients.elasticsearch._types.query_dsl.*;
 import co.elastic.clients.elasticsearch.core.SearchResponse;
 import com.even.zaro.dto.PageResponse;
 import com.even.zaro.dto.post.PostSearchDto;
@@ -28,8 +25,8 @@ public class PostEsSearchService {
     private final ElasticsearchClient elasticsearchClient;
 
     public PageResponse<PostSearchDto> searchWithPage(String category, String keyword, Pageable pageable) throws IOException {
-        Query keywordQuery = MatchQuery.of(m -> m
-                .field("title")
+        Query keywordQuery = MultiMatchQuery.of(m -> m
+                .fields("title", "content")
                 .query(keyword)
         )._toQuery();
 

--- a/src/main/java/com/even/zaro/service/PostEsSearchService.java
+++ b/src/main/java/com/even/zaro/service/PostEsSearchService.java
@@ -1,0 +1,75 @@
+package com.even.zaro.service;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+
+import co.elastic.clients.elasticsearch._types.query_dsl.BoolQuery;
+import co.elastic.clients.elasticsearch._types.query_dsl.MatchQuery;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
+import co.elastic.clients.elasticsearch._types.query_dsl.TermQuery;
+import co.elastic.clients.elasticsearch.core.SearchResponse;
+import com.even.zaro.dto.PageResponse;
+import com.even.zaro.dto.post.PostSearchDto;
+import com.even.zaro.elasticsearch.document.PostEsDocument;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Objects;
+
+
+@Service
+@RequiredArgsConstructor
+public class PostEsSearchService {
+    private final ElasticsearchClient elasticsearchClient;
+
+    public PageResponse<PostSearchDto> searchWithPage(String category, String keyword, Pageable pageable) throws IOException {
+        Query keywordQuery = MatchQuery.of(m -> m
+                .field("title")
+                .query(keyword)
+        )._toQuery();
+
+        BoolQuery.Builder bool = new BoolQuery.Builder()
+                .must(keywordQuery);
+
+        if (category !=null && !category.isBlank()) {
+            Query categoryFilter = TermQuery.of(t -> t
+                    .field("category")
+                    .value(category)
+            )._toQuery();
+            bool.filter(categoryFilter);
+        }
+
+        SearchResponse<PostEsDocument> response = elasticsearchClient.search(s -> s
+                .index("posts")
+                .from((int) pageable.getOffset())
+                .size(pageable.getPageSize())
+                .query(q -> q.bool(bool.build())),
+                PostEsDocument.class);
+
+        List<PostSearchDto> content = response.hits().hits().stream()
+                .map(hit -> {
+                    PostEsDocument doc = hit.source();
+                    if (doc == null) return null;
+                    return new PostSearchDto(
+                            doc.getId(),
+                            doc.getTitle(),
+                            doc.getContent(),
+                            doc.getThumbnailImage(),
+                            doc.getCategory(),
+                            doc.getTag(),
+                            doc.getLikeCount(),
+                            doc.getCommentCount(),
+                            doc.getCreatedAt()
+                    );
+                })
+                .filter(Objects::nonNull)
+                .toList();
+
+        long total = response.hits().total() != null ? response.hits().total().value() : 0;
+        return new PageResponse<>(new PageImpl<>(content, pageable, total));
+    }
+}

--- a/src/main/java/com/even/zaro/service/PostSearchService.java
+++ b/src/main/java/com/even/zaro/service/PostSearchService.java
@@ -21,7 +21,7 @@ public class PostSearchService {
             throw new PostException(ErrorCode.CATEGORY_REQUIRED);
         }
         if (keyword == null || keyword.isBlank()) {
-            throw new PostException(ErrorCode.KEYWORD_REQUIRED);
+            throw new PostException(ErrorCode.SEARCH_KEYWORD_REQUIRED);
         }
 
         Page<PostSearchDto> result = postSearchRepository.searchPosts(category, keyword, pageable);

--- a/src/main/java/com/even/zaro/service/PostService.java
+++ b/src/main/java/com/even/zaro/service/PostService.java
@@ -109,6 +109,8 @@ public class PostService {
         post.changeTag(tag);
         post.changeImageList(request.getPostImageList());
         post.changeThumbnail(thumbnailUrl);
+
+        eventPublisher.publishEvent(new PostSavedEvent(post));
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/even/zaro/service/PostService.java
+++ b/src/main/java/com/even/zaro/service/PostService.java
@@ -5,11 +5,13 @@ import com.even.zaro.dto.post.*;
 import com.even.zaro.entity.Post;
 import com.even.zaro.entity.Status;
 import com.even.zaro.entity.User;
+import com.even.zaro.event.PostSavedEvent;
 import com.even.zaro.global.ErrorCode;
 import com.even.zaro.global.exception.post.PostException;
 import com.even.zaro.repository.PostRepository;
 import com.even.zaro.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -25,6 +27,7 @@ public class PostService {
 
     private final PostRepository postRepository;
     private final UserRepository userRepository;
+    private final ApplicationEventPublisher eventPublisher;
 
     @Transactional
     public PostDetailResponse createPost(PostCreateRequest request, Long userId) {
@@ -54,7 +57,9 @@ public class PostService {
                 .user(user)
                 .build();
 
-        postRepository.save(post);
+        Post saved = postRepository.save(post);
+        eventPublisher.publishEvent(new PostSavedEvent(saved));
+
         return PostDetailResponse.builder()
                 .postId(post.getId())
                 .title(post.getTitle())

--- a/src/main/java/com/even/zaro/service/PostService.java
+++ b/src/main/java/com/even/zaro/service/PostService.java
@@ -5,6 +5,7 @@ import com.even.zaro.dto.post.*;
 import com.even.zaro.entity.Post;
 import com.even.zaro.entity.Status;
 import com.even.zaro.entity.User;
+import com.even.zaro.event.PostDeletedEvent;
 import com.even.zaro.event.PostSavedEvent;
 import com.even.zaro.global.ErrorCode;
 import com.even.zaro.global.exception.post.PostException;
@@ -174,6 +175,7 @@ public class PostService {
         }
 
         post.markAsDeleted();
+        eventPublisher.publishEvent(new PostDeletedEvent(postId));
     }
 
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -44,6 +44,10 @@ spring:
     port: ${REDIS_PORT}
     password: ${REDIS_PASSWORD}
 
+  # ElasticSearch
+  elasticsearch:
+    uris: ${ES_URI}
+
   # SwaggerUI 설정
   springdoc:
     api-docs:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -104,3 +104,8 @@ cloud:
       static: ap-northeast-2
     s3:
       bucket: even-zaro-image-bucket
+
+# Elasticsearch env
+es:
+  host: ${ES_HOST}
+  port: ${ES_PORT}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -38,6 +38,9 @@ spring:
     redis:
       repositories:
         enabled: false
+    elasticsearch:
+      repositories:
+        enabled: false
 
   redis:
     host: ${REDIS_HOST}


### PR DESCRIPTION
## 📌 작업 개요
- Elasticsearch 적용 검색 API 구현

---

## ✨ 주요 변경 사항
- Elasticsearch 적용 검색 API 구현
    - eventlistener을 통해 게시글 작성시 db 저장 후 es 저장 실행 
    - 게시글 수정시 db 수정 후 es 수정(같은 postId 덮어쓰기)
    - 게시글 삭제시 db 수정 후 es에서 아예 삭제
    - title, content 검색
    - 오타 허용(어느 정도..만 fuzzy 사용)
    - 다중 키워드 순서 상관 없음("자취 꿀템", "꿀템 자취")
    - 분석기 nori_only 적용 (한국어 형태소 분석) - 이 부분은 kibana 툴 이용해서 인덱스 생성시 적용(postman도 가능)
- 인덱스 설정 변경시 인덱스 삭제 후 재 생성해야 하는데 이때 사용할 개발용 /api/es/reindex 리인덱스 api 만들었습니다.
     - DB(post) 전체가 ES 인덱스로 저장되는 API 입니다.  (isDeleted true인 row는 들어가지 않습니다.)
    

---

## 🖼️ 기능 살펴 보기
> 포스트맨 요청 응답 스크린샷
- [x] API 문서(요청, 응답)와 일치하는지 확인 - 필요시 API 문서 수정 가능

|게시글 생성 시 같이 저장되는 es 인덱스 | DB 비교 |
|-----|----|
|![image](https://github.com/user-attachments/assets/f04cde1f-e401-4f4e-8a96-f67fec2924d2)|![image](https://github.com/user-attachments/assets/a5da7c6d-25e2-4285-9652-e353c764cb2f)|

|오타 가능| 다중 키워드 부분 검색 x, 순서 상관 없음 |
|--------|--------|
|![image](https://github.com/user-attachments/assets/7eef9941-3341-4182-8872-8abe74d8a185)|![image](https://github.com/user-attachments/assets/d1ad8027-a29b-4f8d-a597-137be7b83146)|


---

## ✅ 작업 체크리스트
- [x] API 테스트 완료 (POSTMAN)
- [x] 스웨거 ui 관련 코드 추가
- [x] 기능별 예외 케이스 고려
- [x] log.info / 불필요한 주석 제거
- [x] 변수명, 클래스명, 메서드명 의미있게 작성
- [x] 반복 코드 메서드로 분리

---

## 📂 테스트 방법
- [ ] 테스트 코드 작성
- [ ] 시나리오 기반 테스트 유무
    - ex: ID 중복 시 예외 처리 발생

---

## 💬 기타 참고 사항
- 동의어, 오타 등등 다 고려하고 싶지만.. 설정에 시간을 너무 쏟는 것은 삼가해야하는 것 같아서 어느 정도 타협했습니다.
- 순서 바꿈 ok, 두 단어 이상 검색시 두 단어 다 포함, 오타 ok, 부분 음절 검색은 딱히 되지 않지만 형태소 검색(가스 -> 가스레인지) 되도록 했습니다.
- 일단은 @TransactionalEventListener를 통해서 DB에 저장되면 ES에 저장되도록 구현은 했습니다. 실패시 롤백이 어려운 단점이 있는데 그정도까지..는 이 PR에서는 넘어가겠습니다. 싱크 맞추려면 몰래 리인덱스 api 한번씩 눌러주면....뭐 ㅎㅎ (아무도 모를 것이오)
- 그래서 실패를 고려한다면 다른 API 좀 구현하고 남는 시간에 event log 같은거 만들어서 fail 되면 스케줄링으로 다시 넣어주고 하는 로직 추가해서 보완할 수 있을 것 같습니다.
- 또는 이후에 시간이 남아 돈다면 kafka 도입 해보겠습니다.

---

## 📎 관련 이슈 / 문서

