### PR TITLE
Ref/map 지도 API 장소 테이블에 category 필드 추가 

### DIFF
--- a/src/main/java/com/even/zaro/dto/favorite/FavoriteAddRequest.java
+++ b/src/main/java/com/even/zaro/dto/favorite/FavoriteAddRequest.java
@@ -25,4 +25,7 @@ public class FavoriteAddRequest {
 
     @Schema(description = "경도", example = "127.1234455")
     private double lng;
+
+    @Schema(description = "장소 분류", example = "MT1")
+    private String category;
 }

--- a/src/main/java/com/even/zaro/dto/map/MarkerInfoResponse.java
+++ b/src/main/java/com/even/zaro/dto/map/MarkerInfoResponse.java
@@ -3,7 +3,6 @@ package com.even.zaro.dto.map;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.Setter;
 
 import java.util.List;
 
@@ -20,6 +19,8 @@ public class MarkerInfoResponse {
 
     double lat;
     double lng;
+
+    String category;
 
     int favoriteCount;
 

--- a/src/main/java/com/even/zaro/dto/map/PlaceResponse.java
+++ b/src/main/java/com/even/zaro/dto/map/PlaceResponse.java
@@ -19,6 +19,7 @@ public class PlaceResponse {
         long place_id;
         String name;
         String address;
+        String category;
         double lat;
         double lng;
     }

--- a/src/main/java/com/even/zaro/entity/Category.java
+++ b/src/main/java/com/even/zaro/entity/Category.java
@@ -1,4 +1,0 @@
-package com.even.zaro.entity;
-
-public enum Category {
-}

--- a/src/main/java/com/even/zaro/entity/Category.java
+++ b/src/main/java/com/even/zaro/entity/Category.java
@@ -1,0 +1,4 @@
+package com.even.zaro.entity;
+
+public enum Category {
+}

--- a/src/main/java/com/even/zaro/entity/Place.java
+++ b/src/main/java/com/even/zaro/entity/Place.java
@@ -37,7 +37,7 @@ public class Place {
     private double lng;
 
     @Column(nullable = false)
-    private String category;
+    private String category = "ETC";
 
     @Column(name = "address", nullable = false)
     private String address;

--- a/src/main/java/com/even/zaro/entity/Place.java
+++ b/src/main/java/com/even/zaro/entity/Place.java
@@ -37,6 +37,7 @@ public class Place {
     private double lng;
 
     @Column(nullable = false)
+    @Builder.Default
     private String category = "ETC";
 
     @Column(name = "address", nullable = false)

--- a/src/main/java/com/even/zaro/entity/Place.java
+++ b/src/main/java/com/even/zaro/entity/Place.java
@@ -36,6 +36,10 @@ public class Place {
     @Column(name = "lng", nullable = false)
     private double lng;
 
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Category category;
+
     @Column(name = "address", nullable = false)
     private String address;
 

--- a/src/main/java/com/even/zaro/entity/Place.java
+++ b/src/main/java/com/even/zaro/entity/Place.java
@@ -36,9 +36,8 @@ public class Place {
     @Column(name = "lng", nullable = false)
     private double lng;
 
-    @Enumerated(EnumType.STRING)
     @Column(nullable = false)
-    private Category category;
+    private String category;
 
     @Column(name = "address", nullable = false)
     private String address;

--- a/src/main/java/com/even/zaro/service/FavoriteService.java
+++ b/src/main/java/com/even/zaro/service/FavoriteService.java
@@ -153,6 +153,7 @@ public class FavoriteService {
                     .name(request.getPlaceName())
                     .lat(request.getLat())
                     .lng(request.getLng())
+                    .category(request.getCategory())
                     .address(request.getAddress())
                     .build();
             placeRepository.save(newPlace);

--- a/src/main/java/com/even/zaro/service/MapService.java
+++ b/src/main/java/com/even/zaro/service/MapService.java
@@ -51,6 +51,7 @@ public class MapService {
                 selectPlace.getAddress(),
                 selectPlace.getLat(),
                 selectPlace.getLng(),
+                selectPlace.getCategory(),
                 selectPlace.getFavoriteCount(),
                 userSimpleResponses
         );
@@ -75,6 +76,7 @@ public class MapService {
                         .address(place.getAddress())
                         .lat(place.getLat())
                         .lng(place.getLng())
+                        .category(place.getCategory())
                         .build()
                 ).toList();
 


### PR DESCRIPTION
## 📌 작업 개요
- 지도 API에서 즐겨찾기 추가 또는 장소데이터를 응답할 때, category 값을 함께 전송 또는 응답 받도록 수정했습니다.

---

## ✨ 주요 변경 사항
- Place 테이블 category 필드 추가 (만약 null값일시 디폴트 ETC로 저장)
- 요청, 응답 dto에 category 필드 추가

---

## 🖼️ 기능 살펴 보기
> ![image](https://github.com/user-attachments/assets/596b8274-b4bf-4e70-92de-3d5a1d336792)
- 즐겨찾기 추가 API 요청객체에 카테고리 필드 추가, 정상 동작 확인

> ![image](https://github.com/user-attachments/assets/8aa3fc06-db39-4632-a0d8-534877b4898f)
> ![image](https://github.com/user-attachments/assets/c4713fbb-177b-43c3-8570-e2a7055f2272)
- 인근맛집 조회 API 요청 및 응답에 정상적으로 category 필드 포함

> ![image](https://github.com/user-attachments/assets/69ba13fd-616f-45ff-b428-cd0f3b75be9d)
- 장소의 메모리스트와 정보 조회API 에 카테고리 필드 정상 응답

---

## ✅ 작업 체크리스트
- [x] API 테스트 완료 (POSTMAN)
- [x] 스웨거 ui 관련 코드 추가
- [ ] 기능별 예외 케이스 고려
- [ ] log.info / 불필요한 주석 제거
- [x] 변수명, 클래스명, 메서드명 의미있게 작성
- [ ] 반복 코드 메서드로 분리

---

## 📂 테스트 방법
- [ ] 테스트 코드 작성
- [ ] 시나리오 기반 테스트 유무
- [x] Swagger API 테스트 

---

## 💬 기타 참고 사항
- 
---

## 📎 관련 이슈 / 문서
- close #99 
