### PR TITLE
Ref/group-favorite 그룹, 즐겨찾기 리팩토링(필드 추가, 필터링, 즐겨찾기 상태 조회API 구현)

### DIFF
--- a/src/main/java/com/even/zaro/controller/FavoriteController.java
+++ b/src/main/java/com/even/zaro/controller/FavoriteController.java
@@ -71,11 +71,11 @@ public class FavoriteController {
     @Operation(summary = "즐겨찾기 여부 확인", description = "유저가 해당 장소를 즐겨찾기 추가했는지 여부를 조회합니다.", security = {@SecurityRequirement(name = "bearer-key")})
     @GetMapping("/check")
     public ResponseEntity<ApiResponse<Boolean>> checkFavorite(@RequestParam long placeId,
-                                                             @AuthenticationPrincipal JwtUserInfoDto userInfoDto) {
+                                                              @AuthenticationPrincipal JwtUserInfoDto userInfoDto) {
         long userId = userInfoDto.getUserId();
 
-        boolean check =  favoriteService.checkFavorite(userId, placeId);
+        boolean check = favoriteService.checkFavorite(userId, placeId);
 
-        return ResponseEntity.ok(ApiResponse.success("즐겨찾기 상태를 조회했습니다.", check));
+        return ResponseEntity.ok(ApiResponse.success(String.format("즐겨찾기 상태 : " + check), check));
     }
 }

--- a/src/main/java/com/even/zaro/controller/FavoriteController.java
+++ b/src/main/java/com/even/zaro/controller/FavoriteController.java
@@ -67,4 +67,15 @@ public class FavoriteController {
 
         return ResponseEntity.ok(ApiResponse.success("즐겨찾기가 성공적으로 삭제되었습니다."));
     }
+
+    @Operation(summary = "즐겨찾기 여부 확인", description = "유저가 해당 장소를 즐겨찾기 추가했는지 여부를 조회합니다.", security = {@SecurityRequirement(name = "bearer-key")})
+    @GetMapping("/check")
+    public ResponseEntity<ApiResponse<Boolean>> checkFavorite(@RequestParam long placeId,
+                                                             @AuthenticationPrincipal JwtUserInfoDto userInfoDto) {
+        long userId = userInfoDto.getUserId();
+
+        boolean check =  favoriteService.checkFavorite(userId, placeId);
+
+        return ResponseEntity.ok(ApiResponse.success("즐겨찾기 상태를 조회했습니다.", check));
+    }
 }

--- a/src/main/java/com/even/zaro/dto/group/GroupResponse.java
+++ b/src/main/java/com/even/zaro/dto/group/GroupResponse.java
@@ -24,4 +24,7 @@ public class GroupResponse {
 
     @Schema(description = "수정 시각", example = "2025-03-25T05:20:00")
     private LocalDateTime updatedAt;
+
+    @Schema(description = "그룹의 즐겨찾기 개수", example = "2")
+    private int groupFavoriteCount;
 }

