### PR TITLE
fix: 젠킨스 - 무중단, 자동 배포 스크립트

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,60 +1,160 @@
 pipeline {
-    agent any
+  agent any
 
-    environment {
-        PROJECT_DIR = "/home/ubuntu/zaro-main"
-    }
+  environment {
+    PROJECT_DIR = "/home/ubuntu/zaro-main"
+    A_IP = "${params.A_IP}"
+    B_IP = "${params.B_IP}"
+  }
 
-    triggers {
-        githubPush()
-    }
+  triggers {
+    githubPush()
+  }
 
-    stages {
-        stage('Git Pull') {
-            steps {
-                withCredentials([
-                    usernamePassword(credentialsId: 'github-token', usernameVariable: 'GIT_USER', passwordVariable: 'GIT_TOKEN'),
-                    string(credentialsId: 'discord-webhook', variable: 'WEBHOOK_URL')
-                ]) {
-                    dir("${PROJECT_DIR}") {
-                        sh '''
-                            echo "📥 Git pull 중..."
-                            if git pull https://$GIT_USER:$GIT_TOKEN@github.com/code-is-evenly-cooked/even-zaro-back.git main; then
-                                curl -H "Content-Type: application/json" -X POST \
-                                  -d '{"content": "✅ [Auto] Git pull 성공!"}' $WEBHOOK_URL
-                            else
-                                curl -H "Content-Type: application/json" -X POST \
-                                  -d '{"content": "❌ [Auto] Git pull 실패!"}' $WEBHOOK_URL
-                                exit 1
-                            fi
-                        '''
-                    }
-                }
+  stages {
+
+    stage('프록시 B로 전환') {
+      steps {
+        withCredentials([
+          sshUserPrivateKey(credentialsId: 'server-key', keyFileVariable: 'PEM_FILE'),
+          string(credentialsId: 'discord-webhook', variable: 'WEBHOOK_URL')
+        ]) {
+          script {
+            try {
+              sh """
+                echo "프록시를 B 서버로 전환 중..."
+                ssh -i "$PEM_FILE" -o StrictHostKeyChecking=no ubuntu@${A_IP} 'sudo bash /home/ubuntu/swap_proxy.sh'
+              """
+            } catch (err) {
+              def msg = err.getMessage().replaceAll('"', '\\"').take(200)
+              sh """
+                curl -H "Content-Type: application/json" -X POST \
+                  -d '{"content": "🅱️❌ B 프록시 전환 실패\\n${msg}"}' $WEBHOOK_URL
+              """
+              error("프록시 전환 실패")
             }
+          }
         }
-
-        stage('Docker Deploy') {
-            steps {
-                withCredentials([string(credentialsId: 'discord-webhook', variable: 'WEBHOOK_URL')]) {
-                    dir("${PROJECT_DIR}") {
-                        sh '''
-                            curl -H "Content-Type: application/json" -X POST \
-                              -d '{"content": "🐳 [Auto] Docker 배포 시작..."}' $WEBHOOK_URL
-
-                            docker-compose -f docker-compose.prod.yml down
-
-                            if docker-compose -f docker-compose.prod.yml up -d --build; then
-                                curl -H "Content-Type: application/json" -X POST \
-                                  -d '{"content": "🚀 [Auto] 배포 완료!"}' $WEBHOOK_URL
-                            else
-                                curl -H "Content-Type: application/json" -X POST \
-                                  -d '{"content": "❌ [Auto] Docker 실패"}' $WEBHOOK_URL
-                                exit 1
-                            fi
-                        '''
-                    }
-                }
-            }
-        }
+      }
     }
+
+    stage('Git Pull') {
+      steps {
+        dir("${PROJECT_DIR}") {
+          withCredentials([
+            usernamePassword(credentialsId: 'github-token', usernameVariable: 'GIT_USER', passwordVariable: 'GIT_TOKEN'),
+            string(credentialsId: 'discord-webhook', variable: 'WEBHOOK_URL')
+          ]) {
+            sh '''
+              echo "📥 Git pull 중..."
+              ERR_MSG=$(git pull https://$GIT_USER:$GIT_TOKEN@github.com/code-is-evenly-cooked/even-zaro-back.git main 2>&1) || {
+                SHORT_MSG=$(echo "$ERR_MSG" | head -n 5 | tr '\n' ' ' | cut -c 1-200)
+                curl -H "Content-Type: application/json" -X POST \
+                  -d "{\"content\": \"📥❌ Git pull 실패\\n$SHORT_MSG\"}" $WEBHOOK_URL
+                exit 1
+              }
+            '''
+          }
+        }
+      }
+    }
+
+    stage('Build Image & A 서버 컨테이너 실행') {
+      steps {
+        dir("${PROJECT_DIR}") {
+          withCredentials([string(credentialsId: 'discord-webhook', variable: 'WEBHOOK_URL')]) {
+            script {
+              try {
+                sh 'echo "🔨 Docker 이미지 빌드 중..."'
+                sh 'docker-compose -f docker-compose.prod.yml stop app'
+                sh 'docker-compose -f docker-compose.prod.yml rm -f app'
+                sh 'docker rmi even-final'
+                sh 'docker-compose -f docker-compose.prod.yml up -d --build app'
+                sh 'docker save even-final > app.tar'
+              } catch (err) {
+                def msg = err.getMessage().replaceAll('"', '\\"').take(200)
+                sh """
+                  curl -H "Content-Type: application/json" -X POST \
+                    -d '{"content": "🐳❌ A 서버 빌드 실패\\n${msg}"}' $WEBHOOK_URL
+                """
+                error("A 서버 빌드 실패")
+              }
+            }
+          }
+        }
+      }
+    }
+
+    stage('프록시 A로 복원') {
+      steps {
+        withCredentials([
+          sshUserPrivateKey(credentialsId: 'server-key', keyFileVariable: 'PEM_FILE'),
+          string(credentialsId: 'discord-webhook', variable: 'WEBHOOK_URL')
+        ]) {
+          script {
+            def result = sh(
+              script: """
+                echo "📍 프록시를 A 서버로 복원 중..."
+                ssh -i "$PEM_FILE" -o StrictHostKeyChecking=no ubuntu@${A_IP} 'sudo bash /home/ubuntu/swap_proxy.sh' 2> err.log
+              """,
+              returnStatus: true
+            )
+            if (result != 0) {
+              def msg = sh(script: "head -n 5 err.log | tr '\\n' ' ' | cut -c 1-200", returnStdout: true).trim()
+              sh """
+                curl -H "Content-Type: application/json" -X POST \
+                  -d "{\\"content\\": \\"🅰️❌ 프록시 A 복원 실패\\\\n${msg}\\"}" $WEBHOOK_URL
+              """
+              error "프록시 복원 실패"
+            }
+          }
+        }
+      }
+    }
+
+    stage('B 서버에 전송 및 실행') {
+      steps {
+        withCredentials([
+          sshUserPrivateKey(credentialsId: 'server-key', keyFileVariable: 'PEM_FILE'),
+          string(credentialsId: 'discord-webhook', variable: 'WEBHOOK_URL')
+        ]) {
+          script {
+            try {
+              echo "📦 B 서버에 파일 전송 중..."
+              sh """
+                scp -i "$PEM_FILE" -o StrictHostKeyChecking=no "$PROJECT_DIR"/app.tar ubuntu@${B_IP}:/home/ubuntu/
+                scp -i "$PEM_FILE" -o StrictHostKeyChecking=no "$PROJECT_DIR"/.env ubuntu@${B_IP}:/home/ubuntu/
+              """
+            } catch (err) {
+              def msg = err.getMessage().replaceAll('"', '\\"').take(200)
+              sh """
+                curl -H "Content-Type: application/json" -X POST \
+                  -d '{"content": "📦❌ B 서버 파일 전송 실패\\n${msg}"}' $WEBHOOK_URL
+              """
+              error("B 서버 파일 전송 실패")
+            }
+
+            try {
+              echo "🚀 B 서버에서 앱 실행 중..."
+              sh """
+                ssh -i "$PEM_FILE" -o StrictHostKeyChecking=no ubuntu@${B_IP} '
+                  docker load -i app.tar && \
+                  docker stop even_final_app || true && \
+                  docker rm even_final_app || true && \
+                  docker run -d --name even_final_app --env-file .env -p 8080:8080 even-final
+                '
+              """
+            } catch (err) {
+              def msg = err.getMessage().replaceAll('"', '\\"').take(200)
+              sh """
+                curl -H "Content-Type: application/json" -X POST \
+                  -d '{"content": "🚀❌ B 서버 앱 실행 실패\\n${msg}"}' $WEBHOOK_URL
+              """
+              error("B 서버 앱 실행 실패")
+            }
+          }
+        }
+      }
+    }
+  }
 }


### PR DESCRIPTION
## 📌 작업 개요
- 젠킨스 파이프라인 수정 : 무중단, 자동 배포 스크립트

---

## ✨ 주요 변경 사항
- 젠킨스 파이프라인 수정
     - 무중단, 자동 배포 스크립트 적용


---

## 🖼️ 기능 살펴 보기
- t2.small(메모리 2G) 서버(편의상 B 서버)를 하나 더 열었습니다.
- 젠킨스파일 stage 보시면 아시겠지만 A에서 빌드 up 될 동안 프록시를 B서버로 옮긴 후, A 서버에서 git pull, 이미지 빌드, 컨테이너 실행을 한 후, 다시 프록시를 A로 옮겨서 새로 배포된 기능을 사용할 수 있도록 했습니다. 그 이후 A 서버의 이미지를 B서버로 복사 하고 B에서도 실행시켜서 A에 문제가 생길 때 또는 다음 빌드 시에 B 서버로 api 사용할 수 있도록 했습니다.

---

## 💬 기타 참고 사항
- 웹훅 너무 많은 것 같아서 에러가 날 때만 메시지 주도록 수정했습니다.
- 젠킨스 서버에 올려서 개인별로 사용(테스트? 놀기..?ㅎ)하실 수 있도록 디코에 id password 공유드리겠습니다!

---

## 📎 관련 이슈 / 문서

