### PR TITLE
Fix/timezone 타임존 문제로 LocalDateTime 타입 수정

### DIFF
--- a/src/main/java/com/even/zaro/dto/comment/CommentResponseDto.java
+++ b/src/main/java/com/even/zaro/dto/comment/CommentResponseDto.java
@@ -8,7 +8,6 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 
 @Getter

--- a/src/main/java/com/even/zaro/dto/comment/CommentResponseDto.java
+++ b/src/main/java/com/even/zaro/dto/comment/CommentResponseDto.java
@@ -1,5 +1,6 @@
 package com.even.zaro.dto.comment;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -8,6 +9,7 @@ import lombok.Getter;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 
 @Getter
 @AllArgsConstructor
@@ -29,11 +31,21 @@ public class CommentResponseDto {
     @Schema(description = "자취 시작일", example = "2024-03-01")
     private LocalDate liveAloneDate;
 
-    @Schema(description = "댓글 작성 시간", example = "2025-05-21T14:33:00")
-    private LocalDateTime createdAt;
+    @Schema(description = "댓글 작성 시간", example = "2025-05-21T05:33:00.111Z")
+    @JsonFormat(
+            shape = JsonFormat.Shape.STRING,
+            pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSX",
+            timezone = "UTC"
+    )
+    private OffsetDateTime createdAt;
 
-    @Schema(description = "댓글 수정 시간", example = "2025-05-22T08:15:12")
-    private LocalDateTime updatedAt;
+    @Schema(description = "댓글 수정 시간", example = "2025-05-22T23:15:12.111Z")
+    @JsonFormat(
+            shape = JsonFormat.Shape.STRING,
+            pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSX",
+            timezone = "UTC"
+    )
+    private OffsetDateTime updatedAt;
 
     @Schema(description = "수정 여부", example = "true")
     @JsonProperty("isEdited")

--- a/src/main/java/com/even/zaro/dto/post/PostDetailResponse.java
+++ b/src/main/java/com/even/zaro/dto/post/PostDetailResponse.java
@@ -6,7 +6,6 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
-import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.util.List;
 

--- a/src/main/java/com/even/zaro/dto/post/PostDetailResponse.java
+++ b/src/main/java/com/even/zaro/dto/post/PostDetailResponse.java
@@ -1,11 +1,13 @@
 package com.even.zaro.dto.post;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 import java.util.List;
 
 @Getter
@@ -41,8 +43,13 @@ public class PostDetailResponse {
     @Schema(description = "포스트 이미지 key 리스트", example = "[\"/images/post/uuid1.png\", \"/images/post/uuid2.png\"]")
     private List<String> postImageList;
 
-    @Schema(description = "게시글 생성 일시", example = "2025-05-21T10:15:30")
-    private LocalDateTime createdAt;
+    @Schema(description = "게시글 생성 일시", example = "2025-05-21T10:15:30.111Z")
+    @JsonFormat(
+            shape = JsonFormat.Shape.STRING,
+            pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSX",
+            timezone = "UTC"
+    )
+    private OffsetDateTime createdAt;
 
     @Schema(description = "작성자 정보")
     private UserInfo user;

--- a/src/main/java/com/even/zaro/dto/post/PostPreviewDto.java
+++ b/src/main/java/com/even/zaro/dto/post/PostPreviewDto.java
@@ -1,6 +1,7 @@
 package com.even.zaro.dto.post;
 
 import com.even.zaro.entity.Post;
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
@@ -8,6 +9,8 @@ import lombok.Builder;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.List;
 
 @Getter
@@ -47,9 +50,13 @@ public class PostPreviewDto {
     @Schema(description = "작성자 닉네임", example = "이브니쨩", nullable = true)
     private String writerNickname;
 
-
-    @Schema(description = "게시글 생성 일시", example = "2025-05-21T12:34:56")
-    private LocalDateTime createdAt;
+    @Schema(description = "게시글 생성 일시", example = "2025-05-21T12:34:56.111Z")
+    @JsonFormat(
+            shape = JsonFormat.Shape.STRING,
+            pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSX",
+            timezone = "UTC"
+    )
+    private OffsetDateTime createdAt;
 
     public static PostPreviewDto from(Post post) {
         PostPreviewDto.PostPreviewDtoBuilder builder = PostPreviewDto.builder()
@@ -61,7 +68,7 @@ public class PostPreviewDto {
                 .tag(post.getTag() != null ? post.getTag().name() : null)
                 .likeCount(post.getLikeCount())
                 .commentCount(post.getCommentCount())
-                .createdAt(post.getCreatedAt());
+                .createdAt(post.getCreatedAt().atOffset(ZoneOffset.UTC));
 
         if (post.getCategory() == Post.Category.RANDOM_BUY){
             builder.writerProfileImage(post.getUser().getProfileImage());

--- a/src/main/java/com/even/zaro/dto/post/PostPreviewDto.java
+++ b/src/main/java/com/even/zaro/dto/post/PostPreviewDto.java
@@ -8,10 +8,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
-import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
-import java.util.List;
 
 @Getter
 @AllArgsConstructor

--- a/src/main/java/com/even/zaro/dto/post/PostSearchDto.java
+++ b/src/main/java/com/even/zaro/dto/post/PostSearchDto.java
@@ -3,7 +3,7 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
-import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 
 
 @JsonPropertyOrder({
@@ -51,10 +51,10 @@ public class PostSearchDto {
             pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSX",
             timezone = "UTC"
     )
-    private final LocalDateTime createdAt;
+    private final OffsetDateTime createdAt;
 
     public PostSearchDto(Long postId, String title, String content, String thumbnailImage,
-                         String category, String tag, int likeCount, int commentCount, LocalDateTime createdAt) {
+                         String category, String tag, int likeCount, int commentCount, OffsetDateTime createdAt) {
         this.postId = postId;
         this.title = title;
         this.contentPreview = truncate(content, 50);

--- a/src/main/java/com/even/zaro/dto/post/PostSearchDto.java
+++ b/src/main/java/com/even/zaro/dto/post/PostSearchDto.java
@@ -1,4 +1,5 @@
 package com.even.zaro.dto.post;
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
@@ -44,7 +45,12 @@ public class PostSearchDto {
     @Schema(description = "댓글 수", example = "7")
     private final int commentCount;
 
-    @Schema(description = "게시글 작성 시간", example = "2025-05-23T09:30:00")
+    @Schema(description = "게시글 작성 시간", example = "2025-05-23T09:30:00.111Z")
+    @JsonFormat(
+            shape = JsonFormat.Shape.STRING,
+            pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSX",
+            timezone = "UTC"
+    )
     private final LocalDateTime createdAt;
 
     public PostSearchDto(Long postId, String title, String content, String thumbnailImage,

--- a/src/main/java/com/even/zaro/dto/user/UpdateNicknameResponseDto.java
+++ b/src/main/java/com/even/zaro/dto/user/UpdateNicknameResponseDto.java
@@ -1,9 +1,11 @@
 package com.even.zaro.dto.user;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @Getter
@@ -14,5 +16,9 @@ public class UpdateNicknameResponseDto {
     private String nickname;
 
     @Schema(description = "다음 닉네임 변경 가능 일시", example = "2025-06-13T12:00:00")
-    private LocalDateTime nextAvailableChangeDate;
+    @JsonFormat(
+            shape = JsonFormat.Shape.STRING,
+            pattern = "yyyy-MM-dd"
+    )
+    private LocalDate nextAvailableChangeDate;
 }

--- a/src/main/java/com/even/zaro/dto/user/UserInfoResponseDto.java
+++ b/src/main/java/com/even/zaro/dto/user/UserInfoResponseDto.java
@@ -10,7 +10,6 @@ import lombok.Builder;
 import lombok.Getter;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 
 @Getter

--- a/src/main/java/com/even/zaro/dto/user/UserInfoResponseDto.java
+++ b/src/main/java/com/even/zaro/dto/user/UserInfoResponseDto.java
@@ -2,6 +2,7 @@ package com.even.zaro.dto.user;
 
 import com.even.zaro.entity.Gender;
 import com.even.zaro.entity.Mbti;
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -10,6 +11,7 @@ import lombok.Getter;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 
 @Getter
 @Builder
@@ -39,13 +41,28 @@ public class UserInfoResponseDto {
     private Mbti mbti;
 
     @Schema(description = "계정 생성일", example = "2024-01-01T12:00:00")
-    private LocalDateTime createdAt;
+    @JsonFormat(
+            shape = JsonFormat.Shape.STRING,
+            pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSX",
+            timezone = "UTC"
+    )
+    private OffsetDateTime createdAt;
 
     @Schema(description = "계정 수정일", example = "2024-04-01T18:20:00")
-    private LocalDateTime updatedAt;
+    @JsonFormat(
+            shape = JsonFormat.Shape.STRING,
+            pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSX",
+            timezone = "UTC"
+    )
+    private OffsetDateTime updatedAt;
 
     @Schema(description = "마지막 로그인 일시", example = "2025-05-15T12:30:00")
-    private LocalDateTime lastLoginAt;
+    @JsonFormat(
+            shape = JsonFormat.Shape.STRING,
+            pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSX",
+            timezone = "UTC"
+    )
+    private OffsetDateTime lastLoginAt;
 
     @Schema(description = "회원가입 경로", example = "LOCAL")
     private String provider;

--- a/src/main/java/com/even/zaro/elasticsearch/document/PostEsDocument.java
+++ b/src/main/java/com/even/zaro/elasticsearch/document/PostEsDocument.java
@@ -10,6 +10,8 @@ import org.springframework.data.elasticsearch.annotations.Document;
 import org.springframework.data.elasticsearch.annotations.Field;
 import org.springframework.data.elasticsearch.annotations.FieldType;
 
+import java.time.ZoneOffset;
+
 @Document(indexName = "posts")
 @Getter
 @Builder
@@ -61,7 +63,7 @@ public class PostEsDocument {
                 .tag(post.getTag().name())
                 .likeCount(post.getLikeCount())
                 .commentCount(post.getCommentCount())
-                .createdAt(post.getCreatedAt().toString())
+                .createdAt(post.getCreatedAt().atOffset(ZoneOffset.UTC).toString())
                 .build();
     }
 }

--- a/src/main/java/com/even/zaro/mapper/PostMapper.java
+++ b/src/main/java/com/even/zaro/mapper/PostMapper.java
@@ -9,8 +9,16 @@ import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.Mappings;
 
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+
 @Mapper(componentModel = "spring")
 public interface PostMapper {
+
+    default OffsetDateTime map(LocalDateTime time) {
+        return time != null ? time.atOffset(ZoneOffset.UTC) : null;
+    }
 
     @Mapping(source = "id", target = "postId")
     @Mapping(source = "user.id", target = "user.userId")

--- a/src/main/java/com/even/zaro/service/CommentService.java
+++ b/src/main/java/com/even/zaro/service/CommentService.java
@@ -22,6 +22,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
 
 @Service
@@ -124,6 +126,9 @@ public class CommentService {
         LocalDateTime createdAt = comment.getCreatedAt();
         LocalDateTime updatedAt = comment.getUpdatedAt();
 
+        OffsetDateTime createdAtUtc = createdAt.atOffset(ZoneOffset.UTC);
+        OffsetDateTime updatedAtUtc = updatedAt.atOffset(ZoneOffset.UTC);
+
         boolean isEdited = !createdAt.truncatedTo(ChronoUnit.SECONDS)
                 .isEqual(updatedAt.truncatedTo(ChronoUnit.SECONDS));
 
@@ -144,8 +149,8 @@ public class CommentService {
                 writer.getNickname(),
                 writer.getProfileImage(),
                 writer.getLiveAloneDate(),
-                createdAt,
-                updatedAt,
+                createdAtUtc,
+                updatedAtUtc,
                 isEdited,
                 isMine,
                 mentionedUser

--- a/src/main/java/com/even/zaro/service/PostEsSearchService.java
+++ b/src/main/java/com/even/zaro/service/PostEsSearchService.java
@@ -16,7 +16,7 @@ import org.springframework.stereotype.Service;
 
 
 import java.io.IOException;
-import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Objects;
 
@@ -87,7 +87,7 @@ public class PostEsSearchService {
                             doc.getTag(),
                             doc.getLikeCount(),
                             doc.getCommentCount(),
-                            LocalDateTime.parse(doc.getCreatedAt())
+                            OffsetDateTime.parse(doc.getCreatedAt())
                     );
                 })
                 .filter(Objects::nonNull)

--- a/src/main/java/com/even/zaro/service/UserService.java
+++ b/src/main/java/com/even/zaro/service/UserService.java
@@ -15,6 +15,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.regex.Pattern;
 
@@ -42,9 +43,9 @@ public class UserService {
                 .liveAloneDate(user.getLiveAloneDate())
                 .gender(user.getGender())
                 .mbti(user.getMbti())
-                .createdAt(user.getCreatedAt())
-                .updatedAt(user.getUpdatedAt())
-                .lastLoginAt(user.getLastLoginAt())
+                .createdAt(user.getCreatedAt().atOffset(ZoneOffset.UTC))
+                .updatedAt(user.getUpdatedAt().atOffset(ZoneOffset.UTC))
+                .lastLoginAt(user.getLastLoginAt().atOffset(ZoneOffset.UTC))
                 .provider(user.getProvider().name())
                 .isValidated(user.isValidated())
                 .build();
@@ -101,7 +102,7 @@ public class UserService {
 
         return new UpdateNicknameResponseDto(
                 newNickname,
-                user.getLastNicknameUpdatedAt().plusDays(14)
+                user.getLastNicknameUpdatedAt().plusDays(14).toLocalDate()
         );
     }
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -10,6 +10,10 @@ spring:
   config:
     import: optional:file:.env[.properties]
 
+  #시간 설정
+  jackson:
+    time-zone: UTC
+
   # JPA
   jpa:
     open-in-view: false

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -10,10 +10,6 @@ spring:
   config:
     import: optional:file:.env[.properties]
 
-  #시간 설정
-  jackson:
-    time-zone: Asia/Seoul
-
   # JPA
   jpa:
     open-in-view: false


### PR DESCRIPTION
## 📌 작업 개요
- LocalDateTime 타입 수정
---

## ✨ 주요 변경 사항
- jackson time-zone 설정 제거
- LocalDateTime -> OffsetDateTime 응답 dto에서 타입 변경
    - 게시글 작성, 수정, 댓글 작성, 수정, 내 정보 조회, 검색(es)
- PostMapper 헬퍼 매서드 추가 -> @LJIEUN 확인 바랍니다.

---

## 🖼️ 기능 살펴 보기
> 포스트맨 요청 응답 스크린샷
- [x] API 문서(요청, 응답)와 일치하는지 확인 - 필요시 API 문서 수정 가능

|게시글 작성| 댓글 작성 | 내 정보 조회
|-----------|----------|----------|
|![image](https://github.com/user-attachments/assets/1c204f43-9f30-4cd0-8f48-03635fa69a05)|![image](https://github.com/user-attachments/assets/e937527c-8ec9-442a-859f-b8c639dce41c)|![image](https://github.com/user-attachments/assets/713f18c6-a408-41f0-8cb4-9d5d7b873144)|


|검색| ES 저장(Z가 붙은 형식의 string)|
|----|-------|
|![image](https://github.com/user-attachments/assets/8833af47-ff8b-4485-a4d1-fc7f2e0321f0)|![image](https://github.com/user-attachments/assets/d105ee02-c93c-4d08-8a35-ef8b9ea42709)|


---

## ✅ 작업 체크리스트
- [x] API 테스트 완료 (POSTMAN)
- [ ] 스웨거 ui 관련 코드 추가
- [ ] 기능별 예외 케이스 고려
- [ ] log.info / 불필요한 주석 제거
- [ ] 변수명, 클래스명, 메서드명 의미있게 작성
- [ ] 반복 코드 메서드로 분리

---

## 📂 테스트 방법
- [ ] 테스트 코드 작성
- [ ] 시나리오 기반 테스트 유무
    - ex: ID 중복 시 예외 처리 발생

---

## 💬 기타 참고 사항
- JDBC 설정은 그대로 Asia/seoul로 뒀습니다. DBeaver, Workbench에서 그대로 KST 로 보입니다. 
- 이게 DB에는 UTC로 저장이 된다고 하네요!(실제로 서버, 서버내 컨테이너, mysql 내부 설정 다 UTC 입니다.)
- JDBC로 UTC로 바꾸는게 헷갈리지 않을 것 같기는 한데 일단 이 프로젝트에서는 문제 없을 것으로 판단해서 백엔드 DB 확인시 보기 편하도록 로컬 타임으로 유지했습니다. 

---

## 📎 관련 이슈 / 문서
- 오늘 중으로 트러블 슈팅으로 작성하겠습니다.
