### PR TITLE
Ref/sse notification : 알림 응답 DTO 확장, Notification 엔티티에 컬럼추가

### DIFF
--- a/src/main/java/com/even/zaro/dto/notification/NotificationDto.java
+++ b/src/main/java/com/even/zaro/dto/notification/NotificationDto.java
@@ -30,6 +30,8 @@ public class NotificationDto {
     @Schema(description = "알림 생성 시각", example = "2025-05-09T12:00:00")
     private LocalDateTime createdAt;
 
+    // 알림 발생 주체 유저 정보
+
     @Schema(description = "알림 발생 주체 유저 ID", example = "88")
     private Long userId;
 
@@ -38,6 +40,8 @@ public class NotificationDto {
 
     @Schema(description = "알림 발생 주체 프로필 이미지", example = "/images/profile/uuid.png")
     private String profileImage;
+
+    // 타입별 필요 정보
 
     @Schema(description = "게시글 카테고리", example = "TOGETHER")
     private String category;

--- a/src/main/java/com/even/zaro/dto/notification/NotificationDto.java
+++ b/src/main/java/com/even/zaro/dto/notification/NotificationDto.java
@@ -29,4 +29,22 @@ public class NotificationDto {
 
     @Schema(description = "알림 생성 시각", example = "2025-05-09T12:00:00")
     private LocalDateTime createdAt;
+
+    @Schema(description = "알림 발생 주체 유저 ID", example = "88")
+    private Long userId;
+
+    @Schema(description = "알림 발생 주체 유저 닉네임", example = "맛잘알")
+    private String username;
+
+    @Schema(description = "알림 발생 주체 프로필 이미지", example = "/images/profile/uuid.png")
+    private String profileImage;
+
+    @Schema(description = "게시글 카테고리", example = "TOGETHER")
+    private String category;
+
+    @Schema(description = "게시글 썸네일", example = "/images/post/thumb.png")
+    private String thumbnailImage;
+
+    @Schema(description = "댓글 내용", example = "레시피 공유 가능할까요??")
+    private String comment;
 }

--- a/src/main/java/com/even/zaro/entity/Notification.java
+++ b/src/main/java/com/even/zaro/entity/Notification.java
@@ -23,6 +23,9 @@ public class Notification {
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
+    @Column(name = "actor_user_id")
+    private Long actorUserId;
+
     @Enumerated(EnumType.STRING)
     @Column(name = "type", nullable = false)
     private Type type;

--- a/src/main/java/com/even/zaro/global/ErrorCode.java
+++ b/src/main/java/com/even/zaro/global/ErrorCode.java
@@ -63,6 +63,7 @@ public enum ErrorCode {
 
     // 알림 Notification
     NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "조회된 알림이 없습니다."),
+    ACTOR_USER_NOT_FOUND(HttpStatus.NOT_FOUND, "알림 생성 주체 유저를 찾을 수 없습니다."),
 
     // 게시글 Post
     IMAGE_REQUIRED_FOR_RANDOM_BUY(HttpStatus.BAD_REQUEST, "이미지는 필수입니다."),

--- a/src/main/java/com/even/zaro/jwt/JwtAuthFilter.java
+++ b/src/main/java/com/even/zaro/jwt/JwtAuthFilter.java
@@ -10,7 +10,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.filter.OncePerRequestFilter;
-import jakarta.servlet.http.Cookie;
 
 import java.io.IOException;
 
@@ -26,7 +25,7 @@ public class JwtAuthFilter extends OncePerRequestFilter {
 
         // Authorization 헤더 없을 경우 쿠키에서 추출 (SSE)
         if (token == null) {
-            token = extractTokenFromCookies(request);
+            token = jwtUtil.extractTokenFromCookies(request);
         }
 
         // 토큰 유효성 검사
@@ -49,17 +48,5 @@ public class JwtAuthFilter extends OncePerRequestFilter {
     protected boolean shouldNotFilter(HttpServletRequest request) {
         String path = request.getRequestURI();
         return path.equals("/api/auth/refresh");
-    }
-
-    // 쿠키에서 access_token 꺼내기
-    private String extractTokenFromCookies(HttpServletRequest request) {
-        if (request.getCookies() != null) {
-            for (Cookie cookie : request.getCookies()) {
-                if ("access_token".equals(cookie.getName())) {
-                    return cookie.getValue();
-                }
-            }
-        }
-        return null;
     }
 }

--- a/src/main/java/com/even/zaro/jwt/JwtUtil.java
+++ b/src/main/java/com/even/zaro/jwt/JwtUtil.java
@@ -5,6 +5,7 @@ import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.oauth2.jwt.JwtException;
@@ -113,6 +114,18 @@ public class JwtUtil {
             return token.substring(7).trim();
         }
         return token;
+    }
+
+    // 쿠키에서 access_token 꺼내기
+    public String extractTokenFromCookies(HttpServletRequest request) {
+        if (request.getCookies() != null) {
+            for (Cookie cookie : request.getCookies()) {
+                if ("access_token".equals(cookie.getName())) {
+                    return cookie.getValue();
+                }
+            }
+        }
+        return null;
     }
 
     // 만료시간 확인

--- a/src/main/java/com/even/zaro/listener/CommentListener.java
+++ b/src/main/java/com/even/zaro/listener/CommentListener.java
@@ -29,6 +29,7 @@ public class CommentListener {
         if (!postOwner.getId().equals(commentAuthor.getId())) {
             Notification notification = new Notification();
             notification.setUser(postOwner);
+            notification.setActorUserId(commentAuthor.getId());
             notification.setType(Notification.Type.COMMENT);
             notification.setTargetId(comment.getId()); // 해당 댓글 commentId
             notification.setRead(false);

--- a/src/main/java/com/even/zaro/listener/FollowListener.java
+++ b/src/main/java/com/even/zaro/listener/FollowListener.java
@@ -30,6 +30,7 @@ public class FollowListener {
 
         Notification notification = new Notification();
         notification.setUser(followee);
+        notification.setActorUserId(follower.getId());
         notification.setType(Notification.Type.FOLLOW);
         notification.setTargetId(follower.getId()); // 팔로우 한 사용자 userId
         notification.setRead(false);

--- a/src/main/java/com/even/zaro/listener/PostLikeListener.java
+++ b/src/main/java/com/even/zaro/listener/PostLikeListener.java
@@ -29,6 +29,7 @@ public class PostLikeListener {
         if (!postOwner.getId().equals(likeUser.getId())) {
             Notification notification = new Notification();
             notification.setUser(postOwner);
+            notification.setActorUserId(likeUser.getId());
             notification.setType(Notification.Type.LIKE);
             notification.setTargetId(postlike.getPost().getId());
             notification.setRead(false);

--- a/src/main/java/com/even/zaro/service/NotificationService.java
+++ b/src/main/java/com/even/zaro/service/NotificationService.java
@@ -9,7 +9,6 @@ import com.even.zaro.global.ErrorCode;
 import com.even.zaro.global.exception.comment.CommentException;
 import com.even.zaro.global.exception.notification.NotificationException;
 import com.even.zaro.global.exception.post.PostException;
-import com.even.zaro.global.exception.profile.ProfileException;
 import com.even.zaro.global.exception.user.UserException;
 import com.even.zaro.repository.NotificationRepository;
 import com.even.zaro.repository.PostRepository;


### PR DESCRIPTION
## 📌 작업 개요
-  알림 응답 DTO 확장, Notification 엔티티에 컬럼추가

---

## ✨ 주요 변경 사항
- extractTokenFromCookies 메서드 jwtUtil로 이동, public 전환
  - 리뷰 반영 #90 
- FE ui 디자인에 따른, 알림 응답 DTO에 정보 추가
  - 액터유저 (알림 유발 유저) 정보 (id, username, profileImage)
  - 게시물 좋아요 & 댓글 알림 : 게시물 정보 (thumbnail, postId)
  - 댓글 알림 : 댓글 정보 (comment.content)
- Notification 엔티티에 actorUserId 컬럼 추가
  - 컬럼추가는 피해보려 했지만, 없을 경우 게시물 좋아요 알림에서 특히 불필요 join 너무 많았습니다
 
---

## 🖼️ 기능 살펴 보기
> 알림 List 조회 시 변경된 응답형식 확인 가능
![image](https://github.com/user-attachments/assets/8feaf905-a0d9-4f86-ad52-b6f01ac53a5c)
![image](https://github.com/user-attachments/assets/1cc5a075-357c-4b50-b1ad-5b24c44c6ed1)

---

## ✅ 작업 체크리스트
- [x] API 테스트 완료
- [x] 스웨거 ui 관련 코드 추가
- [x] 기능별 예외 케이스 고려
- [ ] log.info / 불필요한 주석 제거
- [x] 변수명, 클래스명, 메서드명 의미있게 작성
- [ ] 반복 코드 메서드로 분리

---

## 📂 테스트 방법
- swagger와 로컬서버 ui를 통한 알림 생성 (댓글 쓰기, 좋아요 누르기, 팔로우하기)
- swagger에서 알림조회 응답형식 확인 !

---

## 💬 기타 참고 사항

---

## 📎 관련 이슈 / 문서

