### PR TITLE
Ref/notification : 알림응답DTO 명칭 수정, postId 추가

### DIFF
--- a/src/main/java/com/even/zaro/dto/notification/NotificationDto.java
+++ b/src/main/java/com/even/zaro/dto/notification/NotificationDto.java
@@ -33,13 +33,13 @@ public class NotificationDto {
     // 알림 발생 주체 유저 정보
 
     @Schema(description = "알림 발생 주체 유저 ID", example = "88")
-    private Long userId;
+    private Long actorId;
 
     @Schema(description = "알림 발생 주체 유저 닉네임", example = "맛잘알")
-    private String username;
+    private String actorName;
 
     @Schema(description = "알림 발생 주체 프로필 이미지", example = "/images/profile/uuid.png")
-    private String profileImage;
+    private String actorProfileImage;
 
     // 타입별 필요 정보
 

--- a/src/main/java/com/even/zaro/dto/notification/NotificationDto.java
+++ b/src/main/java/com/even/zaro/dto/notification/NotificationDto.java
@@ -43,6 +43,9 @@ public class NotificationDto {
 
     // 타입별 필요 정보
 
+    @Schema(description = "게시글 ID", example = "2")
+    private Long postId;
+
     @Schema(description = "게시글 카테고리", example = "TOGETHER")
     private String category;
 

--- a/src/main/java/com/even/zaro/service/NotificationService.java
+++ b/src/main/java/com/even/zaro/service/NotificationService.java
@@ -56,9 +56,9 @@ public class NotificationService {
                             .targetId(notification.getTargetId())
                             .isRead(notification.isRead())
                             .createdAt(notification.getCreatedAt())
-                            .userId(actor.getId())
-                            .username(actor.getNickname())
-                            .profileImage(actor.getProfileImage());
+                            .actorId(actor.getId())
+                            .actorName(actor.getNickname())
+                            .actorProfileImage(actor.getProfileImage());
 
                     // LIKE, COMMENT 타입은 게시글, 댓글 정보 추가
                     if (type == Notification.Type.LIKE || type == Notification.Type.COMMENT) {

--- a/src/main/java/com/even/zaro/service/NotificationService.java
+++ b/src/main/java/com/even/zaro/service/NotificationService.java
@@ -64,8 +64,9 @@ public class NotificationService {
                     if (type == Notification.Type.LIKE || type == Notification.Type.COMMENT) {
                         Post post = postRepository.findById(notification.getTargetId())
                                 .orElseThrow(() -> new PostException(ErrorCode.POST_NOT_FOUND));
-                        builder.category(post.getCategory().name());
-                        builder.thumbnailImage(post.getThumbnailImage());
+                        builder.postId(post.getId())
+                                .category(post.getCategory().name())
+                                .thumbnailImage(post.getThumbnailImage());
 
                         if (type == Notification.Type.COMMENT) {
                             Comment comment = commentRepository.findById(notification.getTargetId())


### PR DESCRIPTION
## 📌 작업 개요
- 알림응답DTO 명칭 수정 
- 알림응답DTO에 postId 추가

---

## ✨ 주요 변경 사항
- 알림응답DTO 명칭 수정
  - user -> actor로 명칭 수정
  - 아무래도.. 명확한 것이 좋을 듯 하여 FE 연결작업하며 바꿨습니다
  - @nahyukk 님 리뷰 반영 💪🏻 #109 
  
- 알림응답DTO에 postId 추가
  - targetId만 DTO에 담아 처리하기엔, 댓글알림의 경우 해당 게시글 이동이 어려워 추가했습니다
---

## 🖼️ 기능 살펴 보기
> **변경 / 추가된 부분 == 블럭처리 부분**
![image](https://github.com/user-attachments/assets/6e8c520b-c59d-4caf-aaf7-21f32969048c)

---

## ✅ 작업 체크리스트
- [x] API 테스트 완료 (Swagger)
- [x] 스웨거 ui 관련 코드 추가
- [ ] 기능별 예외 케이스 고려
- [ ] log.info / 불필요한 주석 제거
- [x] 변수명, 클래스명, 메서드명 의미있게 작성
- [ ] 반복 코드 메서드로 분리

---

## 📂 테스트 방법
- [x] Swagger api 호출
- [x] FE localhost 연결 테스트

---

## 💬 기타 참고 사항
- 차후 알림 리팩토링에서 타입별 응답 DTO를 분리할지 말지.... 생각해볼 예정

---

## 📎 관련 이슈 / 문서

