### PR TITLE
Ref/feedback 그룹, 즐겨찾기, 지도 API 멘토링 피드백 반영

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,8 +64,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-elasticsearch'
 
 	// Map Struct
-	implementation 'org.mapstruct:mapstruct:1.4.2.Final'
-	annotationProcessor 'org.mapstruct:mapstruct-processor:1.4.2.Final'
+	implementation 'org.mapstruct:mapstruct:1.6.3'
+	annotationProcessor 'org.mapstruct:mapstruct-processor:1.6.3'
 
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -63,6 +63,10 @@ dependencies {
 	// ElasticSearch
 	implementation 'org.springframework.boot:spring-boot-starter-data-elasticsearch'
 
+	// Map Struct
+	implementation 'org.mapstruct:mapstruct:1.4.2.Final'
+	annotationProcessor 'org.mapstruct:mapstruct-processor:1.4.2.Final'
+
 }
 
 test {

--- a/src/main/java/com/even/zaro/config/security/SecurityConfig.java
+++ b/src/main/java/com/even/zaro/config/security/SecurityConfig.java
@@ -49,6 +49,8 @@ public class SecurityConfig {
                                 .requestMatchers( "/api/posts/rank").permitAll()
                                 .requestMatchers("/api/profile/{userId}").permitAll()
                                 .requestMatchers("/api/es/reindex").permitAll()
+                                .requestMatchers(HttpMethod.GET, "/api/favorite/{groupId}/items").permitAll() // 조회는 인증 x
+                                .requestMatchers(HttpMethod.GET, "/api/group/user/{userId}/group").permitAll()
 //                        .requestMatchers("/**").permitAll() // 전체 인증 없이 개발용
                         .anyRequest().authenticated()
                 )

--- a/src/main/java/com/even/zaro/config/security/SecurityConfig.java
+++ b/src/main/java/com/even/zaro/config/security/SecurityConfig.java
@@ -49,7 +49,7 @@ public class SecurityConfig {
                                 .requestMatchers( "/api/posts/rank").permitAll()
                                 .requestMatchers("/api/profile/{userId}").permitAll()
                                 .requestMatchers("/api/es/reindex").permitAll()
-                                .requestMatchers(HttpMethod.GET, "/api/favorite/{groupId}/items").permitAll() // 조회는 인증 x
+                                .requestMatchers(HttpMethod.GET, "/api/favorite/{groupId}/items").permitAll() // 그룹, 즐겨찾기 조회는 인증 필요 x
                                 .requestMatchers(HttpMethod.GET, "/api/group/user/{userId}/group").permitAll()
 //                        .requestMatchers("/**").permitAll() // 전체 인증 없이 개발용
                         .anyRequest().authenticated()

--- a/src/main/java/com/even/zaro/dto/map/PlaceResponse.java
+++ b/src/main/java/com/even/zaro/dto/map/PlaceResponse.java
@@ -16,7 +16,7 @@ public class PlaceResponse {
     @Builder
     @Getter
     static public class PlaceInfo {
-        long place_id;
+        long placeId;
         String name;
         String address;
         String category;

--- a/src/main/java/com/even/zaro/entity/Favorite.java
+++ b/src/main/java/com/even/zaro/entity/Favorite.java
@@ -36,7 +36,6 @@ public class Favorite {
     private Place place;
 
     @Column(name = "memo")
-    @Setter
     private String memo;
 
     @CreationTimestamp
@@ -53,5 +52,9 @@ public class Favorite {
 
     public void setDeleteTrue() {
         isDeleted = true;
+    }
+
+    public void editMemo(String memo) {
+        this.memo = memo;
     }
 }

--- a/src/main/java/com/even/zaro/entity/Favorite.java
+++ b/src/main/java/com/even/zaro/entity/Favorite.java
@@ -49,7 +49,6 @@ public class Favorite {
     @Column(name = "is_deleted", nullable = false)
     private boolean isDeleted;
 
-
     public void setDeleteTrue() {
         isDeleted = true;
     }

--- a/src/main/java/com/even/zaro/entity/FavoriteGroup.java
+++ b/src/main/java/com/even/zaro/entity/FavoriteGroup.java
@@ -26,7 +26,6 @@ public class FavoriteGroup {
 
     // Group 이름
     @Column(name = "name", nullable = false)
-    @Setter
     private String name;
 
     @Column(name = "is_deleted", nullable = false)
@@ -43,5 +42,9 @@ public class FavoriteGroup {
 
     public void setIsDeleted() {
         this.isDeleted = true;
+    }
+
+    public void editGroupName(String name) {
+        this.name = name;
     }
 }

--- a/src/main/java/com/even/zaro/mapper/FavoriteMapper.java
+++ b/src/main/java/com/even/zaro/mapper/FavoriteMapper.java
@@ -1,0 +1,16 @@
+package com.even.zaro.mapper;
+
+import com.even.zaro.dto.favorite.FavoriteAddResponse;
+import com.even.zaro.entity.Favorite;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper(componentModel = "spring")
+public interface FavoriteMapper {
+
+    @Mapping(source = "favorite.place.id", target = "placeId")
+    @Mapping(source = "favorite.place.lat", target = "lat")
+    @Mapping(source = "favorite.place.lng", target = "lng")
+    @Mapping(source = "favorite.place.address", target = "address")
+    FavoriteAddResponse toFavoriteAddResponse(Favorite favorite);
+}

--- a/src/main/java/com/even/zaro/mapper/FavoriteMapper.java
+++ b/src/main/java/com/even/zaro/mapper/FavoriteMapper.java
@@ -1,9 +1,13 @@
 package com.even.zaro.mapper;
 
 import com.even.zaro.dto.favorite.FavoriteAddResponse;
+import com.even.zaro.dto.favorite.FavoriteResponse;
+import com.even.zaro.dto.map.MarkerInfoResponse;
 import com.even.zaro.entity.Favorite;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
+
+import java.util.List;
 
 @Mapper(componentModel = "spring")
 public interface FavoriteMapper {
@@ -13,4 +17,19 @@ public interface FavoriteMapper {
     @Mapping(source = "favorite.place.lng", target = "lng")
     @Mapping(source = "favorite.place.address", target = "address")
     FavoriteAddResponse toFavoriteAddResponse(Favorite favorite);
+
+    @Mapping(source = "favorite.user.id", target = "userId")
+    @Mapping(source = "favorite.group.id", target = "groupId")
+    @Mapping(source = "favorite.place.id", target = "placeId")
+    @Mapping(source = "favorite.place.lat", target = "lat")
+    @Mapping(source = "favorite.place.lng", target = "lng")
+    @Mapping(source = "favorite.place.address", target = "address")
+    @Mapping(target = "isDeleted", expression = "java(favorite.isDeleted())")
+    FavoriteResponse toFavoriteResponse(Favorite favorite);
+
+    default List<FavoriteResponse> toFavoriteResponseList(List<Favorite> favorites) {
+        return favorites.stream()
+                .map(this::toFavoriteResponse)
+                .toList();
+    }
 }

--- a/src/main/java/com/even/zaro/mapper/GroupMapper.java
+++ b/src/main/java/com/even/zaro/mapper/GroupMapper.java
@@ -1,0 +1,23 @@
+package com.even.zaro.mapper;
+
+import com.even.zaro.dto.favorite.FavoriteResponse;
+import com.even.zaro.dto.group.GroupResponse;
+import com.even.zaro.entity.Favorite;
+import com.even.zaro.entity.FavoriteGroup;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+import java.util.List;
+
+@Mapper(componentModel = "spring")
+public interface GroupMapper {
+
+    @Mapping(source = "group.id", target = "groupId")
+    GroupResponse toGroupResponse(FavoriteGroup group);
+
+    default List<GroupResponse> toGroupResponseList(List<FavoriteGroup> groupList) {
+        return groupList.stream()
+                .map(this::toGroupResponse)
+                .toList();
+    }
+}

--- a/src/main/java/com/even/zaro/mapper/MapMapper.java
+++ b/src/main/java/com/even/zaro/mapper/MapMapper.java
@@ -5,16 +5,20 @@ import com.even.zaro.entity.Favorite;
 import com.even.zaro.entity.Place;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
-import org.mapstruct.factory.Mappers;
 
 import java.util.List;
 
 @Mapper(componentModel = "spring")
 public interface MapMapper {
-    MapMapper INSTANCE = Mappers.getMapper(MapMapper.class);
 
     @Mapping(source = "place.id", target = "placeId")
     @Mapping(source = "place.name", target = "placeName")
+    @Mapping(source = "place.address", target = "address")
+    @Mapping(source = "place.lat", target = "lat")
+    @Mapping(source = "place.lng", target = "lng")
+    @Mapping(source = "place.category", target = "category")
+    @Mapping(source = "place.favoriteCount", target = "favoriteCount")
+    @Mapping(source = "userSimpleResponses", target = "usersInfo") // ❗ 명시적으로 매핑
     MarkerInfoResponse toMarkerInfoResponse(Place place, List<MarkerInfoResponse.UserSimpleResponse> userSimpleResponses);
 
     @Mapping(source = "user.id", target = "userId")
@@ -28,5 +32,4 @@ public interface MapMapper {
                 .map(this::toUserSimpleResponse)
                 .toList();
     }
-
 }

--- a/src/main/java/com/even/zaro/mapper/MapMapper.java
+++ b/src/main/java/com/even/zaro/mapper/MapMapper.java
@@ -1,0 +1,32 @@
+package com.even.zaro.mapper;
+
+import com.even.zaro.dto.map.MarkerInfoResponse;
+import com.even.zaro.entity.Favorite;
+import com.even.zaro.entity.Place;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.factory.Mappers;
+
+import java.util.List;
+
+@Mapper(componentModel = "spring")
+public interface MapMapper {
+    MapMapper INSTANCE = Mappers.getMapper(MapMapper.class);
+
+    @Mapping(source = "place.id", target = "placeId")
+    @Mapping(source = "place.name", target = "placeName")
+    MarkerInfoResponse toMarkerInfoResponse(Place place, List<MarkerInfoResponse.UserSimpleResponse> userSimpleResponses);
+
+    @Mapping(source = "user.id", target = "userId")
+    @Mapping(source = "user.profileImage", target = "profileImage")
+    @Mapping(source = "user.nickname", target = "nickname")
+    @Mapping(source = "memo", target = "memo")
+    MarkerInfoResponse.UserSimpleResponse toUserSimpleResponse(Favorite favorite);
+
+    default List<MarkerInfoResponse.UserSimpleResponse> toUserSimpleResponseList(List<Favorite> favorites) {
+        return favorites.stream()
+                .map(this::toUserSimpleResponse)
+                .toList();
+    }
+
+}

--- a/src/main/java/com/even/zaro/repository/FavoriteGroupRepository.java
+++ b/src/main/java/com/even/zaro/repository/FavoriteGroupRepository.java
@@ -9,5 +9,5 @@ import java.util.List;
 public interface FavoriteGroupRepository extends JpaRepository<FavoriteGroup, Long> {
     List<FavoriteGroup> findByUser(User user);
 
-    boolean existsByUser_IdAndName(Long userId, String name);
+    boolean existsByUserIdAndName(Long userId, String name);
 }

--- a/src/main/java/com/even/zaro/repository/PlaceRepository.java
+++ b/src/main/java/com/even/zaro/repository/PlaceRepository.java
@@ -3,6 +3,8 @@ package com.even.zaro.repository;
 import com.even.zaro.entity.Place;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface PlaceRepository extends JpaRepository<Place, Long> {
-    Place findByKakaoPlaceId(long kakaoPlaceId);
+    Optional<Place> findByKakaoPlaceId(long kakaoPlaceId);
 }

--- a/src/main/java/com/even/zaro/service/FavoriteService.java
+++ b/src/main/java/com/even/zaro/service/FavoriteService.java
@@ -13,6 +13,7 @@ import com.even.zaro.global.exception.favorite.FavoriteException;
 import com.even.zaro.global.exception.group.GroupException;
 import com.even.zaro.global.exception.map.MapException;
 import com.even.zaro.global.exception.user.UserException;
+import com.even.zaro.mapper.FavoriteMapper;
 import com.even.zaro.repository.FavoriteGroupRepository;
 import com.even.zaro.repository.FavoriteRepository;
 import com.even.zaro.repository.PlaceRepository;
@@ -34,6 +35,7 @@ public class FavoriteService {
     private final UserRepository userRepository;
     private final PlaceRepository placeRepository;
     private final FavoriteGroupRepository favoriteGroupRepository;
+    private final FavoriteMapper favoriteMapper;
 
     // 그룹에 즐겨찾기를 추가
     public FavoriteAddResponse addFavorite(long groupId, FavoriteAddRequest request, long userId) {
@@ -68,15 +70,7 @@ public class FavoriteService {
 
         favoriteRepository.save(favorite);
 
-        FavoriteAddResponse favoriteAddResponse = FavoriteAddResponse.builder()
-                .placeId(favorite.getPlace().getId())
-                .memo(favorite.getMemo())
-                .lat(favorite.getPlace().getLat())
-                .lng(favorite.getPlace().getLng())
-                .address(favorite.getPlace().getAddress())
-                .build();
-
-        return favoriteAddResponse;
+        return favoriteMapper.toFavoriteAddResponse(favorite);
     }
 
     // 해당 그룹의 즐겨찾기 리스트를 조회

--- a/src/main/java/com/even/zaro/service/FavoriteService.java
+++ b/src/main/java/com/even/zaro/service/FavoriteService.java
@@ -119,7 +119,7 @@ public class FavoriteService {
             throw new FavoriteException(ErrorCode.UNAUTHORIZED_FAVORITE_UPDATE);
         }
 
-        favorite.setMemo(request.getMemo());
+        favorite.editMemo(request.getMemo());
     }
 
     // 해당 즐겨찾기를 soft 삭제

--- a/src/main/java/com/even/zaro/service/FavoriteService.java
+++ b/src/main/java/com/even/zaro/service/FavoriteService.java
@@ -17,13 +17,13 @@ import com.even.zaro.repository.FavoriteGroupRepository;
 import com.even.zaro.repository.FavoriteRepository;
 import com.even.zaro.repository.PlaceRepository;
 import com.even.zaro.repository.UserRepository;
-import lombok.AllArgsConstructor;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Optional;
 
 @Service
 @Slf4j
@@ -145,23 +145,19 @@ public class FavoriteService {
 
     // Place 테이블에 해당 kakaoPlaceId를 가진 데이터 존재 여부 검증
     Place checkDuplicateByKakoPlaceId(FavoriteAddRequest request) {
-        Place getPlace = placeRepository.findByKakaoPlaceId(request.getKakaoPlaceId());
+        Optional<Place> getPlace = placeRepository.findByKakaoPlaceId(request.getKakaoPlaceId());
 
-        // 없다면 새로 생성
-        if (getPlace == null) {
-            Place newPlace = Place.builder()
-                    .kakaoPlaceId(request.getKakaoPlaceId())
-                    .name(request.getPlaceName())
-                    .lat(request.getLat())
-                    .lng(request.getLng())
-                    .category(request.getCategory())
-                    .address(request.getAddress())
-                    .build();
-            placeRepository.save(newPlace);
-
-            return newPlace;
-        }
-        return getPlace;
+        // 장소가 이미 추가되어있지 않았다면, 그 장소를 DB에 저장
+        return getPlace.orElseGet(() ->
+                placeRepository.save(Place.builder()
+                        .kakaoPlaceId(request.getKakaoPlaceId())
+                        .name(request.getPlaceName())
+                        .lat(request.getLat())
+                        .lng(request.getLng())
+                        .category(request.getCategory())
+                        .address(request.getAddress())
+                        .build())
+        );
     }
 
 }

--- a/src/main/java/com/even/zaro/service/FavoriteService.java
+++ b/src/main/java/com/even/zaro/service/FavoriteService.java
@@ -18,6 +18,7 @@ import com.even.zaro.repository.FavoriteRepository;
 import com.even.zaro.repository.PlaceRepository;
 import com.even.zaro.repository.UserRepository;
 import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -26,7 +27,7 @@ import java.util.List;
 
 @Service
 @Slf4j
-@AllArgsConstructor
+@RequiredArgsConstructor
 @Transactional
 public class FavoriteService {
     private final FavoriteRepository favoriteRepository;

--- a/src/main/java/com/even/zaro/service/FavoriteService.java
+++ b/src/main/java/com/even/zaro/service/FavoriteService.java
@@ -84,23 +84,7 @@ public class FavoriteService {
             throw new FavoriteException(ErrorCode.FAVORITE_LIST_NOT_FOUND);
         }
 
-        List<FavoriteResponse> favoriteResponseList = favoriteList.stream().map(favorite ->
-                FavoriteResponse.builder()
-                        .id(favorite.getId())
-                        .userId(favorite.getUser().getId())
-                        .groupId(favorite.getGroup().getId())
-                        .placeId(favorite.getPlace().getId())
-                        .memo(favorite.getMemo())
-                        .createdAt(favorite.getCreatedAt())
-                        .updatedAt(favorite.getUpdatedAt())
-                        .isDeleted(favorite.isDeleted())
-                        .lat(favorite.getPlace().getLat())
-                        .lng(favorite.getPlace().getLng())
-                        .address(favorite.getPlace().getAddress())
-                        .build()
-        ).toList();
-
-        return favoriteResponseList;
+        return favoriteMapper.toFavoriteResponseList(favoriteList);
     }
 
     // 해당 즐겨찾기의 메모를 수정

--- a/src/main/java/com/even/zaro/service/GroupService.java
+++ b/src/main/java/com/even/zaro/service/GroupService.java
@@ -11,6 +11,7 @@ import com.even.zaro.global.exception.user.UserException;
 import com.even.zaro.repository.FavoriteGroupRepository;
 import com.even.zaro.repository.UserRepository;
 import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,7 +21,7 @@ import java.util.List;
 
 @Service
 @Slf4j
-@AllArgsConstructor
+@RequiredArgsConstructor
 @Transactional
 public class GroupService {
     private final UserRepository userRepository;

--- a/src/main/java/com/even/zaro/service/GroupService.java
+++ b/src/main/java/com/even/zaro/service/GroupService.java
@@ -8,6 +8,7 @@ import com.even.zaro.entity.User;
 import com.even.zaro.global.ErrorCode;
 import com.even.zaro.global.exception.group.GroupException;
 import com.even.zaro.global.exception.user.UserException;
+import com.even.zaro.mapper.GroupMapper;
 import com.even.zaro.repository.FavoriteGroupRepository;
 import com.even.zaro.repository.UserRepository;
 import lombok.AllArgsConstructor;
@@ -26,6 +27,7 @@ import java.util.List;
 public class GroupService {
     private final UserRepository userRepository;
     private final FavoriteGroupRepository favoriteGroupRepository;
+    private final GroupMapper groupMapper;
 
     public void createGroup(GroupCreateRequest request, long userid) {
 
@@ -59,19 +61,7 @@ public class GroupService {
             throw new GroupException(ErrorCode.GROUP_LIST_NOT_FOUND);
         }
 
-
-        // GroupResponse 리스트로 변환
-        List<GroupResponse> responseList = groupList.stream().map(group ->
-                        GroupResponse.builder()
-                                .groupId(group.getId())
-                                .name(group.getName())
-                                .isDeleted(group.isDeleted())
-                                .createdAt(group.getCreatedAt())
-                                .updatedAt(group.getUpdatedAt())
-                                .build())
-                .toList();
-
-        return responseList;
+        return groupMapper.toGroupResponseList(groupList);
     }
 
     public void deleteGroup(long groupId, long userId) {

--- a/src/main/java/com/even/zaro/service/GroupService.java
+++ b/src/main/java/com/even/zaro/service/GroupService.java
@@ -114,6 +114,6 @@ public class GroupService {
 
     // 입력한 그룹 이름이 이미 해당 userId가 가지고 있는지 확인
     public boolean groupNameDuplicateCheck(String groupName, long userId) {
-        return favoriteGroupRepository.existsByUser_IdAndName(userId, groupName);
+        return favoriteGroupRepository.existsByUserIdAndName(userId, groupName);
     }
 }

--- a/src/main/java/com/even/zaro/service/GroupService.java
+++ b/src/main/java/com/even/zaro/service/GroupService.java
@@ -108,7 +108,7 @@ public class GroupService {
         if (dupCheck) {
             throw new GroupException(ErrorCode.GROUP_ALREADY_EXIST);
         }
-        group.setName(request.getGroupName());
+        group.editGroupName(request.getGroupName());
     }
 
 

--- a/src/main/java/com/even/zaro/service/MapService.java
+++ b/src/main/java/com/even/zaro/service/MapService.java
@@ -37,36 +37,11 @@ public class MapService {
         // 해당 지역에 메모를 남긴 사용자들 리스트를 가져와야 함.
         List<Favorite> allByPlace = favoriteRepository.findAllByPlace(selectPlace);
 
-        // 유저 요약 정보 순회하며 리스트에 저장
-//        List<MarkerInfoResponse.UserSimpleResponse> userSimpleResponses = allByPlace.stream()
-//                .map(fav -> MarkerInfoResponse.UserSimpleResponse.builder()
-//                        .userId(fav.getUser().getId())
-//                        .profileImage(fav.getUser().getProfileImage())
-//                        .nickname(fav.getUser().getNickname())
-//                        .memo(fav.getMemo())
-//                        .build())
-//                .toList();
+        // 유저 메모 리스트 객체
         List<MarkerInfoResponse.UserSimpleResponse> userSimpleResponseList = mapMapper.toUserSimpleResponseList(allByPlace);
 
-
-
-
-
-        // 생성자를 이용해 응답하도록 수정
+        // 마커 정보
         MarkerInfoResponse markerInfo = mapMapper.toMarkerInfoResponse(selectPlace, userSimpleResponseList);
-
-
-//        MarkerInfoResponse markerInfo = new MarkerInfoResponse(
-//                selectPlace.getId(),
-//                selectPlace.getName(),
-//                selectPlace.getAddress(),
-//                selectPlace.getLat(),
-//                selectPlace.getLng(),
-//                selectPlace.getCategory(),
-//                selectPlace.getFavoriteCount(),
-//                userSimpleResponseList
-//        );
-
 
         return markerInfo;
     }

--- a/src/main/java/com/even/zaro/service/MapService.java
+++ b/src/main/java/com/even/zaro/service/MapService.java
@@ -11,6 +11,7 @@ import com.even.zaro.repository.FavoriteRepository;
 import com.even.zaro.repository.MapQueryRepository;
 import com.even.zaro.repository.PlaceRepository;
 import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -19,7 +20,7 @@ import java.util.List;
 
 @Service
 @Slf4j
-@AllArgsConstructor
+@RequiredArgsConstructor
 @Transactional
 public class MapService {
     private final PlaceRepository placeRepository;

--- a/src/main/java/com/even/zaro/service/MapService.java
+++ b/src/main/java/com/even/zaro/service/MapService.java
@@ -57,7 +57,7 @@ public class MapService {
 
         List<PlaceResponse.PlaceInfo> placeInfos =  placeByCoordinate.stream()
                 .map(place -> PlaceResponse.PlaceInfo.builder()
-                        .place_id(place.getId())
+                        .placeId(place.getId())
                         .name(place.getName())
                         .address(place.getAddress())
                         .lat(place.getLat())

--- a/src/main/java/com/even/zaro/service/MapService.java
+++ b/src/main/java/com/even/zaro/service/MapService.java
@@ -7,6 +7,7 @@ import com.even.zaro.entity.Place;
 import com.even.zaro.global.ErrorCode;
 import com.even.zaro.global.exception.map.MapException;
 import com.even.zaro.global.exception.place.PlaceException;
+import com.even.zaro.mapper.MapMapper;
 import com.even.zaro.repository.FavoriteRepository;
 import com.even.zaro.repository.MapQueryRepository;
 import com.even.zaro.repository.PlaceRepository;
@@ -26,6 +27,7 @@ public class MapService {
     private final PlaceRepository placeRepository;
     private final FavoriteRepository favoriteRepository;
     private final MapQueryRepository mapQueryRepository;
+    private final MapMapper mapMapper;
 
     public MarkerInfoResponse getPlaceInfo(long placeId) {
 
@@ -36,26 +38,34 @@ public class MapService {
         List<Favorite> allByPlace = favoriteRepository.findAllByPlace(selectPlace);
 
         // 유저 요약 정보 순회하며 리스트에 저장
-        List<MarkerInfoResponse.UserSimpleResponse> userSimpleResponses = allByPlace.stream()
-                .map(fav -> MarkerInfoResponse.UserSimpleResponse.builder()
-                        .userId(fav.getUser().getId())
-                        .profileImage(fav.getUser().getProfileImage())
-                        .nickname(fav.getUser().getNickname())
-                        .memo(fav.getMemo())
-                        .build())
-                .toList();
+//        List<MarkerInfoResponse.UserSimpleResponse> userSimpleResponses = allByPlace.stream()
+//                .map(fav -> MarkerInfoResponse.UserSimpleResponse.builder()
+//                        .userId(fav.getUser().getId())
+//                        .profileImage(fav.getUser().getProfileImage())
+//                        .nickname(fav.getUser().getNickname())
+//                        .memo(fav.getMemo())
+//                        .build())
+//                .toList();
+        List<MarkerInfoResponse.UserSimpleResponse> userSimpleResponseList = mapMapper.toUserSimpleResponseList(allByPlace);
+
+
+
+
 
         // 생성자를 이용해 응답하도록 수정
-        MarkerInfoResponse markerInfo = new MarkerInfoResponse(
-                selectPlace.getId(),
-                selectPlace.getName(),
-                selectPlace.getAddress(),
-                selectPlace.getLat(),
-                selectPlace.getLng(),
-                selectPlace.getCategory(),
-                selectPlace.getFavoriteCount(),
-                userSimpleResponses
-        );
+        MarkerInfoResponse markerInfo = mapMapper.toMarkerInfoResponse(selectPlace, userSimpleResponseList);
+
+
+//        MarkerInfoResponse markerInfo = new MarkerInfoResponse(
+//                selectPlace.getId(),
+//                selectPlace.getName(),
+//                selectPlace.getAddress(),
+//                selectPlace.getLat(),
+//                selectPlace.getLng(),
+//                selectPlace.getCategory(),
+//                selectPlace.getFavoriteCount(),
+//                userSimpleResponseList
+//        );
 
 
         return markerInfo;


### PR DESCRIPTION
## 📌 작업 개요
- 멘토링 때 피드백 받은 내용을 수정하고 추가하였습니다.

---

## ✨ 주요 변경 사항
- MapStruct 라이브러리 추가
- @AllArgs -> @RequiredArgs 수정
- @Setter -> 메서드 분리
- 어색한 snake_case -> camelCase 변경
- 인증 없이 그룹, 즐겨찾기 조회할 수 있도록 SecurityConfig 수정

---

## 🖼️ 기능 살펴 보기

---

## ✅ 작업 체크리스트
- [x] API 테스트 완료 (POSTMAN)
- [ ] 스웨거 ui 관련 코드 추가
- [ ] 기능별 예외 케이스 고려
- [ ] log.info / 불필요한 주석 제거
- [x] 변수명, 클래스명, 메서드명 의미있게 작성
- [x] 반복 코드 메서드로 분리

---

## 📂 테스트 방법
- [ ] 테스트 코드 작성
- [ ] 시나리오 기반 테스트 유무
- [x] SwaggerUi 테스트  

---

## 💬 기타 참고 사항
- MapStruct 적용해보면서 느낀 점이 이거 굳이 이렇게까지 해야하나.. ?했는데 
(너무 복잡하다고 느낌 ㅠ)
매핑 필드가 5~6개 이상이고, 여러 개발자가 참여하고 있다면 사용하는 것이 좋다고 하네요
```
1. 매핑 로직의 자동화 → 생산성 향상
	•	일일이 .builder().fieldA(a.getA())... 하는 코드를 작성하지 않아도 됨
	•	컴파일 타임에 매핑 코드 생성 (런타임 Reflection 기반 X → 빠름)

2. 안전성 확보 (컴파일 타임 검증)
	•	DTO나 Entity 필드명이 바뀌면 컴파일 에러 발생 → 숨겨진 버그 방지
	•	Lombok 없이도 타입 안전하게 매핑 가능

3. 테스트 가능한 정형화된 매핑
	•	매핑 로직이 한곳에 집중되어 있어 테스트 및 유지보수가 용이함
	•	서비스 코드가 훨씬 깔끔해지고 비즈니스 로직에 집중 가능
```
이런 장점이 있다고 하네요~~.. 

---

## 📎 관련 이슈 / 문서
- close #118
