### PR TITLE
fix: 댓글 리스트 조회 desc, asc 변동 안되는 버그 수정 - repository 메서드 문제

### DIFF
--- a/src/main/java/com/even/zaro/repository/CommentRepository.java
+++ b/src/main/java/com/even/zaro/repository/CommentRepository.java
@@ -15,7 +15,7 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
 
     Page<Comment> findByUserAndIsDeletedFalse(User user, Pageable pageable);
 
-    Page<Comment> findByPostIdAndIsDeletedFalseOrderByCreatedAtAsc(Long postId, Pageable pageable);
+    Page<Comment> findByPostIdAndIsDeletedFalse(Long postId, Pageable pageable);
 
     Optional<Comment> findByIdAndIsDeletedFalse(Long commentId);
 }

--- a/src/main/java/com/even/zaro/service/CommentService.java
+++ b/src/main/java/com/even/zaro/service/CommentService.java
@@ -73,7 +73,7 @@ public class CommentService {
             throw new PostException(ErrorCode.POST_NOT_FOUND);
         }
 
-        Page<CommentResponseDto> page = commentRepository.findByPostIdAndIsDeletedFalseOrderByCreatedAtAsc(postId, pageable)
+        Page<CommentResponseDto> page = commentRepository.findByPostIdAndIsDeletedFalse(postId, pageable)
                 .map(comment -> toDto(comment, currentUserId));
         return new PageResponse<>(page);
     }


### PR DESCRIPTION
## 📌 작업 개요
- 댓글 리스트 조회 desc, asc 변동 안되는 버그 수정

---

## ✨ 주요 변경 사항
- 댓글 리스트 조회 desc, asc 변동 안되는 버그 수정 
      - repository 메서드 문제

---

## 🖼️ 기능 살펴 보기
> 포스트맨 요청 응답 스크린샷
- [x] API 문서(요청, 응답)와 일치하는지 확인 - 필요시 API 문서 수정 가능

desc
![image](https://github.com/user-attachments/assets/8cab2ffa-c05d-41e8-a47b-3280f057b7b8)
asc
![image](https://github.com/user-attachments/assets/a8b71dcb-294c-46a5-bb85-ec7935301556)


---

## ✅ 작업 체크리스트
- [x] API 테스트 완료 (POSTMAN)
- [ ] 스웨거 ui 관련 코드 추가
- [ ] 기능별 예외 케이스 고려
- [ ] log.info / 불필요한 주석 제거
- [ ] 변수명, 클래스명, 메서드명 의미있게 작성
- [ ] 반복 코드 메서드로 분리

---

## 📂 테스트 방법
- [ ] 테스트 코드 작성
- [ ] 시나리오 기반 테스트 유무
    - ex: ID 중복 시 예외 처리 발생

---

## 💬 기타 참고 사항
- 프론트에서 버그 발견해주셨습니다.

---

## 📎 관련 이슈 / 문서

