### PR TITLE
chore: 도커파일 의존성 캐시 최적화로 빌드 속도 향상

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,11 @@
 FROM gradle:8.4-jdk21 AS build
 WORKDIR /app
+
+COPY build.gradle settings.gradle ./
+RUN gradle dependencies --no-daemon
+
 COPY . .
-RUN gradle build --no-daemon -x test
+RUN gradle build --no-daemon -x test --build-cache
 
 FROM openjdk:21-jdk-slim
 WORKDIR /app


### PR DESCRIPTION
## 📌 작업 개요
- 도커파일 의존성 캐시 최적화로 빌드 속도 향상

---

## ✨ 주요 변경 사항
- Dockerfile 내 COPY 순서 변경
    - gradle dependencies 선 실행으로 의존성 캐시 최적화
    - -build-cache 옵션 추가 

---

## 💬 기타 참고 사항
- 도커 컴포즈 빌드가 너무 오래걸려서 확인 후 수정했습니다.
- 빌드 속도 약 40초 → 10초로 단축


---

## 📎 관련 이슈 / 문서
트러블 슈팅 참고
- Fixes #93 