### PR TITLE
ref: 리스트조회 content 자르는거 수정

### DIFF
--- a/src/main/java/com/even/zaro/dto/post/PostPreviewDto.java
+++ b/src/main/java/com/even/zaro/dto/post/PostPreviewDto.java
@@ -55,7 +55,7 @@ public class PostPreviewDto {
         PostPreviewDto.PostPreviewDtoBuilder builder = PostPreviewDto.builder()
                 .postId(post.getId())
                 .title(post.getTitle())
-                .content(truncate(post.getContent(), 50))
+                .content(post.getContent())
                 .thumbnailImage(post.getThumbnailImage())
                 .category(post.getCategory().name())
                 .tag(post.getTag() != null ? post.getTag().name() : null)
@@ -72,8 +72,4 @@ public class PostPreviewDto {
 
     }
 
-    private static String truncate(String content, int maxLength) {
-        if (content == null) return "";
-        return content.length() <= maxLength ? content : content.substring(0, maxLength) + "...";
-    }
 }


### PR DESCRIPTION
## 📌 작업 개요
- 리스트조회시 content 자르는 부분 삭제!

---

## 🖼️ 기능 살펴 보기
> 
| 기존 | 수정 후 |
|-----|-----|
|<img width="1624" alt="스크린샷 2025-05-27 오후 6 12 56" src="https://github.com/user-attachments/assets/26f72148-3d8a-444e-82fd-758bbca0d907" />|<img width="1624" alt="스크린샷 2025-05-27 오후 6 11 18" src="https://github.com/user-attachments/assets/7b067216-91fe-4516-98e2-1d5867b8d558" />|

