### PR TITLE
Feat/update profile 프로필(계정정보) 변경 API

### DIFF
--- a/src/main/java/com/even/zaro/controller/UserController.java
+++ b/src/main/java/com/even/zaro/controller/UserController.java
@@ -1,10 +1,7 @@
 package com.even.zaro.controller;
 
 import com.even.zaro.dto.jwt.JwtUserInfoDto;
-import com.even.zaro.dto.user.UpdateNicknameRequestDto;
-import com.even.zaro.dto.user.UpdateNicknameResponseDto;
-import com.even.zaro.dto.user.UpdatePasswordRequestDto;
-import com.even.zaro.dto.user.UserInfoResponseDto;
+import com.even.zaro.dto.user.*;
 import com.even.zaro.global.ApiResponse;
 import com.even.zaro.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -44,6 +41,16 @@ public class UserController {
 
         String message = String.format("닉네임이 변경되었습니다. 다음 변경 가능일은 %s 입니다.", formattedDate);
         return ResponseEntity.ok(ApiResponse.success(message, responseDto));
+    }
+
+    @Operation(summary = "프로필 변경", description = "로그인한 사용자의 프로필(생일, 자취 시작일, 성별, mbti를 변경합니다.", security = {@SecurityRequirement(name = "bearer-key")})
+    @PatchMapping("/me/profile")
+    public ResponseEntity<ApiResponse<UpdateProfileResponseDto>> updateProfile(
+            @RequestBody UpdateProfileRequestDto requestDto,
+            @AuthenticationPrincipal JwtUserInfoDto userInfoDto
+    ) {
+        UpdateProfileResponseDto responseDto = userService.updateProfile(userInfoDto.getUserId(), requestDto);
+        return ResponseEntity.ok(ApiResponse.success("프로필이 변경되었습니다.", responseDto));
     }
 
     @Operation(summary = "비밀번호 변경", description = "로그인한 사용자의 비밀번호를 변경합니다.", security = {@SecurityRequirement(name = "bearer-key")})

--- a/src/main/java/com/even/zaro/dto/profile/UserProfileDto.java
+++ b/src/main/java/com/even/zaro/dto/profile/UserProfileDto.java
@@ -1,5 +1,6 @@
 package com.even.zaro.dto.profile;
 
