### PR TITLE
Feat/update profile image 프로필 이미지 변경 API

### DIFF
--- a/src/main/java/com/even/zaro/controller/UserController.java
+++ b/src/main/java/com/even/zaro/controller/UserController.java
@@ -28,6 +28,16 @@ public class UserController {
         return ResponseEntity.ok(ApiResponse.success("내 정보 조회에 성공했습니다.", responseDto));
     }
 
+    @Operation(summary = "프로필 이미지 변경", description = "로그인한 사용자의 프로필 이미지를 변경합니다.", security = {@SecurityRequirement(name = "bearer-key")})
+    @PatchMapping("/me/profileImage")
+    public ResponseEntity<ApiResponse<UpdateProfileImageResponseDto>> updateProfileImage(
+            @RequestBody UpdateProfileImageRequestDto requestDto,
+            @AuthenticationPrincipal JwtUserInfoDto userInfoDto
+    ) {
+        UpdateProfileImageResponseDto responseDto = userService.updateProfileImage(userInfoDto.getUserId(), requestDto);
+        return ResponseEntity.ok(ApiResponse.success("프로필 이미지가 변경되었습니다.", responseDto));
+    }
+
     @Operation(summary = "닉네임 변경", description = "로그인한 사용자의 닉네임을 변경합니다.", security = {@SecurityRequirement(name = "bearer-key")})
     @PatchMapping("/me/nickname")
     public ResponseEntity<ApiResponse<UpdateNicknameResponseDto>> updateNickname(

--- a/src/main/java/com/even/zaro/dto/user/UpdateProfileImageRequestDto.java
+++ b/src/main/java/com/even/zaro/dto/user/UpdateProfileImageRequestDto.java
@@ -1,0 +1,12 @@
+package com.even.zaro.dto.user;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class UpdateProfileImageRequestDto {
+    @Schema(description = "프로필 이미지", example = "/images/profile/2-uuid.png")
+    private String profileImage;
+}

--- a/src/main/java/com/even/zaro/dto/user/UpdateProfileImageResponseDto.java
+++ b/src/main/java/com/even/zaro/dto/user/UpdateProfileImageResponseDto.java
@@ -1,0 +1,12 @@
+package com.even.zaro.dto.user;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class UpdateProfileImageResponseDto {
+    @Schema(description = "프로필 이미지", example = "/images/profile/2-uuid.png")
+    private String profileImage;
+}

--- a/src/main/java/com/even/zaro/entity/User.java
+++ b/src/main/java/com/even/zaro/entity/User.java
@@ -104,6 +104,10 @@ public class User {
         this.lastNicknameUpdatedAt = time;
     }
 
+    public void updateProfileImage(String profileImage) {
+        this.profileImage = profileImage;
+    }
+
     public void updateBirthday(LocalDate birthday) {
         this.birthday = birthday;
     }

--- a/src/main/java/com/even/zaro/service/UserService.java
+++ b/src/main/java/com/even/zaro/service/UserService.java
@@ -46,6 +46,20 @@ public class UserService {
     }
 
     @Transactional
+    public UpdateProfileImageResponseDto updateProfileImage(Long userId, UpdateProfileImageRequestDto requestDto) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserException(ErrorCode.USER_NOT_FOUND));
+
+        if (user.getStatus() == Status.PENDING) {
+            throw new UserException(ErrorCode.MAIL_NOT_VERIFIED);
+        }
+
+        user.updateProfileImage(requestDto.getProfileImage());
+
+        return new UpdateProfileImageResponseDto(user.getProfileImage());
+    }
+
+    @Transactional
     public UpdateNicknameResponseDto updateNickname(Long userId, UpdateNicknameRequestDto requestDto) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new UserException(ErrorCode.USER_NOT_FOUND));

--- a/src/test/java/com/even/zaro/service/UserServiceTest.java
+++ b/src/test/java/com/even/zaro/service/UserServiceTest.java
@@ -1,9 +1,6 @@
 package com.even.zaro.service;
 
-import com.even.zaro.dto.user.UpdateNicknameRequestDto;
-import com.even.zaro.dto.user.UpdateNicknameResponseDto;
-import com.even.zaro.dto.user.UpdatePasswordRequestDto;
-import com.even.zaro.dto.user.UpdateProfileRequestDto;
+import com.even.zaro.dto.user.*;
 import com.even.zaro.entity.Gender;
 import com.even.zaro.entity.Mbti;
 import com.even.zaro.entity.Status;
@@ -38,6 +35,54 @@ class UserServiceTest {
 
     @Mock
     private PasswordEncoder passwordEncoder;
+
+    @Nested
+    class updateProfileImageTest {
+        private User user;
+
+        static User createTestUser() {
+            return User.builder()
+                    .id(1L)
+                    .status(Status.ACTIVE)
+                    .build();
+        }
+
+        @BeforeEach
+        void setUp() {
+            user = createTestUser();
+            when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+        }
+
+        @Test
+        void successfully_updated_profileImage() {
+            UpdateProfileImageRequestDto requestDto = new UpdateProfileImageRequestDto("/images/profile/2-uuid.png");
+
+            UpdateProfileImageResponseDto responseDto = userService.updateProfileImage(1L, requestDto);
+
+            assertEquals("/images/profile/2-uuid.png", responseDto.getProfileImage());
+        }
+
+        @Test
+        void shouldThrowException_whenUserDoesNotExist() {
+            UpdateProfileImageRequestDto requestDto = new UpdateProfileImageRequestDto("/images/profile/2-uuid.png");
+            when(userRepository.findById(1L)).thenReturn(Optional.empty());
+
+            UserException ex = assertThrows(UserException.class, () -> userService.updateProfileImage(1L, requestDto));
+
+            assertEquals(ErrorCode.USER_NOT_FOUND, ex.getErrorCode());
+        }
+
+        @Test
+        void shouldThrowException_whenUserIsNotVerified() {
+            user.changeStatus(Status.PENDING);
+            when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+            UpdateProfileImageRequestDto requestDto = new UpdateProfileImageRequestDto("/images/profile/2-uuid.png");
+
+            UserException ex = assertThrows(UserException.class, () -> userService.updateProfileImage(1L, requestDto));
+
+            assertEquals(ErrorCode.MAIL_NOT_VERIFIED, ex.getErrorCode());
+        }
+    }
 
     @Nested
     class updateNicknameTest {


### PR DESCRIPTION
## 📌 작업 개요
- 프로필 이미지 변경 API

---

## ✨ 주요 변경 사항
- 프로필 이미지 변경 API

---

## 🖼️ 기능 살펴 보기
> 포스트맨 요청 응답 스크린샷
- [x] API 문서(요청, 응답)와 일치하는지 확인 - 필요시 API 문서 수정 가능
![image](https://github.com/user-attachments/assets/333b9224-4440-4092-b188-e82b8dfd1b5e)

---

## ✅ 작업 체크리스트
- [x] API 테스트 완료 (POSTMAN)
- [x] 스웨거 ui 관련 코드 추가
- [x] 기능별 예외 케이스 고려
- [x] log.info / 불필요한 주석 제거
- [x] 변수명, 클래스명, 메서드명 의미있게 작성
- [x] 반복 코드 메서드로 분리

---

## 📂 테스트 방법
- [x] 테스트 코드 작성
- [x] 시나리오 기반 테스트 유무
    - 성공
    - userId 예외
    - status PENDING 예외

![image](https://github.com/user-attachments/assets/0120f2d6-4fcf-404f-b5c0-c198079f5a8f)

---

## 💬 기타 참고 사항

---

## 📎 관련 이슈 / 문서

