### PR TITLE
Feat/rank : 실시간 인기 게시글 API 구현

### DIFF
--- a/src/main/java/com/even/zaro/config/security/SecurityConfig.java
+++ b/src/main/java/com/even/zaro/config/security/SecurityConfig.java
@@ -46,6 +46,7 @@ public class SecurityConfig {
                                 .requestMatchers(HttpMethod.GET, "/api/posts").permitAll()
                                 .requestMatchers(HttpMethod.GET, "/api/search").permitAll()
                                 .requestMatchers(HttpMethod.GET, "/api/search/es").permitAll() // search 로 합쳐질 예정
+                                .requestMatchers( "/api/posts/rank").permitAll()
                                 .requestMatchers("/api/profile/{userId}").permitAll()
                                 .requestMatchers("/api/es/reindex").permitAll()
 //                        .requestMatchers("/**").permitAll() // 전체 인증 없이 개발용

--- a/src/main/java/com/even/zaro/controller/PostController.java
+++ b/src/main/java/com/even/zaro/controller/PostController.java
@@ -144,6 +144,7 @@ public class PostController {
         return ResponseEntity.ok(ApiResponse.success("게시글 신고가 완료되었습니다.", response));
     }
 
+    @Operation(summary = "실시간 인기 게시글 조회", description = "좋아요 수 & 댓글 수 를 기반으로 계산하여 실시간 인기 게시글 10개를 조회합니다.")
     @GetMapping("/rank")
     public ApiResponse<?> getRankedPosts() {
         List<PostRankResponseDto> result = postService.getRankedPosts();

--- a/src/main/java/com/even/zaro/controller/PostController.java
+++ b/src/main/java/com/even/zaro/controller/PostController.java
@@ -24,6 +24,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
 import java.util.Map;
 
 @Tag(name = "게시판", description = "게시판 API")
@@ -141,6 +142,12 @@ public class PostController {
     ){
         ReportResponseDto response = postReportService.reportPost(postId, request, userInfoDto.getUserId());
         return ResponseEntity.ok(ApiResponse.success("게시글 신고가 완료되었습니다.", response));
+    }
+
+    @GetMapping("/rank")
+    public ApiResponse<?> getRankedPosts() {
+        List<PostRankResponseDto> result = postService.getRankedPosts();
+        return ApiResponse.success("실시간 인기 게시글이 확인 되었습니다.", Map.of("posts", result));
     }
 
 }

--- a/src/main/java/com/even/zaro/dto/post/PostRankResponseDto.java
+++ b/src/main/java/com/even/zaro/dto/post/PostRankResponseDto.java
@@ -1,6 +1,7 @@
 package com.even.zaro.dto.post;
 
 import com.even.zaro.entity.Post;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -8,10 +9,19 @@ import lombok.Getter;
 @Getter
 @Builder
 @AllArgsConstructor
+@Schema(description = "실시간 인기 게시글 응답 DTO")
 public class PostRankResponseDto {
+
+    @Schema(description = "게시글 ID", example = "1")
     private Long postId;
+
+    @Schema(description = "게시글 제목", example = "레몬 사세요 🍋")
     private String title;
+
+    @Schema(description = "좋아요 수", example = "5")
     private int likeCount;
+
+    @Schema(description = "댓글 수", example = "3")
     private int commentCount;
 
     public static PostRankResponseDto from(Post post) {

--- a/src/main/java/com/even/zaro/dto/post/PostRankResponseDto.java
+++ b/src/main/java/com/even/zaro/dto/post/PostRankResponseDto.java
@@ -1,0 +1,25 @@
+package com.even.zaro.dto.post;
+
+import com.even.zaro.entity.Post;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class PostRankResponseDto {
+    private Long postId;
+    private String title;
+    private int likeCount;
+    private int commentCount;
+
+    public static PostRankResponseDto from(Post post) {
+        return PostRankResponseDto.builder()
+                .postId(post.getId())
+                .title(post.getTitle())
+                .likeCount(post.getLikeCount())
+                .commentCount(post.getCommentCount())
+                .build();
+    }
+}

--- a/src/main/java/com/even/zaro/entity/Post.java
+++ b/src/main/java/com/even/zaro/entity/Post.java
@@ -78,6 +78,10 @@ public class Post {
     @Column(name = "updated_at")
     private LocalDateTime updatedAt;
 
+    @Column(name = "score", nullable = false)
+    @Builder.Default
+    private double score = 0.0;
+
     public void changeTitle(String title) {
         this.title = title;
     }
@@ -116,6 +120,10 @@ public class Post {
 
     public void changeCommentCount(int commentCount) {
         this.commentCount = commentCount;
+    }
+
+    public void updateScore(){
+        this.score = (this.likeCount * 3.0) + (this.commentCount * 5.0);
     }
 
     public enum Category {

--- a/src/main/java/com/even/zaro/repository/PostRepository.java
+++ b/src/main/java/com/even/zaro/repository/PostRepository.java
@@ -6,7 +6,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -31,5 +30,5 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 
     Page<Post> findByCategoryAndTagAndIsDeletedFalseAndIsReportedFalse(Post.Category category, Post.Tag tag, Pageable pageable);
 
-    Page<Post> findByCategoryAndTagAndIsDeletedFalse(Post.Category postCategory, Post.Tag postTag, Pageable pageable);
+    List<Post> findTop10ByIsDeletedFalseAndIsReportedFalseOrderByScoreDescCreatedAtDesc();
 }

--- a/src/main/java/com/even/zaro/service/CommentService.java
+++ b/src/main/java/com/even/zaro/service/CommentService.java
@@ -60,6 +60,8 @@ public class CommentService {
 
         commentRepository.save(comment);
         post.changeCommentCount(post.getCommentCount() + 1);
+        post.updateScore();
+        postRepository.save(post);
 
         return toDto(comment, currentUserId);
     }
@@ -110,6 +112,8 @@ public class CommentService {
 
         Post post = comment.getPost();
         post.changeCommentCount(Math.max(0, post.getCommentCount() - 1));
+        post.updateScore();
+        postRepository.save(post);
     }
 
     // 공통 응답

--- a/src/main/java/com/even/zaro/service/PostLikeService.java
+++ b/src/main/java/com/even/zaro/service/PostLikeService.java
@@ -20,6 +20,7 @@ public class PostLikeService {
     private final PostLikeRepository postLikeRepository;
     private final PostRepository postRepository;
     private final UserRepository userRepository;
+    private final PostService postService;
 
     @Transactional
     public void likePost(Long postId, Long userId) {
@@ -35,6 +36,7 @@ public class PostLikeService {
                 .post(post)
                 .build());
         post.changeLikeCount(post.getLikeCount() + 1);
+        postService.updatePostScore(post);
     }
 
 
@@ -49,6 +51,7 @@ public class PostLikeService {
         postLikeRepository.delete(postLike);
 
         post.changeLikeCount(Math.max(0,post.getLikeCount() - 1));
+        postService.updatePostScore(post);
     }
 
     @Transactional(readOnly = true)


### PR DESCRIPTION
## 📌 작업 개요
- 인기게시글 API 구현

---

## ✨ 주요 변경 사항
- 삭제된 게시글 미포함
- 인기 게시글 조회시 score순으로 상위 10개 정렬 후 반환
    - **score 기준** ⬇️
    -  좋아요 (likeCount) **3점** + 댓글 수 (commentCount) **5점**
    - score 가 동점일때 -> 최신글 우선으로 정렬

---

## 🖼️ 기능 살펴 보기
> 
| 인기글 조회 | DB | 스웨거 |
|-------|-------|-------|
|![스크린샷 2025-05-30 오후 9 23 27](https://github.com/user-attachments/assets/1b649841-8a2b-43f9-903a-a41f7557d84c)|<img width="1012" alt="스크린샷 2025-05-30 오후 9 22 57" src="https://github.com/user-attachments/assets/17932d53-af8f-4008-952f-bbf87e18de3c" />|![스크린샷 2025-05-30 오후 9 34 48](https://github.com/user-attachments/assets/575bca1b-d99e-4191-b41a-645df08ac71b)|


---

## 💬 기타 참고 사항
- 조회수를 추가할까 하다가 조작이 쉬운점과 조회만으로 관심도를 판단하기 어렵다 생각이들어 좋아요수와 댓글수로 기준을 잡았습니다.

