### PR TITLE
Fix/code reviewed UserService 책임분리

### DIFF
--- a/src/main/java/com/even/zaro/service/UserService.java
+++ b/src/main/java/com/even/zaro/service/UserService.java
@@ -24,6 +24,7 @@ public class UserService {
     public final UserRepository userRepository;
     public final PasswordEncoder passwordEncoder;
 
+    @Transactional(readOnly = true)
     public UserInfoResponseDto getMyInfo(Long userId) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new UserException(ErrorCode.USER_NOT_FOUND));

--- a/src/main/java/com/even/zaro/service/UserService.java
+++ b/src/main/java/com/even/zaro/service/UserService.java
@@ -26,8 +26,7 @@ public class UserService {
 
     @Transactional(readOnly = true)
     public UserInfoResponseDto getMyInfo(Long userId) {
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new UserException(ErrorCode.USER_NOT_FOUND));
+        User user = findUserById(userId);
 
         return UserInfoResponseDto.builder()
                 .userId(user.getId())
@@ -48,12 +47,8 @@ public class UserService {
 
     @Transactional
     public UpdateProfileImageResponseDto updateProfileImage(Long userId, UpdateProfileImageRequestDto requestDto) {
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new UserException(ErrorCode.USER_NOT_FOUND));
-
-        if (user.getStatus() == Status.PENDING) {
-            throw new UserException(ErrorCode.MAIL_NOT_VERIFIED);
-        }
+        User user = findUserById(userId);
+        validateNotPending(user);
 
         user.updateProfileImage(requestDto.getProfileImage());
 
@@ -62,12 +57,8 @@ public class UserService {
 
     @Transactional
     public UpdateNicknameResponseDto updateNickname(Long userId, UpdateNicknameRequestDto requestDto) {
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new UserException(ErrorCode.USER_NOT_FOUND));
-
-        if (user.getStatus() == Status.PENDING) {
-            throw new UserException(ErrorCode.MAIL_NOT_VERIFIED);
-        }
+        User user = findUserById(userId);
+        validateNotPending(user);
 
         String newNickname = requestDto.getNewNickname();
 
@@ -111,12 +102,8 @@ public class UserService {
 
     @Transactional
     public UpdateProfileResponseDto updateProfile(Long userId, UpdateProfileRequestDto requestDto) {
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new UserException(ErrorCode.USER_NOT_FOUND));
-
-        if (user.getStatus() == Status.PENDING) {
-            throw new UserException(ErrorCode.MAIL_NOT_VERIFIED);
-        }
+        User user = findUserById(userId);
+        validateNotPending(user);
 
         user.updateBirthday(requestDto.getBirthday());
         user.updateLiveAloneDate(requestDto.getLiveAloneDate());
@@ -133,12 +120,8 @@ public class UserService {
 
     @Transactional
     public void updatePassword(Long userId, UpdatePasswordRequestDto requestDto) {
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new UserException(ErrorCode.USER_NOT_FOUND));
-
-        if (user.getStatus() == Status.PENDING) {
-            throw new UserException(ErrorCode.MAIL_NOT_VERIFIED);
-        }
+        User user = findUserById(userId);
+        validateNotPending(user);
 
         String currentPassword = requestDto.getCurrentPassword();
         String newPassword = requestDto.getNewPassword();
@@ -154,6 +137,17 @@ public class UserService {
         validateNewPassword(currentPassword, newPassword);
 
         user.updatePassword(passwordEncoder.encode(newPassword));
+    }
+
+    public User findUserById(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new UserException(ErrorCode.USER_NOT_FOUND));
+    }
+
+    public void validateNotPending(User user) {
+        if (user.getStatus() == Status.PENDING) {
+            throw new UserException(ErrorCode.MAIL_NOT_VERIFIED);
+        }
     }
 
     private void validateNewPassword(String currentPassword, String newPassword) {


### PR DESCRIPTION
## 📌 작업 개요
- UserService 책임분리

---

## ✨ 주요 변경 사항
- 빼먹은 Transactional :)
- UserService 공통 검증 메서드 추출


---

## 🖼️ 기능 살펴 보기
> 포스트맨 요청 응답 스크린샷
- [ ] API 문서(요청, 응답)와 일치하는지 확인 - 필요시 API 문서 수정 가능

---

## ✅ 작업 체크리스트
- [ ] API 테스트 완료 (POSTMAN)
- [ ] 스웨거 ui 관련 코드 추가
- [ ] 기능별 예외 케이스 고려
- [ ] log.info / 불필요한 주석 제거
- [ ] 변수명, 클래스명, 메서드명 의미있게 작성
- [ ] 반복 코드 메서드로 분리

---

## 📂 테스트 방법
- [x] 테스트 코드 작성
- [ ] 시나리오 기반 테스트 유무
    - 공통 메서드 단위테스트 추가했습니다. FindByIdUserNotExists, validateNotPending 
    - 기존 코드는 굳이 지우지는 않았습니다.

---

## 💬 기타 참고 사항
- 이슈 #112 참고 부탁드립니다. 다른 서비스에서 많이 사용되는 검증 메서드 인것 같습니다.

---

## 📎 관련 이슈 / 문서
- 이슈 : Fixes #112 
