### PR TITLE
Feat/update nickname 닉네임 변경 API 

### DIFF
--- a/src/main/java/com/even/zaro/controller/UserController.java
+++ b/src/main/java/com/even/zaro/controller/UserController.java
@@ -1,6 +1,8 @@
 package com.even.zaro.controller;
 
 import com.even.zaro.dto.jwt.JwtUserInfoDto;
+import com.even.zaro.dto.user.UpdateNicknameRequestDto;
+import com.even.zaro.dto.user.UpdateNicknameResponseDto;
 import com.even.zaro.dto.user.UpdatePasswordRequestDto;
 import com.even.zaro.dto.user.UserInfoResponseDto;
 import com.even.zaro.global.ApiResponse;
@@ -12,6 +14,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+
+import java.time.format.DateTimeFormatter;
 
 @Tag(name = "Users", description = "사용자 관련 API")
 @RestController
@@ -25,6 +29,21 @@ public class UserController {
     public ResponseEntity<ApiResponse<UserInfoResponseDto>> getMyInfo(@AuthenticationPrincipal JwtUserInfoDto userInfoDto) {
         UserInfoResponseDto responseDto = userService.getMyInfo(userInfoDto.getUserId());
         return ResponseEntity.ok(ApiResponse.success("내 정보 조회에 성공했습니다.", responseDto));
+    }
+
+    @Operation(summary = "닉네임 변경", description = "로그인한 사용자의 닉네임을 변경합니다.", security = {@SecurityRequirement(name = "bearer-key")})
+    @PatchMapping("/me/nickname")
+    public ResponseEntity<ApiResponse<UpdateNicknameResponseDto>> updateNickname(
+            @RequestBody UpdateNicknameRequestDto requestDto,
+            @AuthenticationPrincipal JwtUserInfoDto userInfoDto
+            ) {
+        UpdateNicknameResponseDto responseDto = userService.updateNickname(userInfoDto.getUserId(), requestDto);
+
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy년 MM월 dd일");
+        String formattedDate = responseDto.getNextAvailableChangeDate().format(formatter);
+
+        String message = String.format("닉네임이 변경되었습니다. 다음 변경 가능일은 %s 입니다.", formattedDate);
+        return ResponseEntity.ok(ApiResponse.success(message, responseDto));
     }
 
     @Operation(summary = "비밀번호 변경", description = "로그인한 사용자의 비밀번호를 변경합니다.", security = {@SecurityRequirement(name = "bearer-key")})

--- a/src/main/java/com/even/zaro/controller/UserController.java
+++ b/src/main/java/com/even/zaro/controller/UserController.java
@@ -47,7 +47,7 @@ public class UserController {
     }
 
     @Operation(summary = "비밀번호 변경", description = "로그인한 사용자의 비밀번호를 변경합니다.", security = {@SecurityRequirement(name = "bearer-key")})
-    @PatchMapping("/password")
+    @PatchMapping("/me/password")
     public ResponseEntity<ApiResponse<Void>> updatePassword(
             @RequestBody UpdatePasswordRequestDto requestDto,
             @AuthenticationPrincipal JwtUserInfoDto userInfoDto) {

--- a/src/main/java/com/even/zaro/dto/user/UpdateNicknameRequestDto.java
+++ b/src/main/java/com/even/zaro/dto/user/UpdateNicknameRequestDto.java
@@ -1,0 +1,10 @@
+package com.even.zaro.dto.user;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class UpdateNicknameRequestDto {
+    private String newNickname;
+}

--- a/src/main/java/com/even/zaro/dto/user/UpdateNicknameRequestDto.java
+++ b/src/main/java/com/even/zaro/dto/user/UpdateNicknameRequestDto.java
@@ -1,10 +1,17 @@
 package com.even.zaro.dto.user;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
 public class UpdateNicknameRequestDto {
+
+    @Schema(description = "새 닉네임", example = "이브니짱")
+    @NotBlank
+    @Pattern(regexp = "^[a-zA-Z0-9가-힣]{2,12}$")
     private String newNickname;
 }

--- a/src/main/java/com/even/zaro/dto/user/UpdateNicknameResponseDto.java
+++ b/src/main/java/com/even/zaro/dto/user/UpdateNicknameResponseDto.java
@@ -1,0 +1,14 @@
+package com.even.zaro.dto.user;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class UpdateNicknameResponseDto {
+
+    private String nickname;
+    private LocalDateTime nextAvailableChangeDate;
+}

--- a/src/main/java/com/even/zaro/dto/user/UpdateNicknameResponseDto.java
+++ b/src/main/java/com/even/zaro/dto/user/UpdateNicknameResponseDto.java
@@ -1,5 +1,6 @@
 package com.even.zaro.dto.user;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -9,6 +10,9 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 public class UpdateNicknameResponseDto {
 
+    @Schema(description = "변경된 닉네임", example = "새닉네임")
     private String nickname;
+
+    @Schema(description = "다음 닉네임 변경 가능 일시", example = "2025-06-13T12:00:00")
     private LocalDateTime nextAvailableChangeDate;
 }

--- a/src/main/java/com/even/zaro/entity/User.java
+++ b/src/main/java/com/even/zaro/entity/User.java
@@ -83,6 +83,9 @@ public class User {
     @Column(name = "provider_id")
     private String providerId;
 
+    @Column(name = "last_nickname_updated_at")
+    private LocalDateTime lastNicknameUpdatedAt;
+
     public void updateLastLoginAt(LocalDateTime time) {
         this.lastLoginAt = time;
     }

--- a/src/main/java/com/even/zaro/entity/User.java
+++ b/src/main/java/com/even/zaro/entity/User.java
@@ -94,6 +94,14 @@ public class User {
         this.status = Status.ACTIVE;
     }
 
+    public void updateNickname(String newNickname) {
+        this.nickname = newNickname;
+    }
+
+    public void updateLastNicknameUpdatedAt(LocalDateTime time) {
+        this.lastNicknameUpdatedAt = time;
+    }
+
     public void updatePassword(String encodedPassword) {
         this.password = encodedPassword;
     }

--- a/src/main/java/com/even/zaro/global/ErrorCode.java
+++ b/src/main/java/com/even/zaro/global/ErrorCode.java
@@ -32,7 +32,7 @@ public enum ErrorCode {
     INVALID_PASSWORD_FORMAT(HttpStatus.BAD_REQUEST, "비밀번호는 대문자, 소문자, 숫자, 특수문자를 포함한 6자 이상이어야 합니다."),
 
     NICKNAME_REQUIRED(HttpStatus.BAD_REQUEST, "닉네임은 필수 입력 값입니다."),
-    INVALID_NICKNAME(HttpStatus.BAD_REQUEST, "닉네임은 2-12자, 영문, 한글, 숫자, -, _만 가능합니다."),
+    INVALID_NICKNAME_FORMAT(HttpStatus.BAD_REQUEST, "닉네임은 2-12자, 영문, 한글, 숫자, -, _만 가능합니다."),
     NICKNAME_ALREADY_EXISTED(HttpStatus.CONFLICT, "이미 사용 중인 닉네임입니다."),
 
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),

--- a/src/main/java/com/even/zaro/global/ErrorCode.java
+++ b/src/main/java/com/even/zaro/global/ErrorCode.java
@@ -60,6 +60,9 @@ public enum ErrorCode {
     CURRENT_PASSWORD_REQUIRED(HttpStatus.BAD_REQUEST, "현재 비밀번호는 필수 입력 값입니다."),
     CURRENT_PASSWORD_WRONG(HttpStatus.FORBIDDEN, "현재 비밀번호가 올바르지 않습니다."),
     CURRENT_PASSWORD_EQUALS_NEW_PASSWORD(HttpStatus.BAD_REQUEST,"이전과 다른 비밀번호를 입력해주세요."),
+    NEW_NICKNAME_REQUIRED(HttpStatus.BAD_REQUEST, "새 닉네임을 입력해주세요."),
+    NEW_NICKNAME_EQUALS_ORIGINAL_NICKNAME(HttpStatus.BAD_REQUEST, "이전 닉네임과 다른 닉네임을 입력해주세요."),
+    NICKNAME_UPDATE_COOLDOWN(HttpStatus.CONFLICT, "닉네임은 최근 변경일로부터 14일 후에 변경할 수 있습니다."),
 
     // 알림 Notification
     NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "조회된 알림이 없습니다."),

--- a/src/main/java/com/even/zaro/global/exception/CustomException.java
+++ b/src/main/java/com/even/zaro/global/exception/CustomException.java
@@ -23,5 +23,11 @@ public class CustomException extends RuntimeException {
         this.message = errorCode.getDefaultMessage();
     }
 
+    public CustomException(ErrorCode errorCode, String customMessage) {
+        super(customMessage);
+        this.code = errorCode.getCode();
+        this.status = errorCode.getHttpStatus();
+        this.message = customMessage;
+    }
 
 }

--- a/src/main/java/com/even/zaro/global/exception/user/UserException.java
+++ b/src/main/java/com/even/zaro/global/exception/user/UserException.java
@@ -13,4 +13,9 @@ public class UserException extends CustomException {
         super(errorCode);
         this.errorCode = errorCode;
     }
+
+    public UserException(ErrorCode errorCode, String customMessage) {
+        super(errorCode, errorCode.getDefaultMessage() + " " + customMessage);
+        this.errorCode = errorCode;
+    }
 }

--- a/src/main/java/com/even/zaro/service/AuthService.java
+++ b/src/main/java/com/even/zaro/service/AuthService.java
@@ -59,7 +59,7 @@ public class AuthService {
             throw new UserException(ErrorCode.NICKNAME_REQUIRED);
         }
         if (!Pattern.matches(NICKNAME_REGEX, nickname)) {
-            throw new UserException(ErrorCode.INVALID_NICKNAME);
+            throw new UserException(ErrorCode.INVALID_NICKNAME_FORMAT);
         }
 
         // 중복 확인

--- a/src/main/java/com/even/zaro/service/UserService.java
+++ b/src/main/java/com/even/zaro/service/UserService.java
@@ -15,6 +15,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.regex.Pattern;
 
 @Service
@@ -75,11 +76,16 @@ public class UserService {
         }
 
         LocalDateTime now = LocalDateTime.now();
-        boolean canUpdate = user.getLastNicknameUpdatedAt() == null
-                || user.getLastNicknameUpdatedAt().plusDays(14).isBefore(now);
+        LocalDateTime lastNicknameUpdatedAt = user.getLastNicknameUpdatedAt();
+
+        boolean canUpdate = lastNicknameUpdatedAt == null
+                || lastNicknameUpdatedAt.plusDays(14).isBefore(now);
 
         if (!canUpdate) {
-            throw new UserException(ErrorCode.NICKNAME_UPDATE_COOLDOWN);
+            LocalDateTime nextAvailableDate = lastNicknameUpdatedAt.plusDays(14);
+            String formatted = nextAvailableDate.format(DateTimeFormatter.ofPattern("yyyy년 MM월 dd일"));
+            throw new UserException(ErrorCode.NICKNAME_UPDATE_COOLDOWN,
+                    String.format("%s 이후에 다시 변경할 수 있습니다.", formatted));
         }
 
         user.updateNickname(newNickname);

--- a/src/test/java/com/even/zaro/service/UserServiceTest.java
+++ b/src/test/java/com/even/zaro/service/UserServiceTest.java
@@ -1,5 +1,7 @@
 package com.even.zaro.service;
 
+import com.even.zaro.dto.user.UpdateNicknameRequestDto;
+import com.even.zaro.dto.user.UpdateNicknameResponseDto;
 import com.even.zaro.dto.user.UpdatePasswordRequestDto;
 import com.even.zaro.entity.Status;
 import com.even.zaro.entity.User;
@@ -15,6 +17,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -31,6 +34,103 @@ class UserServiceTest {
 
     @Mock
     private PasswordEncoder passwordEncoder;
+
+    @Nested
+    class updateNicknameTest {
+        private User user;
+
+        static User createTestUser() {
+            return User.builder()
+                    .id(1L)
+                    .status(Status.ACTIVE)
+                    .nickname("기존닉네임")
+                    .build();
+        }
+
+        @BeforeEach
+        void setUp() {
+            user = createTestUser();
+            when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+        }
+
+        @Test
+        void successfully_updated_nickname() {
+            UpdateNicknameRequestDto requestDto = new UpdateNicknameRequestDto("새닉네임");
+
+            UpdateNicknameResponseDto responseDto = userService.updateNickname(1L, requestDto);
+
+            assertEquals("새닉네임", responseDto.getNickname());
+            assertNotNull(user.getLastNicknameUpdatedAt());
+        }
+
+        @Test
+        void shouldThrowException_whenUserDoesNotExist() {
+            UpdateNicknameRequestDto requestDto = new UpdateNicknameRequestDto("새닉네임");
+            when(userRepository.findById(1L)).thenReturn(Optional.empty());
+
+            UserException ex = assertThrows(UserException.class, () -> userService.updateNickname(1L, requestDto));
+
+            assertEquals(ErrorCode.USER_NOT_FOUND, ex.getErrorCode());
+        }
+
+        @Test
+        void shouldThrowException_whenUserIsNotVerified() {
+            user.changeStatus(Status.PENDING);
+            when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+            UpdateNicknameRequestDto requestDto = new UpdateNicknameRequestDto("새닉네임");
+
+            UserException ex = assertThrows(UserException.class, () -> userService.updateNickname(1L, requestDto));
+
+            assertEquals(ErrorCode.MAIL_NOT_VERIFIED, ex.getErrorCode());
+        }
+
+        @Test
+        void shouldThrowException_whenNewNicknameIsBlank() {
+            UpdateNicknameRequestDto requestDto = new UpdateNicknameRequestDto("");
+
+            UserException ex = assertThrows(UserException.class, () -> userService.updateNickname(1L, requestDto));
+
+            assertEquals(ErrorCode.NEW_NICKNAME_REQUIRED, ex.getErrorCode());
+        }
+
+        @Test
+        void shouldThrowException_whenNicknameFormatIsInvalid() {
+            UpdateNicknameRequestDto requestDto = new UpdateNicknameRequestDto("형식파괴!!!");
+
+            UserException ex = assertThrows(UserException.class, () -> userService.updateNickname(1L, requestDto));
+
+            assertEquals(ErrorCode.INVALID_NICKNAME_FORMAT, ex.getErrorCode());
+        }
+
+        @Test
+        void shouldThrowException_whenNicknameAlreadyExists() {
+            UpdateNicknameRequestDto requestDto = new UpdateNicknameRequestDto("이미있니");
+            when(userRepository.existsByNickname("이미있니")).thenReturn(true);
+
+            UserException ex = assertThrows(UserException.class, () -> userService.updateNickname(1L, requestDto));
+
+            assertEquals(ErrorCode.NICKNAME_ALREADY_EXISTED, ex.getErrorCode());
+        }
+
+        @Test
+        void shouldThrowException_whenNewNicknameIsSameAsOriginalOne() {
+            UpdateNicknameRequestDto requestDto = new UpdateNicknameRequestDto("기존닉네임");
+
+            UserException ex = assertThrows(UserException.class, () -> userService.updateNickname(1L, requestDto));
+
+            assertEquals(ErrorCode.NEW_NICKNAME_EQUALS_ORIGINAL_NICKNAME, ex.getErrorCode());
+        }
+
+        @Test
+        void shouldThrowException_whenNicknameChangedWithinRestrictionPeriod() {
+            user.updateLastNicknameUpdatedAt(LocalDateTime.now().minusDays(13));
+            UpdateNicknameRequestDto requestDto = new UpdateNicknameRequestDto("새닉네임");
+
+            UserException ex = assertThrows(UserException.class, () -> userService.updateNickname(1L, requestDto));
+
+            assertEquals(ErrorCode.NICKNAME_UPDATE_COOLDOWN, ex.getErrorCode());
+        }
+    }
 
     @Nested
     class updatePasswordTest {

--- a/src/test/java/com/even/zaro/service/UserServiceTest.java
+++ b/src/test/java/com/even/zaro/service/UserServiceTest.java
@@ -37,17 +37,17 @@ class UserServiceTest {
 
         private User user;
 
-        static User createTestUser(Status status, String password) {
+        static User createTestUser() {
             return User.builder()
                     .id(1L)
-                    .status(status)
-                    .password(password)
+                    .status(Status.ACTIVE)
+                    .password("OldEncoded1!")
                     .build();
         }
 
         @BeforeEach
         void setUp() {
-            user = createTestUser(Status.ACTIVE, "OldEncoded1!");
+            user = createTestUser();
             when(userRepository.findById(1L)).thenReturn(Optional.of(user));
         }
 

--- a/src/test/java/com/even/zaro/service/UserServiceTest.java
+++ b/src/test/java/com/even/zaro/service/UserServiceTest.java
@@ -72,9 +72,7 @@ class UserServiceTest {
             when(userRepository.findById(1L)).thenReturn(Optional.of(user));
             UpdatePasswordRequestDto requestDto = new UpdatePasswordRequestDto("Old1234!", "New1234!");
 
-            UserException ex = assertThrows(UserException.class, () -> {
-                userService.updatePassword(1L, requestDto);
-            });
+            UserException ex = assertThrows(UserException.class, () -> userService.updatePassword(1L, requestDto));
 
             assertEquals(ErrorCode.MAIL_NOT_VERIFIED, ex.getErrorCode());
         }
@@ -83,9 +81,7 @@ class UserServiceTest {
         void shouldThrowException_whenCurrentPasswordIsBlank() {
             UpdatePasswordRequestDto requestDto = new UpdatePasswordRequestDto("", "New1234!");
 
-            UserException ex = assertThrows(UserException.class, () -> {
-                userService.updatePassword(1L, requestDto);
-            });
+            UserException ex = assertThrows(UserException.class, () -> userService.updatePassword(1L, requestDto));
 
             assertEquals(ErrorCode.CURRENT_PASSWORD_REQUIRED, ex.getErrorCode());
         }
@@ -95,9 +91,7 @@ class UserServiceTest {
             UpdatePasswordRequestDto requestDto = new UpdatePasswordRequestDto("ThisIsWrong1!", "New1234!");
             when(passwordEncoder.matches("ThisIsWrong1!", "OldEncoded1!")).thenReturn(false);
 
-            UserException ex = assertThrows(UserException.class, () -> {
-                userService.updatePassword(1L, requestDto);
-            });
+            UserException ex = assertThrows(UserException.class, () -> userService.updatePassword(1L, requestDto));
 
             assertEquals(ErrorCode.CURRENT_PASSWORD_WRONG, ex.getErrorCode());
         }
@@ -107,9 +101,7 @@ class UserServiceTest {
             UpdatePasswordRequestDto requestDto = new UpdatePasswordRequestDto("Old1234!", "");
             when(passwordEncoder.matches("Old1234!", "OldEncoded1!")).thenReturn(true);
 
-            UserException ex = assertThrows(UserException.class, () -> {
-                userService.updatePassword(1L, requestDto);
-            });
+            UserException ex = assertThrows(UserException.class, () -> userService.updatePassword(1L, requestDto));
 
             assertEquals(ErrorCode.PASSWORD_REQUIRED, ex.getErrorCode());
         }
@@ -119,9 +111,7 @@ class UserServiceTest {
             UpdatePasswordRequestDto requestDto = new UpdatePasswordRequestDto("Old1234!", "wrongFormat");
             when(passwordEncoder.matches("Old1234!", "OldEncoded1!")).thenReturn(true);
 
-            UserException ex = assertThrows(UserException.class, () -> {
-                userService.updatePassword(1L, requestDto);
-            });
+            UserException ex = assertThrows(UserException.class, () -> userService.updatePassword(1L, requestDto));
 
             assertEquals(ErrorCode.INVALID_PASSWORD_FORMAT, ex.getErrorCode());
         }
@@ -131,9 +121,7 @@ class UserServiceTest {
             UpdatePasswordRequestDto requestDto = new UpdatePasswordRequestDto("Old1234!", "Old1234!");
             when(passwordEncoder.matches("Old1234!", "OldEncoded1!")).thenReturn(true);
 
-            UserException ex = assertThrows(UserException.class, () -> {
-                userService.updatePassword(1L, requestDto);
-            });
+            UserException ex = assertThrows(UserException.class, () -> userService.updatePassword(1L, requestDto));
 
             assertEquals(ErrorCode.CURRENT_PASSWORD_EQUALS_NEW_PASSWORD, ex.getErrorCode());
         }


### PR DESCRIPTION
## 📌 작업 개요
- 닉네임 변경 API 

---

## ✨ 주요 변경 사항
- 닉네임 변경 API 



---

## 🖼️ 기능 살펴 보기
> 포스트맨 요청 응답 스크린샷
- [x] API 문서(요청, 응답)와 일치하는지 확인 - 필요시 API 문서 수정 가능
닉네임 변경시
![image](https://github.com/user-attachments/assets/dbfc117d-4e40-4c6e-bf0f-60546c47b25e)

프론트에서 토스트로 띄우시는 것 같아서 예외처리에도 날짜 추가했습니다.
![image](https://github.com/user-attachments/assets/76cb77c1-0da8-4a0d-acbf-7cfaf3122674)


---

## ✅ 작업 체크리스트
- [x] API 테스트 완료 (POSTMAN)
- [x] 스웨거 ui 관련 코드 추가
- [x] 기능별 예외 케이스 고려
- [x] log.info / 불필요한 주석 제거
- [x] 변수명, 클래스명, 메서드명 의미있게 작성
- [x] 반복 코드 메서드로 분리

---

## 📂 테스트 방법
- [x] 테스트 코드 작성
- [x] 시나리오 기반 테스트 유무
  - 성공
     - [x]  실제 변경 결과
     - [x] lastNicknameUpatedAt 검증
  - 예외처리 7
     - [x]  유저 정보가 없는 경우 (userId로 조회 실패)
     - [x]  PENDING 사용자
     - [x]  요청 닉네임이 비어 있음
     - [x]  요청 닉네임 형식 오류
     - [x]  이미 존재하는 닉네임
     - [x]  기존 닉네임과 동일
     - [x]  14일 이내 재수정 시도
![image](https://github.com/user-attachments/assets/9e2f9703-0de2-4a80-8ffb-cb7d575cdf20)


---

## 💬 기타 참고 사항
- 비밀번호 변경, 닉네임 변경 엔드포인트 바꿨습니다. +restful함 추가

---

## 📎 관련 이슈 / 문서

