### PR TITLE
Ref/error response 공통 예외처리 적용

### DIFF
--- a/src/main/java/com/even/zaro/global/ApiResponse.java
+++ b/src/main/java/com/even/zaro/global/ApiResponse.java
@@ -24,16 +24,4 @@ public class ApiResponse<T> {
     public static <T> ApiResponse<T> success(String message, T data) {
         return new ApiResponse<>("SUCCESS", message, data);
     }
-
-    public static <T> ApiResponse<T> fail(ErrorCode errorCode) {
-        return new ApiResponse<>(errorCode.getCode(), errorCode.getDefaultMessage(), null);
-    }
-
-    public static <T> ApiResponse<T> fail(ErrorCode errorCode, String message) {
-        return new ApiResponse<>(errorCode.getCode(), message, null);
-    }
-
-    public static <T> ApiResponse<T> fail(String code, String message) {
-        return new ApiResponse<>(code, message, null);
-    }
 }

--- a/src/main/java/com/even/zaro/global/ApiResponse.java
+++ b/src/main/java/com/even/zaro/global/ApiResponse.java
@@ -1,21 +1,15 @@
 package com.even.zaro.global;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
-import org.springframework.http.HttpStatus;
 
 @Getter
+@AllArgsConstructor
 public class ApiResponse<T> {
 
     private String code;
     private String message;
     private T data;
-
-    private ApiResponse(String code, String message, T data){
-        this.code = code;
-        this.message = message;
-        this.data = data;
-    }
 
     public static <T> ApiResponse<T> success(String message) {
         return new ApiResponse<>("SUCCESS", message, null);

--- a/src/main/java/com/even/zaro/global/ErrorResponse.java
+++ b/src/main/java/com/even/zaro/global/ErrorResponse.java
@@ -1,0 +1,23 @@
+package com.even.zaro.global;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ErrorResponse {
+    private String code;
+    private String message;
+
+    public static ErrorResponse fail(ErrorCode errorCode) {
+        return new ErrorResponse(errorCode.getCode(), errorCode.getDefaultMessage());
+    }
+
+    public static ErrorResponse fail(ErrorCode errorCode, String message) {
+        return new ErrorResponse(errorCode.getCode(), message);
+    }
+
+    public static ErrorResponse fail(String code, String message) {
+        return new ErrorResponse(code, message);
+    }
+}

--- a/src/main/java/com/even/zaro/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/even/zaro/global/exception/GlobalExceptionHandler.java
@@ -1,9 +1,8 @@
 package com.even.zaro.global.exception;
 
-import com.even.zaro.global.ApiResponse;
+import com.even.zaro.global.ErrorResponse;
 import com.even.zaro.global.ErrorCode;
 import jakarta.persistence.NoResultException;
-import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataAccessException;
 import org.springframework.dao.EmptyResultDataAccessException;
@@ -17,96 +16,96 @@ import org.springframework.web.method.annotation.MethodArgumentTypeMismatchExcep
 public class GlobalExceptionHandler {
     // 커스텀 처리
     @ExceptionHandler(CustomException.class)
-    public ResponseEntity<ApiResponse<?>> handleCustom(CustomException ex) {
+    public ResponseEntity<ErrorResponse> handleCustom(CustomException ex) {
         return ResponseEntity
                 .status(ex.getStatus())
-                .body(ApiResponse.fail(ex.getCode(), ex.getMessage()));
+                .body(ErrorResponse.fail(ex.getCode(), ex.getMessage()));
     }
 
     // 기타 예외 처리
     @ExceptionHandler(Exception.class)
-    public ResponseEntity<ApiResponse<?>> handleGeneralException(Exception ex) {
+    public ResponseEntity<ErrorResponse> handleGeneralException(Exception ex) {
         String message = "요청 url을 다시 확인해보세요 : " + ex.getMessage();
         log.error(message, ex);
         return ResponseEntity
                 .status(ErrorCode.UNKNOWN_REQUEST.getHttpStatus())
-                .body(ApiResponse.fail(ErrorCode.UNKNOWN_REQUEST, message));
+                .body(ErrorResponse.fail(ErrorCode.UNKNOWN_REQUEST, message));
     }
 
     // 이메일 중복 인증 발생 예외 처리
     @ExceptionHandler(IllegalStateException.class)
-    public ResponseEntity<ApiResponse<?>> handleIllegalStateException(IllegalStateException ex) {
+    public ResponseEntity<ErrorResponse> handleIllegalStateException(IllegalStateException ex) {
         log.error(ex.getMessage(), ex);
         return ResponseEntity
                 .status(ErrorCode.ILLEGAL_STATE.getHttpStatus())
-                .body(ApiResponse.fail(ErrorCode.ILLEGAL_STATE));
+                .body(ErrorResponse.fail(ErrorCode.ILLEGAL_STATE));
     }
 
     // 파라미터로 받은 값의 인자가 맞지 않을 때
     @ExceptionHandler(MethodArgumentTypeMismatchException.class)
-    public ResponseEntity<ApiResponse<?>> handleTypeMismatchException(MethodArgumentTypeMismatchException ex) {
+    public ResponseEntity<ErrorResponse> handleTypeMismatchException(MethodArgumentTypeMismatchException ex) {
         String message = String.format("잘못된 요청: '%s' 값을 '%s' 타입으로 변환할 수 없습니다.", ex.getValue(), ex.getRequiredType().getSimpleName());
         log.error(message, ex);
         return ResponseEntity.status(ErrorCode.TYPE_MISMATCH
                 .getHttpStatus())
-                .body(ApiResponse.fail(ErrorCode.TYPE_MISMATCH, message));
+                .body(ErrorResponse.fail(ErrorCode.TYPE_MISMATCH, message));
     }
 
     // 숫자 변환 실패
     @ExceptionHandler(NumberFormatException.class)
-    public ResponseEntity<ApiResponse<?>> handleNumberFormatException(NumberFormatException ex) {
+    public ResponseEntity<ErrorResponse> handleNumberFormatException(NumberFormatException ex) {
         String message = "숫자 변환 오류: " + ex.getMessage();
         log.error(message, ex);
-        return ResponseEntity.status(ErrorCode.NUMBER_FORMAT_ERROR.getHttpStatus()).body(ApiResponse.fail(ErrorCode.NUMBER_FORMAT_ERROR, message));
+        return ResponseEntity.status(ErrorCode.NUMBER_FORMAT_ERROR.getHttpStatus()).body(ErrorResponse.fail(ErrorCode.NUMBER_FORMAT_ERROR, message));
     }
 
     // 데이터베이스 접근 오류
     @ExceptionHandler(DataAccessException.class)
-    public ResponseEntity<ApiResponse<?>> handleDataAccessException(DataAccessException ex) {
+    public ResponseEntity<ErrorResponse> handleDataAccessException(DataAccessException ex) {
         String message = "데이터베이스 오류 발생: " + ex.getMessage();
         log.error(message, ex);
         return ResponseEntity
                 .status(ErrorCode.DB_ACCESS_ERROR.getHttpStatus())
-                .body(ApiResponse.fail(ErrorCode.DB_ACCESS_ERROR, message));
+                .body(ErrorResponse.fail(ErrorCode.DB_ACCESS_ERROR, message));
 
     }
 
     // 요구되는 값이 비어있을 때
     @ExceptionHandler(NullPointerException.class)
-    public ResponseEntity<ApiResponse<?>> handleNullPointerException(NullPointerException ex) {
+    public ResponseEntity<ErrorResponse> handleNullPointerException(NullPointerException ex) {
         String message = "필수 데이터가 누락되었습니다 : " + ex.getMessage();
         log.error(ex.getMessage(), ex);
         return ResponseEntity
                 .status(ErrorCode.NULL_POINTER.getHttpStatus())
-                .body(ApiResponse.fail(ErrorCode.NULL_POINTER, message));
+                .body(ErrorResponse.fail(ErrorCode.NULL_POINTER, message));
 
     }
 
     // 유효하지 않은 요청 파라미터
     @ExceptionHandler(IllegalArgumentException.class)
-    public ResponseEntity<ApiResponse<?>> handleIllegalArgumentException(IllegalArgumentException ex) {
+    public ResponseEntity<ErrorResponse> handleIllegalArgumentException(IllegalArgumentException ex) {
         String message = "잘못된 요청: " + ex.getMessage();
         log.error(message, ex);
         return ResponseEntity
                 .status(ErrorCode.INVALID_ARGUMENT.getHttpStatus())
-                .body(ApiResponse.fail(ErrorCode.INVALID_ARGUMENT, message));
+                .body(ErrorResponse.fail(ErrorCode.INVALID_ARGUMENT, message));
     }
 
     // 특정 예외를 명확히 처리
     @ExceptionHandler(NoResultException.class)
-    public ResponseEntity<ApiResponse<?>> handleNoResultException(NoResultException ex) {
+    public ResponseEntity<ErrorResponse> handleNoResultException(NoResultException ex) {
         log.error(ex.getMessage(), ex);
         return ResponseEntity
                 .status(ErrorCode.NO_RESULT.getHttpStatus())
-                .body(ApiResponse.fail(ErrorCode.NO_RESULT));
+                .body(ErrorResponse.fail(ErrorCode.NO_RESULT));
     }
 
     @ExceptionHandler(EmptyResultDataAccessException.class)
-    public ResponseEntity<ApiResponse<?>> handleEmptyResultException(EmptyResultDataAccessException ex) {
+    public ResponseEntity<ErrorResponse> handleEmptyResultException(EmptyResultDataAccessException ex) {
         String message = "결과가 존재하지 않습니다 : " + ex.getMessage();
         log.error(message, ex);
         return ResponseEntity
                 .status(ErrorCode.EMPTY_RESULT.getHttpStatus())
-                .body(ApiResponse.fail(ErrorCode.EMPTY_RESULT, message));
+                .body(ErrorResponse.fail(ErrorCode.EMPTY_RESULT, message));
     }
 }

--- a/src/main/java/com/even/zaro/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/even/zaro/global/exception/GlobalExceptionHandler.java
@@ -17,6 +17,12 @@ public class GlobalExceptionHandler {
     // 커스텀 처리
     @ExceptionHandler(CustomException.class)
     public ResponseEntity<ErrorResponse> handleCustom(CustomException ex) {
+        log.error("[{}] Status: {}, CustomCode: {}, Message: {}",
+                ex.getClass().getSimpleName(),
+                ex.getStatus().value(),
+                ex.getCode(),
+                ex.getMessage());
+
         return ResponseEntity
                 .status(ex.getStatus())
                 .body(ErrorResponse.fail(ex.getCode(), ex.getMessage()));

--- a/src/main/java/com/even/zaro/healthcheck/HealthCheckController.java
+++ b/src/main/java/com/even/zaro/healthcheck/HealthCheckController.java
@@ -2,6 +2,7 @@ package com.even.zaro.healthcheck;
 
 import com.even.zaro.global.ApiResponse;
 import com.even.zaro.global.ErrorCode;
+import com.even.zaro.global.ErrorResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -24,14 +25,14 @@ public class HealthCheckController {
 
     @Operation(summary = "DB 헬스 체크", description = "DB 연결 상태를 확인합니다.")
     @GetMapping("/health/db")
-    public ResponseEntity<ApiResponse<String>> dbHealth() {
+    public ResponseEntity<?> dbHealth() {
         try {
             mockRepository.count(); // 실제 쿼리로 DB 연결 확인
             return ResponseEntity.ok(ApiResponse.success("DB 연결 성공",null));
         } catch (Exception e) {
             return ResponseEntity
                     .status(ErrorCode.DB_CONNECTION_FAILED.getHttpStatus())
-                    .body(ApiResponse.fail(ErrorCode.DB_CONNECTION_FAILED));
+                    .body(ErrorResponse.fail(ErrorCode.DB_CONNECTION_FAILED));
         }
     }
 }

--- a/src/main/java/com/even/zaro/jwt/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/even/zaro/jwt/JwtAuthenticationEntryPoint.java
@@ -10,8 +10,6 @@ import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
 
 @Component
 public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {

--- a/src/main/java/com/even/zaro/jwt/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/even/zaro/jwt/JwtAuthenticationEntryPoint.java
@@ -1,7 +1,7 @@
 package com.even.zaro.jwt;
 
-import com.even.zaro.global.ApiResponse;
 import com.even.zaro.global.ErrorCode;
+import com.even.zaro.global.ErrorResponse;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -22,7 +22,7 @@ public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
         response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
         response.setContentType("application/json");
 
-        ApiResponse<Object> body = ApiResponse.fail(ErrorCode.AUTH_REQUIRED);
-        objectMapper.writeValue(response.getWriter(), body);
+        ErrorResponse errorResponse = ErrorResponse.fail(ErrorCode.AUTH_REQUIRED);
+        objectMapper.writeValue(response.getWriter(), errorResponse);
     }
 }


### PR DESCRIPTION
## 📌 작업 개요
- 공통 예외처리 수정

---

## ✨ 주요 변경 사항
- 기존 예외처리시 ApiResponse를 공통으로 사용해서 data가 항상 null로 출력됨.
- data를 응답으로 내리지 않는 ErrorResponse를 적용했습니다.
- 로그를 명확히 볼 수 있도록 로깅 처리도 했습니다. (CustomException만 해당)
---

## 🖼️ 기능 살펴 보기
> 포스트맨 요청 응답 스크린샷
- [x] API 문서(요청, 응답)와 일치하는지 확인 - 필요시 API 문서 수정 가능

![image](https://github.com/user-attachments/assets/37b520c1-077c-43d6-8818-9b3a4f40ffb6)

![image](https://github.com/user-attachments/assets/dbcaaaeb-363b-4873-8a9a-26381da9664d)

![image](https://github.com/user-attachments/assets/b7d24806-2a30-4140-91b8-77d617eff6ef)

---

## ✅ 작업 체크리스트
- [ ] API 테스트 완료 (POSTMAN)
- [ ] 스웨거 ui 관련 코드 추가
- [ ] 기능별 예외 케이스 고려
- [ ] log.info / 불필요한 주석 제거
- [ ] 변수명, 클래스명, 메서드명 의미있게 작성
- [ ] 반복 코드 메서드로 분리

---

## 📂 테스트 방법
- [ ] 테스트 코드 작성
- [ ] 시나리오 기반 테스트 유무
    - ex: ID 중복 시 예외 처리 발생

---

## 💬 기타 참고 사항
- 혹시나.. 프론트에서 오류 발생시 롤백 예정입니다. ㅎㅎ

---

## 📎 관련 이슈 / 문서
- 이슈 : Fixes #114 