--- a/src/main/java/com/even/zaro/entity/Favorite.java
+++ b/src/main/java/com/even/zaro/entity/Favorite.java
@@ -47,10 +47,10 @@ public class Favorite {
     private LocalDateTime updatedAt;
 
     @Column(name = "is_deleted", nullable = false)
-    private boolean isDeleted;
+    private boolean deleted;
 
     public void setDeleteTrue() {
-        isDeleted = true;
+        deleted = true;
     }
 
     public void editMemo(String memo) {

--- a/src/main/java/com/even/zaro/entity/FavoriteGroup.java
+++ b/src/main/java/com/even/zaro/entity/FavoriteGroup.java
@@ -40,6 +40,10 @@ public class FavoriteGroup {
     @UpdateTimestamp
     private LocalDateTime updatedAt;
 
+    @Column(name = "favorite_count") // 그룹에 속한 즐겨찾기 개수
+    @Builder.Default
+    private int favoriteCount = 0;
+
     public void setIsDeleted() {
         this.isDeleted = true;
     }
@@ -47,4 +51,14 @@ public class FavoriteGroup {
     public void editGroupName(String name) {
         this.name = name;
     }
+
+    public void incrementFavoriteCount() {
+        this.favoriteCount++;
+    }
+
+    public void decrementFavoriteCount() {
+        this.favoriteCount--;
+    }
+
+
 }

--- a/src/main/java/com/even/zaro/entity/FavoriteGroup.java
+++ b/src/main/java/com/even/zaro/entity/FavoriteGroup.java
@@ -40,7 +40,7 @@ public class FavoriteGroup {
     @UpdateTimestamp
     private LocalDateTime updatedAt;
 
-    @Column(name = "favorite_count") // 그룹에 속한 즐겨찾기 개수
+    @Column(name = "favorite_count", nullable = false) // 그룹에 속한 즐겨찾기 개수
     @Builder.Default
     private int favoriteCount = 0;
 

--- a/src/main/java/com/even/zaro/entity/FavoriteGroup.java
+++ b/src/main/java/com/even/zaro/entity/FavoriteGroup.java
@@ -30,7 +30,7 @@ public class FavoriteGroup {
 
     @Column(name = "is_deleted", nullable = false)
     @Builder.Default
-    private boolean isDeleted = false;
+    private boolean deleted = false;
 
     @CreationTimestamp
     @Column(name = "created_at", nullable = false, updatable = false)
@@ -45,7 +45,7 @@ public class FavoriteGroup {
     private int favoriteCount = 0;
 
     public void setIsDeleted() {
-        this.isDeleted = true;
+        this.deleted = true;
     }
 
     public void editGroupName(String name) {

--- a/src/main/java/com/even/zaro/mapper/GroupMapper.java
+++ b/src/main/java/com/even/zaro/mapper/GroupMapper.java
@@ -1,8 +1,6 @@
 package com.even.zaro.mapper;
 
-import com.even.zaro.dto.favorite.FavoriteResponse;
 import com.even.zaro.dto.group.GroupResponse;
-import com.even.zaro.entity.Favorite;
 import com.even.zaro.entity.FavoriteGroup;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
@@ -13,6 +11,7 @@ import java.util.List;
 public interface GroupMapper {
 
     @Mapping(source = "group.id", target = "groupId")
+    @Mapping(source = "group.favoriteCount", target = "groupFavoriteCount")
     GroupResponse toGroupResponse(FavoriteGroup group);
 
     default List<GroupResponse> toGroupResponseList(List<FavoriteGroup> groupList) {

--- a/src/main/java/com/even/zaro/repository/FavoriteGroupRepository.java
+++ b/src/main/java/com/even/zaro/repository/FavoriteGroupRepository.java
@@ -7,7 +7,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 
 public interface FavoriteGroupRepository extends JpaRepository<FavoriteGroup, Long> {
-    List<FavoriteGroup> findByUser(User user);
-
     boolean existsByUserIdAndName(Long userId, String name);
+
+    List<FavoriteGroup> findAllByUserAndDeletedFalse(User user);
 }

--- a/src/main/java/com/even/zaro/repository/FavoriteRepository.java
+++ b/src/main/java/com/even/zaro/repository/FavoriteRepository.java
@@ -15,4 +15,5 @@ public interface FavoriteRepository extends JpaRepository<Favorite, Long> {
     @EntityGraph(attributePaths = { "user"})
     List<Favorite> findAllByPlace(Place place);
     List<Favorite> findByPlaceAndUser(Place place, User user);
+    List<Favorite> findAllByGroupAndIsDeletedFalse(FavoriteGroup group);
 }

--- a/src/main/java/com/even/zaro/repository/FavoriteRepository.java
+++ b/src/main/java/com/even/zaro/repository/FavoriteRepository.java
@@ -10,11 +10,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 
 public interface FavoriteRepository extends JpaRepository<Favorite, Long> {
-    List<Favorite> findAllByGroup(FavoriteGroup group);
-
     @EntityGraph(attributePaths = { "user"})
     List<Favorite> findAllByPlace(Place place);
-    List<Favorite> findAllByGroupAndIsDeletedFalse(FavoriteGroup group);
+    List<Favorite> findAllByGroupAndDeletedFalse(FavoriteGroup group);
 
     boolean existsByPlaceAndUser(Place place, User user);
 }

--- a/src/main/java/com/even/zaro/repository/FavoriteRepository.java
+++ b/src/main/java/com/even/zaro/repository/FavoriteRepository.java
@@ -14,6 +14,7 @@ public interface FavoriteRepository extends JpaRepository<Favorite, Long> {
 
     @EntityGraph(attributePaths = { "user"})
     List<Favorite> findAllByPlace(Place place);
-    List<Favorite> findByPlaceAndUser(Place place, User user);
     List<Favorite> findAllByGroupAndIsDeletedFalse(FavoriteGroup group);
+
+    boolean existsByPlaceAndUser(Place place, User user);
 }

--- a/src/main/java/com/even/zaro/service/FavoriteService.java
+++ b/src/main/java/com/even/zaro/service/FavoriteService.java
@@ -50,11 +50,11 @@ public class FavoriteService {
         // 해당 장소가 이미 저장되어있는지 없다면 장소 추가
         Place place = checkDuplicateByKakoPlaceId(request);
 
-        // 해당 유저가 이미 그 장소를 추가했는지 확인하고 저장
-        List<Favorite> placeList = favoriteRepository.findByPlaceAndUser(place, user);
+        // 해당 유저가 이미 그 장소를 추가했는지 확인
+        boolean check = favoriteRepository.existsByPlaceAndUser(place, user);
 
         // 해당 유저가 placeId가 일치하는 장소가 이미 추가되어있다면
-        if (placeList.size() > 0) {
+        if (check) {
             throw new FavoriteException(ErrorCode.FAVORITE_ALREADY_EXISTS);
         }
 
@@ -159,13 +159,10 @@ public class FavoriteService {
         Place place = placeRepository.findById(placeId)
                 .orElseThrow(() -> new PlaceException(ErrorCode.PLACE_NOT_FOUND));
 
-        // 해당 유저가 이미 그 장소를 추가했는지 확인하고 저장
-        List<Favorite> placeList = favoriteRepository.findByPlaceAndUser(place, user);
 
-        // 해당 유저가 placeId가 일치하는 장소가 이미 추가되어있다면
-        if (placeList.size() > 0) {
-            return true;
-        }
-        return false;
+        // 해당 유저가 이미 그 장소를 추가했는지 확인
+        boolean check = favoriteRepository.existsByPlaceAndUser(place, user);
+
+        return check;
     }
 }

--- a/src/main/java/com/even/zaro/service/FavoriteService.java
+++ b/src/main/java/com/even/zaro/service/FavoriteService.java
@@ -68,6 +68,9 @@ public class FavoriteService {
         // 즐겨찾기 개수 1 증가
         place.incrementFavoriteCount();
 
+        // 그룹의 즐겨찾기 개수 1 증가
+        group.incrementFavoriteCount();
+
         favoriteRepository.save(favorite);
 
         return favoriteMapper.toFavoriteAddResponse(favorite);
@@ -126,6 +129,14 @@ public class FavoriteService {
 
         // 즐겨찾기 개수 1 감소
         place.decrementFavoriteCount();
+
+        // 해당 즐겨찾기가 포함된 그룹
+        FavoriteGroup group = favoriteGroupRepository.findById(favorite.getGroup().getId())
+                .orElseThrow(() -> new GroupException(ErrorCode.GROUP_NOT_FOUND));
+
+        // 그룹의 즐겨찾기 개수 1 감소
+        group.decrementFavoriteCount();
+
         // 삭제 상태 변경
         favorite.setDeleteTrue();
     }

--- a/src/main/java/com/even/zaro/service/FavoriteService.java
+++ b/src/main/java/com/even/zaro/service/FavoriteService.java
@@ -63,7 +63,7 @@ public class FavoriteService {
                 .group(group)
                 .place(place)
                 .memo(request.getMemo())
-                .isDeleted(false)
+                .deleted(false)
                 .build();
 
         // 즐겨찾기 개수 1 증가
@@ -83,7 +83,7 @@ public class FavoriteService {
                 .orElseThrow(() -> new GroupException(ErrorCode.GROUP_NOT_FOUND));
 
         // 삭제된 데이터 제외하고 조회
-        List<Favorite> activeFavoriteList = favoriteRepository.findAllByGroupAndIsDeletedFalse(group);
+        List<Favorite> activeFavoriteList = favoriteRepository.findAllByGroupAndDeletedFalse(group);
 
         if (activeFavoriteList.isEmpty()) {
             throw new FavoriteException(ErrorCode.FAVORITE_LIST_NOT_FOUND);

--- a/src/main/java/com/even/zaro/service/FavoriteService.java
+++ b/src/main/java/com/even/zaro/service/FavoriteService.java
@@ -81,16 +81,8 @@ public class FavoriteService {
         FavoriteGroup group = favoriteGroupRepository.findById(groupId)
                 .orElseThrow(() -> new GroupException(ErrorCode.GROUP_NOT_FOUND));
 
-        List<Favorite> favoriteList = favoriteRepository.findAllByGroup(group);
-
-        if (favoriteList.isEmpty()) {
-            throw new FavoriteException(ErrorCode.FAVORITE_LIST_NOT_FOUND);
-        }
-
-        // 삭제되지 않은 즐겨찾기만 조회
-        List<Favorite> activeFavoriteList = favoriteList.stream()
-                .filter(favorite -> !favorite.isDeleted())
-                .toList();
+        // 삭제된 데이터 제외하고 조회
+        List<Favorite> activeFavoriteList = favoriteRepository.findAllByGroupAndIsDeletedFalse(group);
 
         if (activeFavoriteList.isEmpty()) {
             throw new FavoriteException(ErrorCode.FAVORITE_LIST_NOT_FOUND);
@@ -141,6 +133,7 @@ public class FavoriteService {
         favorite.setDeleteTrue();
     }
 
+
     // Place 테이블에 해당 kakaoPlaceId를 가진 데이터 존재 여부 검증
     Place checkDuplicateByKakoPlaceId(FavoriteAddRequest request) {
         Optional<Place> getPlace = placeRepository.findByKakaoPlaceId(request.getKakaoPlaceId());
@@ -158,4 +151,12 @@ public class FavoriteService {
         );
     }
 
+    public boolean checkFavorite(long userId, long placeId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserException(ErrorCode.USER_NOT_FOUND));
+
+
+
+        return false;
+    }
 }

--- a/src/main/java/com/even/zaro/service/FavoriteService.java
+++ b/src/main/java/com/even/zaro/service/FavoriteService.java
@@ -84,7 +84,16 @@ public class FavoriteService {
             throw new FavoriteException(ErrorCode.FAVORITE_LIST_NOT_FOUND);
         }
 
-        return favoriteMapper.toFavoriteResponseList(favoriteList);
+        // 삭제되지 않은 즐겨찾기만 조회
+        List<Favorite> activeFavoriteList = favoriteList.stream()
+                .filter(favorite -> !favorite.isDeleted())
+                .toList();
+
+        if (activeFavoriteList.isEmpty()) {
+            throw new FavoriteException(ErrorCode.FAVORITE_LIST_NOT_FOUND);
+        }
+
+        return favoriteMapper.toFavoriteResponseList(activeFavoriteList);
     }
 
     // 해당 즐겨찾기의 메모를 수정

--- a/src/main/java/com/even/zaro/service/FavoriteService.java
+++ b/src/main/java/com/even/zaro/service/FavoriteService.java
@@ -12,6 +12,7 @@ import com.even.zaro.global.ErrorCode;
 import com.even.zaro.global.exception.favorite.FavoriteException;
 import com.even.zaro.global.exception.group.GroupException;
 import com.even.zaro.global.exception.map.MapException;
+import com.even.zaro.global.exception.place.PlaceException;
 import com.even.zaro.global.exception.user.UserException;
 import com.even.zaro.mapper.FavoriteMapper;
 import com.even.zaro.repository.FavoriteGroupRepository;
@@ -155,8 +156,16 @@ public class FavoriteService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new UserException(ErrorCode.USER_NOT_FOUND));
 
+        Place place = placeRepository.findById(placeId)
+                .orElseThrow(() -> new PlaceException(ErrorCode.PLACE_NOT_FOUND));
 
+        // 해당 유저가 이미 그 장소를 추가했는지 확인하고 저장
+        List<Favorite> placeList = favoriteRepository.findByPlaceAndUser(place, user);
 
+        // 해당 유저가 placeId가 일치하는 장소가 이미 추가되어있다면
+        if (placeList.size() > 0) {
+            return true;
+        }
         return false;
     }
 }

--- a/src/main/java/com/even/zaro/service/GroupService.java
+++ b/src/main/java/com/even/zaro/service/GroupService.java
@@ -61,7 +61,15 @@ public class GroupService {
             throw new GroupException(ErrorCode.GROUP_LIST_NOT_FOUND);
         }
 
-        return groupMapper.toGroupResponseList(groupList);
+       List<FavoriteGroup> activeGroups = groupList.stream()
+               .filter(group -> !group.isDeleted()) // false인 데이터들만 남김
+               .toList();
+
+        if (activeGroups.isEmpty()) {
+            throw new GroupException(ErrorCode.GROUP_LIST_NOT_FOUND);
+        }
+
+        return groupMapper.toGroupResponseList(activeGroups);
     }
 
     public void deleteGroup(long groupId, long userId) {

--- a/src/main/java/com/even/zaro/service/GroupService.java
+++ b/src/main/java/com/even/zaro/service/GroupService.java
@@ -10,14 +10,13 @@ import com.even.zaro.global.exception.group.GroupException;
 import com.even.zaro.global.exception.user.UserException;
 import com.even.zaro.mapper.GroupMapper;
 import com.even.zaro.repository.FavoriteGroupRepository;
+import com.even.zaro.repository.FavoriteRepository;
 import com.even.zaro.repository.UserRepository;
-import lombok.AllArgsConstructor;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
 import java.util.List;
 
 @Service
@@ -28,6 +27,7 @@ public class GroupService {
     private final UserRepository userRepository;
     private final FavoriteGroupRepository favoriteGroupRepository;
     private final GroupMapper groupMapper;
+    private final FavoriteRepository favoriteRepository;
 
     public void createGroup(GroupCreateRequest request, long userid) {
 
@@ -63,7 +63,7 @@ public class GroupService {
 
         // 삭제되지 않은 그룹만 조회
        List<FavoriteGroup> activeGroups = groupList.stream()
-               .filter(group -> !group.isDeleted()) // false인 데이터들만 남김
+               .filter(group -> !group.isDeleted())// false인 데이터들만 남김
                .toList();
 
         if (activeGroups.isEmpty()) {

--- a/src/main/java/com/even/zaro/service/GroupService.java
+++ b/src/main/java/com/even/zaro/service/GroupService.java
@@ -61,6 +61,7 @@ public class GroupService {
             throw new GroupException(ErrorCode.GROUP_LIST_NOT_FOUND);
         }
 
+        // 삭제되지 않은 그룹만 조회
        List<FavoriteGroup> activeGroups = groupList.stream()
                .filter(group -> !group.isDeleted()) // false인 데이터들만 남김
                .toList();

--- a/src/main/java/com/even/zaro/service/GroupService.java
+++ b/src/main/java/com/even/zaro/service/GroupService.java
@@ -54,17 +54,8 @@ public class GroupService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new UserException(ErrorCode.USER_NOT_FOUND));
 
-        // userId 값이 일치하는 데이터 조회
-        List<FavoriteGroup> groupList = favoriteGroupRepository.findByUser(user);
-
-        if (groupList.isEmpty()) {
-            throw new GroupException(ErrorCode.GROUP_LIST_NOT_FOUND);
-        }
-
-        // 삭제되지 않은 그룹만 조회
-       List<FavoriteGroup> activeGroups = groupList.stream()
-               .filter(group -> !group.isDeleted())// false인 데이터들만 남김
-               .toList();
+        // userId 값이 일치하고, 삭제된 데이터를 제외하고 조회
+        List<FavoriteGroup> activeGroups = favoriteGroupRepository.findAllByUserAndDeletedFalse(user);
 
         if (activeGroups.isEmpty()) {
             throw new GroupException(ErrorCode.GROUP_LIST_NOT_FOUND);


### PR DESCRIPTION
## 📌 작업 개요
- 그룹에 즐겨찾기를 추가, 삭제할 때 그룹 테이블의 즐겨찾기 개수 필드값이 증감하도록 하였습니다.
- 그룹, 즐겨찾기 리스트를 조회할 때, 삭제된 데이터는 조회되지 않도록 수정했습니다.
- 장소에 대해 즐겨찾기 상태를 조회할 수 있는 API를 구현했습니다.

---

## ✨ 주요 변경 사항
- 그룹 조회 시 삭제된 데이터 필터링
- 그룹의 즐겨찾기 조회 시 삭제된 데이터 필터링
- 그룹에 즐겨찾기 개수 필드 추가 (favorite_count)
- 그룹 조회 응답 Dto에 그룹의 즐겨찾기 개수 응답 추가 (groupFavoriteCount)
- 그룹 객체에 즐겨찾기 추가, 삭제에 따른 메서드 추가
(incrementFavoriteCount, decrementFavoriteCount)
- 유저가 해당 장소를 즐겨찾기 추가했는지 조회하는 API 구현

---

## 🖼️ 기능 살펴 보기
> ![스크린샷 2025-06-06 오전 2 08 07](https://github.com/user-attachments/assets/0cb41992-431e-4b6f-8d79-f9419b5fb45d)
- 그룹id 6에 대해서 즐겨찾기 리스트 확인 (placeId 11, 27이 이미 추가되어있음.)

> ![image](https://github.com/user-attachments/assets/6a3c87b9-6f03-433d-a022-37d87731e0b9)
> ![image](https://github.com/user-attachments/assets/6c3312b6-915e-4956-a1ad-3cea46a2d01e)
- placeId 11, 27 로 테스트. true 응답

> ![image](https://github.com/user-attachments/assets/0cd4d372-e607-41da-9ead-109c79a0ce02)
- 전체 placeList
> ![image](https://github.com/user-attachments/assets/dfdf4cf7-3d16-4a1f-a3bb-8134c99b613d)
>  ![image](https://github.com/user-attachments/assets/5d2d5d33-ea8b-4d95-8a1a-488b87ebf792)
- placeId 7, 8 로 테스트, false 응답



---

## ✅ 작업 체크리스트
- [x] API 테스트 완료 (POSTMAN)
- [x] 스웨거 ui 관련 코드 추가
- [x] 기능별 예외 케이스 고려
- [x] log.info / 불필요한 주석 제거
- [x] 변수명, 클래스명, 메서드명 의미있게 작성
- [x] 반복 코드 메서드로 분리

---

## 📂 테스트 방법
- Swagger 테스트 완료 

---

## 💬 기타 참고 사항
- RDS DB의 그룹 테이블과 이번에 필드가 추가되면서 바뀐 테이블과 다르기 때문에 충돌이 발생할 수 있습니다
- pr반영 후 기존 데이터의 즐겨찾기 카운트가 null로 되어있을 것인데 수동으로 0으로 데이터를 초기화해야할 수 있습니다. (제 로컬에서 작업할 때 그렇게 했더니 됐습니다.)

---

## 📎 관련 이슈 / 문서
- close #135  
- close #134 
- close #137
