### PR TITLE
fix: es 저장시 content 이미지 url, html, 여러 줄바꿈 생략

### DIFF
--- a/src/main/java/com/even/zaro/elasticsearch/document/PostEsDocument.java
+++ b/src/main/java/com/even/zaro/elasticsearch/document/PostEsDocument.java
@@ -45,10 +45,17 @@ public class PostEsDocument {
     private String createdAt;
 
     public static PostEsDocument from(Post post) {
+
+        String cleanContent = post.getContent()
+                .replaceAll("!\\[.*?]\\(.*?\\)", "")
+                .replaceAll("<[^>]*>", "")
+                .replaceAll("\\s+", " ")
+                .trim();
+
         return PostEsDocument.builder()
                 .id(post.getId())
                 .title(post.getTitle())
-                .content(post.getContent())
+                .content(cleanContent)
                 .thumbnailImage(post.getThumbnailImage())
                 .category(post.getCategory().name())
                 .tag(post.getTag().name())


### PR DESCRIPTION
## 📌 작업 개요
- es 저장시 content 이미지 url, html, 여러 줄바꿈 생략

---

## ✨ 주요 변경 사항
- es 저장시 content 이미지 url, html, 여러 줄바꿈 생략
- 기능 변화는 없습니다.

서버에 아래 사진과 같이 content에 이미지 마크다운까지 저장이 되어서.. 이 부분 생략하고 es에 저장하도록 했습니다. -> 이미지로 검색시.. 나옴 ㅠㅠ
![image](https://github.com/user-attachments/assets/eeafd256-c672-424b-8b5b-cc25bfd2ee85)


수정 후 
![image](https://github.com/user-attachments/assets/ffa3d844-683c-46cc-a6de-e261f2cf6625)

![image](https://github.com/user-attachments/assets/9ef9edb7-beb9-4572-a8af-0f8e6cf911c0)


---

## ✅ 작업 체크리스트
- [ ] API 테스트 완료 (POSTMAN)
- [ ] 스웨거 ui 관련 코드 추가
- [ ] 기능별 예외 케이스 고려
- [ ] log.info / 불필요한 주석 제거
- [ ] 변수명, 클래스명, 메서드명 의미있게 작성
- [ ] 반복 코드 메서드로 분리

---

## 📂 테스트 방법
- [ ] 테스트 코드 작성
- [ ] 시나리오 기반 테스트 유무
    - ex: ID 중복 시 예외 처리 발생

---

## 💬 기타 참고 사항


---

## 📎 관련 이슈 / 문서

