### PR TITLE
fix/profile-test : 변경된 getUserPosts메서드 리턴타입에 맞게 testCode 수정

### DIFF
--- a/src/test/java/com/even/zaro/profile/ProfileApiTest.java
+++ b/src/test/java/com/even/zaro/profile/ProfileApiTest.java
@@ -1,5 +1,6 @@
 package com.even.zaro.profile;
 
+import com.even.zaro.dto.PageResponse;
 import com.even.zaro.dto.profile.FollowerFollowingListDto;
 import com.even.zaro.dto.profile.UserCommentDto;
 import com.even.zaro.dto.profile.UserPostDto;
@@ -67,7 +68,7 @@ public class ProfileApiTest {
         createPost(user, "제목2", "내용2");
 
         // when
-        Page<UserPostDto> posts = profileService.getUserPosts(user.getId(), PageRequest.of(0, 10));
+        PageResponse<UserPostDto> posts = profileService.getUserPosts(user.getId(), PageRequest.of(0, 10));
 
         // then
         assertThat(posts.getContent()).hasSize(2);


### PR DESCRIPTION
## 📌 작업 개요
- 변경된 getUserPosts메서드 리턴타입에 맞게 testCode 수정

---

## ✨ 주요 변경 사항
- 유저가_쓴_게시물_목록_조회_성공() 테스트 메서드 내부, getUsersPost호출 코드 최신에 맞게 수정

---

## 🖼️ 기능 살펴 보기
> 빨간 줄 제거됨, 수정된 케이스 포함한 다시 전체 테스트케이스 정상 통과됨
![image](https://github.com/user-attachments/assets/c6169900-9e97-4cd7-aad7-4d9c2b6ffe56)

---

## ✅ 작업 체크리스트
- [x] testCode 수정

---

## 📂 테스트 방법
- [x] ProfileApiTest 전체 테스트 실행

---

## 💬 기타 참고 사항
- 프로필 기능 내 공통 Page 응답 dto 리팩토링 이후, TestCode는 수정하지 않아서 뜬 오류..
- 변경사항 있을 경우 testCode도 잊지않고 같이 수정하도록 해야겠습니다, 알려주신 @nahyukk 께 Thanks를...💗

---

## 📎 관련 이슈 / 문서
- 관련 이슈 번호: #91 
