### PR TITLE
Ref/page response : 프로필 기능 내 공통 Page 응답 dto 리팩토링

### DIFF
--- a/src/main/java/com/even/zaro/controller/ProfileController.java
+++ b/src/main/java/com/even/zaro/controller/ProfileController.java
@@ -91,17 +91,11 @@ public class ProfileController {
     @GetMapping("/{userId}/comments")
     public ResponseEntity<?> getUserComments(
             @Parameter(description = "조회할 유저의 ID") @PathVariable("userId") Long userId,
-            @Parameter(description = "페이지 번호 (기본값: 0)") @RequestParam(defaultValue = "0") int page,
-            @Parameter(description = "페이지 크기 (기본값: 10)") @RequestParam(defaultValue = "10") int size,
+            @ParameterObject @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable,
             @AuthenticationPrincipal JwtUserInfoDto userInfoDto) {
 
-        PageRequest pageRequest = PageRequest.of(page, size);
-        Page<UserCommentDto> comments = profileService.getUserComments(userId, pageRequest);
-
-        return ResponseEntity.ok(ApiResponse.success("사용자가 작성한 댓글 조회 성공 !", Map.of(
-                        "content", comments.getContent(),
-                        "totalPages", comments.getTotalPages()
-                )));
+        PageResponse<UserCommentDto> comments = profileService.getUserComments(userId, pageable);
+        return ResponseEntity.ok(ApiResponse.success("사용자가 작성한 댓글 조회 성공 !", comments));
     }
 
     // 다른 유저 팔로우 하기

--- a/src/main/java/com/even/zaro/controller/ProfileController.java
+++ b/src/main/java/com/even/zaro/controller/ProfileController.java
@@ -75,16 +75,11 @@ public class ProfileController {
     @GetMapping("/{userId}/likes")
     public ResponseEntity<?> getUserLikedPosts(
             @Parameter(description = "조회할 유저의 ID") @PathVariable("userId") Long userId,
-            @Parameter(description = "페이지 번호 (기본값: 0)") @RequestParam(defaultValue = "0") int page,
-            @Parameter(description = "페이지 크기 (기본값: 10)") @RequestParam(defaultValue = "10") int size,
+            @ParameterObject @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable,
             @AuthenticationPrincipal JwtUserInfoDto userInfoDto) {
 
-        PageRequest pageRequest = PageRequest.of(page, size);
-        Page<UserPostDto> likedPosts = profileService.getUserLikedPosts(userId, pageRequest);
-        return ResponseEntity.ok(ApiResponse.success("사용자가 좋아요 한 게시글 조회 성공 !", Map.of(
-                "content", likedPosts.getContent(),
-                "totalPages", likedPosts.getTotalPages()
-        )));
+        PageResponse<UserPostDto> likedPosts = profileService.getUserLikedPosts(userId, pageable);
+        return ResponseEntity.ok(ApiResponse.success("사용자가 좋아요 한 게시글 조회 성공 !", likedPosts));
     }
 
     // 유저가 쓴 댓글 list 조회

--- a/src/main/java/com/even/zaro/controller/ProfileController.java
+++ b/src/main/java/com/even/zaro/controller/ProfileController.java
@@ -9,6 +9,11 @@ import com.even.zaro.jwt.JwtUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import com.even.zaro.dto.PageResponse;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -54,16 +59,11 @@ public class ProfileController {
     @GetMapping("/{userId}/posts")
     public ResponseEntity<?> getUserPosts(
             @Parameter(description = "조회할 유저의 ID") @PathVariable("userId") Long userId,
-            @Parameter(description = "페이지 번호 (기본값: 0)") @RequestParam(defaultValue = "0") int page,
-            @Parameter(description = "페이지 크기 (기본값: 10)") @RequestParam(defaultValue = "10") int size,
+            @ParameterObject @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable,
             @AuthenticationPrincipal JwtUserInfoDto userInfoDto) {
 
-        PageRequest pageRequest = PageRequest.of(page, size);
-        Page<UserPostDto> posts = profileService.getUserPosts(userId, pageRequest);
-        return ResponseEntity.ok(ApiResponse.success("사용자 게시글 조회 성공 !", Map.of(
-                "content", posts.getContent(),
-                "totalPages", posts.getTotalPages()
-        )));
+        PageResponse<UserPostDto> posts = profileService.getUserPosts(userId, pageable);
+        return ResponseEntity.ok(ApiResponse.success("사용자 게시글 조회 성공 !", posts));
     }
 
     // 유저가 좋아요 누른 게시물 list 조회

--- a/src/main/java/com/even/zaro/controller/ProfileController.java
+++ b/src/main/java/com/even/zaro/controller/ProfileController.java
@@ -6,9 +6,6 @@ import com.even.zaro.service.ProfileService;
 
 import com.even.zaro.global.ApiResponse;
 import com.even.zaro.jwt.JwtUtil;
-import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 import com.even.zaro.dto.PageResponse;
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Pageable;
@@ -21,6 +18,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;

--- a/src/main/java/com/even/zaro/service/ProfileService.java
+++ b/src/main/java/com/even/zaro/service/ProfileService.java
@@ -72,11 +72,11 @@ public class ProfileService {
     }
 
     // 유저가 좋아요 누른 게시물 list 조회
-    public Page<UserPostDto> getUserLikedPosts(Long userId, Pageable pageable) {
+    public PageResponse<UserPostDto> getUserLikedPosts(Long userId, Pageable pageable) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new UserException(ErrorCode.USER_NOT_FOUND));
 
-        return postLikeRepository.findByUser(user, pageable)
+        Page<UserPostDto> page = postLikeRepository.findByUser(user, pageable)
                 .map(postLike -> UserPostDto.builder()
                         .postId(postLike.getPost().getId())
                         .title(postLike.getPost().getTitle())
@@ -88,6 +88,8 @@ public class ProfileService {
                         .commentCount(postLike.getPost().getCommentCount())
                         .createdAt(postLike.getPost().getCreatedAt())
                         .build());
+
+        return new PageResponse<>(page);
     }
 
     // 유저가 작성한 댓글 list 조회

--- a/src/main/java/com/even/zaro/service/ProfileService.java
+++ b/src/main/java/com/even/zaro/service/ProfileService.java
@@ -93,11 +93,11 @@ public class ProfileService {
     }
 
     // 유저가 작성한 댓글 list 조회
-    public Page<UserCommentDto> getUserComments(Long userId, Pageable pageable) {
+    public PageResponse<UserCommentDto> getUserComments(Long userId, Pageable pageable) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new UserException(ErrorCode.USER_NOT_FOUND));
 
-        return commentRepository.findByUserAndIsDeletedFalse(user, pageable)
+        Page<UserCommentDto> page = commentRepository.findByUserAndIsDeletedFalse(user, pageable)
                 .map(comment -> {
                     Post post = comment.getPost();
                     if (post == null) {
@@ -115,6 +115,8 @@ public class ProfileService {
                             .commentCreatedAt(comment.getCreatedAt())
                             .build();
                 });
+
+        return new PageResponse<>(page);
     }
 
     ////////////// 팔로우 관련

--- a/src/main/java/com/even/zaro/service/ProfileService.java
+++ b/src/main/java/com/even/zaro/service/ProfileService.java
@@ -1,5 +1,6 @@
 package com.even.zaro.service;
 
+import com.even.zaro.dto.PageResponse;
 import com.even.zaro.dto.profile.*;
 import com.even.zaro.repository.*;
 import com.even.zaro.entity.*;
@@ -50,11 +51,11 @@ public class ProfileService {
     }
 
     // 유저가 쓴 게시물 list 조회
-    public Page<UserPostDto> getUserPosts(Long userId, Pageable pageable) {
+    public PageResponse<UserPostDto> getUserPosts(Long userId, Pageable pageable) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new UserException(ErrorCode.USER_NOT_FOUND));
 
-        return postRepository.findByUserAndIsDeletedFalse(user, pageable)
+        Page<UserPostDto> page = postRepository.findByUserAndIsDeletedFalse(user, pageable)
                 .map(post -> UserPostDto.builder()
                         .postId(post.getId())
                         .title(post.getTitle())
@@ -66,6 +67,8 @@ public class ProfileService {
                         .commentCount(post.getCommentCount())
                         .createdAt(post.getCreatedAt())
                         .build());
+
+        return new PageResponse<>(page);
     }
 
     // 유저가 좋아요 누른 게시물 list 조회


### PR DESCRIPTION
## 📌 작업 개요
- 프로필 기능 내 공통 Page 응답 dto 리팩토링

---

## ✨ 주요 변경 사항
- 기존 페이지네이션 -> 공통 PageResponseDto 사용코드로 변경
- 기능 특성에 맞게 DESC로 최신순 정렬(내림차순) 사용했습니다 ~
`@PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC)`
 
---

## 🖼️ 기능 살펴 보기
> 유저가 쓴 게시물 list 조회
![image](https://github.com/user-attachments/assets/4f524134-072c-470e-8728-d2b742067591)

> 유저가 좋아요 누른 게시물 list 조회
![image](https://github.com/user-attachments/assets/59d2f08f-3483-4934-b361-c36f5f91eb3b)

> 유저가 쓴 댓글 list 조회
![image](https://github.com/user-attachments/assets/1f1068e9-9ab3-4a48-9c91-0811699a505d)

- 데이터가 없는 것은 로컬DB에 데이터가 없어서일 뿐 이전과 같이 잘 작동됩니다~!

---

## ✅ 작업 체크리스트
- [x] API 테스트 완료 (POSTMAN)
- [x] 공통형식으로 리팩토링

---

## 📂 테스트 방법
- [x] swagger

---

## 💬 기타 참고 사항
- 머지할 때 Issue close 걸어두겠습니다 :) ~ approve시 확인코멘트 남겨주세용

---

## 📎 관련 이슈 / 문서
- 관련 이슈 번호: close #54 