+import com.even.zaro.entity.Mbti;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -26,7 +27,7 @@ public class UserProfileDto {
     private LocalDate liveAloneDate;
 
     @Schema(description = "사용자 MBTI", example = "ENTP")
-    private String mbti;
+    private Mbti mbti;
 
     @Schema(description = "작성한 게시글 수", example = "10")
     private int postCount;

--- a/src/main/java/com/even/zaro/dto/user/UpdateProfileRequestDto.java
+++ b/src/main/java/com/even/zaro/dto/user/UpdateProfileRequestDto.java
@@ -1,0 +1,26 @@
+package com.even.zaro.dto.user;
+
+import com.even.zaro.entity.Gender;
+import com.even.zaro.entity.Mbti;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+@AllArgsConstructor
+public class UpdateProfileRequestDto {
+
+    @Schema(description = "생일", example = "1997-05-15", nullable = true)
+    private LocalDate birthday;
+
+    @Schema(description = "자취 시작일", example = "2024-01-01", nullable = true)
+    private LocalDate liveAloneDate;
+
+    @Schema(description = "성별", example = "MALE", nullable = true)
+    private Gender gender;
+
+    @Schema(description = "MBTI", example = "INFP", nullable = true)
+    private Mbti mbti;
+}

--- a/src/main/java/com/even/zaro/dto/user/UpdateProfileResponseDto.java
+++ b/src/main/java/com/even/zaro/dto/user/UpdateProfileResponseDto.java
@@ -1,0 +1,26 @@
+package com.even.zaro.dto.user;
+
+import com.even.zaro.entity.Gender;
+import com.even.zaro.entity.Mbti;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+@AllArgsConstructor
+public class UpdateProfileResponseDto {
+
+    @Schema(description = "생일", example = "1997-05-15", nullable = true)
+    private LocalDate birthday;
+
+    @Schema(description = "자취 시작일", example = "2024-01-01", nullable = true)
+    private LocalDate liveAloneDate;
+
+    @Schema(description = "성별", example = "MALE", nullable = true)
+    private Gender gender;
+
+    @Schema(description = "MBTI", example = "INFP", nullable = true)
+    private Mbti mbti;
+}

--- a/src/main/java/com/even/zaro/dto/user/UserInfoResponseDto.java
+++ b/src/main/java/com/even/zaro/dto/user/UserInfoResponseDto.java
@@ -1,5 +1,7 @@
 package com.even.zaro.dto.user;
 
+import com.even.zaro.entity.Gender;
+import com.even.zaro.entity.Mbti;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -31,10 +33,10 @@ public class UserInfoResponseDto {
     private LocalDate liveAloneDate;
 
     @Schema(description = "성별", example = "MALE", nullable = true)
-    private String gender;
+    private Gender gender;
 
     @Schema(description = "MBTI", example = "INFP", nullable = true)
-    private String mbti;
+    private Mbti mbti;
 
     @Schema(description = "계정 생성일", example = "2024-01-01T12:00:00")
     private LocalDateTime createdAt;

--- a/src/main/java/com/even/zaro/dto/user/UserInfoResponseDto.java
+++ b/src/main/java/com/even/zaro/dto/user/UserInfoResponseDto.java
@@ -24,7 +24,7 @@ public class UserInfoResponseDto {
     @Schema(description = "프로필 이미지 URL", example = "/images/profile/2-uuid.png")
     private String profileImage;
 
-    @Schema(description = "생일", example = "1997-05-15")
+    @Schema(description = "생일", example = "1997-05-15", nullable = true)
     private LocalDate birthday;
 
     @Schema(description = "자취 시작일", example = "2024-01-01", nullable = true)

--- a/src/main/java/com/even/zaro/entity/Gender.java
+++ b/src/main/java/com/even/zaro/entity/Gender.java
@@ -1,0 +1,5 @@
+package com.even.zaro.entity;
+
+public enum Gender {
+    MALE, FEMALE, OTHER, UNKNOWN
+}

--- a/src/main/java/com/even/zaro/entity/Gender.java
+++ b/src/main/java/com/even/zaro/entity/Gender.java
@@ -1,5 +1,13 @@
 package com.even.zaro.entity;
 
 public enum Gender {
-    MALE, FEMALE, OTHER, UNKNOWN
+    MALE, FEMALE, OTHER, UNKNOWN;
+
+    public static Gender fromKakao(String kakaoGender) {
+        return switch (kakaoGender) {
+            case "male" -> MALE;
+            case "female" -> FEMALE;
+            default -> UNKNOWN;
+        };
+    }
 }

--- a/src/main/java/com/even/zaro/entity/Mbti.java
+++ b/src/main/java/com/even/zaro/entity/Mbti.java
@@ -1,0 +1,9 @@
+package com.even.zaro.entity;
+
+public enum Mbti {
+    ISTJ, ISFJ, INFJ, INTJ,
+    ISTP, ISFP, INFP, INTP,
+    ESTP, ESFP, ENFP, ENTP,
+    ESTJ, ESFJ, ENFJ, ENTJ,
+    UNKNOWN
+}

--- a/src/main/java/com/even/zaro/entity/User.java
+++ b/src/main/java/com/even/zaro/entity/User.java
@@ -104,6 +104,22 @@ public class User {
         this.lastNicknameUpdatedAt = time;
     }
 
+    public void updateBirthday(LocalDate birthday) {
+        this.birthday = birthday;
+    }
+
+    public void updateLiveAloneDate(LocalDate liveAloneDate) {
+        this.liveAloneDate = liveAloneDate;
+    }
+
+    public void updateGender(Gender gender) {
+        this.gender = gender;
+    }
+
+    public void updateMbti(Mbti mbti) {
+        this.mbti = mbti;
+    }
+
     public void updatePassword(String encodedPassword) {
         this.password = encodedPassword;
     }

--- a/src/main/java/com/even/zaro/entity/User.java
+++ b/src/main/java/com/even/zaro/entity/User.java
@@ -47,11 +47,13 @@ public class User {
     @Column(name = "live_alone_date")
     private LocalDate liveAloneDate;
 
+    @Enumerated(EnumType.STRING)
     @Column(name = "gender")
-    private String gender;
+    private Gender gender;
 
+    @Enumerated(EnumType.STRING)
     @Column(name = "mbti",  length = 4)
-    private String mbti;
+    private Mbti mbti;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "status", nullable = false)

--- a/src/main/java/com/even/zaro/service/AuthService.java
+++ b/src/main/java/com/even/zaro/service/AuthService.java
@@ -108,7 +108,7 @@ public class AuthService {
         String email = kakaoUser.getKakaoAccount().getEmail();
         String nickname = kakaoUser.getKakaoAccount().getProfile().getNickname();
         String profileImage = kakaoUser.getKakaoAccount().getProfile().getProfileImageUrl();
-        String gender = kakaoUser.getKakaoAccount().getGender();
+        Gender gender = Gender.fromKakao(kakaoUser.getKakaoAccount().getGender());
 
         // 이메일, 프로필 사진이 없는 경우 더미로 추가
         String safeEmail = (email != null) ? email : "kakao_" + kakaoId + "@kakao-user.com";

--- a/src/main/java/com/even/zaro/service/UserService.java
+++ b/src/main/java/com/even/zaro/service/UserService.java
@@ -1,9 +1,6 @@
 package com.even.zaro.service;
 
-import com.even.zaro.dto.user.UpdateNicknameRequestDto;
-import com.even.zaro.dto.user.UpdateNicknameResponseDto;
-import com.even.zaro.dto.user.UpdatePasswordRequestDto;
-import com.even.zaro.dto.user.UserInfoResponseDto;
+import com.even.zaro.dto.user.*;
 import com.even.zaro.entity.Status;
 import com.even.zaro.entity.User;
 import com.even.zaro.global.ErrorCode;
@@ -94,6 +91,28 @@ public class UserService {
         return new UpdateNicknameResponseDto(
                 newNickname,
                 user.getLastNicknameUpdatedAt().plusDays(14)
+        );
+    }
+
+    @Transactional
+    public UpdateProfileResponseDto updateProfile(Long userId, UpdateProfileRequestDto requestDto) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserException(ErrorCode.USER_NOT_FOUND));
+
+        if (user.getStatus() == Status.PENDING) {
+            throw new UserException(ErrorCode.MAIL_NOT_VERIFIED);
+        }
+
+        user.updateBirthday(requestDto.getBirthday());
+        user.updateLiveAloneDate(requestDto.getLiveAloneDate());
+        user.updateGender(requestDto.getGender());
+        user.updateMbti(requestDto.getMbti());
+
+        return new UpdateProfileResponseDto(
+                user.getBirthday(),
+                user.getLiveAloneDate(),
+                user.getGender(),
+                user.getMbti()
         );
     }
 


### PR DESCRIPTION
## 📌 작업 개요
- 프로필(계정정보) 변경 API

---

## ✨ 주요 변경 사항
- 프로필(계정정보) 변경 API
    - gender, mbti enum으로 변경


---

## 🖼️ 기능 살펴 보기
> 포스트맨 요청 응답 스크린샷
- [x] API 문서(요청, 응답)와 일치하는지 확인 - 필요시 API 문서 수정 가능
![image](https://github.com/user-attachments/assets/e1834dad-da08-4fb9-be82-b17d7101dbc0)

---

## ✅ 작업 체크리스트
- [x] API 테스트 완료 (POSTMAN)
- [x] 스웨거 ui 관련 코드 추가
- [x] 기능별 예외 케이스 고려
- [x] log.info / 불필요한 주석 제거
- [x] 변수명, 클래스명, 메서드명 의미있게 작성
- [x] 반복 코드 메서드로 분리

---

## 📂 테스트 방법
- [x] 테스트 코드 작성
- [x] 시나리오 기반 테스트 유무
    - 성공
        - 전체 변경
        - 부분 변경 (부분 null)
    - userId 예외
    - status PENDING 예외

![image](https://github.com/user-attachments/assets/bb3a96f2-8b31-4e77-a7b9-89b89579451c)

---

## 💬 기타 참고 사항
- enum 변경으로 기존 로직 중 변경해야 하는 부분 같이 변경했습니다.
    - UserProfileDto MBTI enum 으로 수정 @yoorym-kim 
    - 카카오 로그인 - 성별 enum 수정
    - 내정보조회 dto - 성별, mbti enum 수정
---

## 📎 관련 이슈 / 문서

