### PR TITLE
Feat/dormant user 휴면계정 처리

### DIFF
--- a/src/main/java/com/even/zaro/repository/UserRepository.java
+++ b/src/main/java/com/even/zaro/repository/UserRepository.java
@@ -21,5 +21,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByNickname(String nickname);
 
+    List<User> findByStatusAndLastLoginAtBefore(Status status, LocalDateTime time);
+    List<User> findByStatusAndUpdatedAtBefore(Status status, LocalDateTime time);
     List<User> findByStatusAndDeletedAtBefore(Status status, LocalDateTime threshold);
 }

--- a/src/main/java/com/even/zaro/service/AuthService.java
+++ b/src/main/java/com/even/zaro/service/AuthService.java
@@ -181,6 +181,8 @@ public class AuthService {
         String accessToken = tokens[0];
         String refreshToken = tokens[1];
 
+        reactivateIfDormant(user);
+
         // lastLoginAt
         user.updateLastLoginAt(LocalDateTime.now());
         userRepository.save(user);
@@ -207,6 +209,12 @@ public class AuthService {
     private void validateNotDeleted(User user) {
         if (user.getStatus() == Status.DELETED) {
             throw new UserException(ErrorCode.USER_ALREADY_DELETED);
+        }
+    }
+
+    private void reactivateIfDormant(User user) {
+        if (user.getStatus() == Status.DORMANT) {
+            user.updateStatusToActive();
         }
     }
 }

--- a/src/test/java/com/even/zaro/integration/UserSchedulerIntegrationTest.java
+++ b/src/test/java/com/even/zaro/integration/UserSchedulerIntegrationTest.java
@@ -45,7 +45,7 @@ public class UserSchedulerIntegrationTest {
                     .password("Password1!")
                     .provider(Provider.LOCAL)
                     .status(Status.ACTIVE)
-                    .lastLoginAt(now.minusMonths(7))
+                    .lastLoginAt(now.minusMonths(6).minusDays(1))
                     .build();
 
             userRepository.save(activeUser);


### PR DESCRIPTION
## 📌 작업 개요
- 휴면계정 처리

---

## ✨ 주요 변경 사항
- 휴면계정 처리
   - 6개월 미접속시 휴면 처리 스케줄러
   - 휴면 경과 1년 이상 탈퇴처리 스케줄러
   - 탈퇴 30일 경과 정보 영구 삭제 스케줄러 시간 변경
   - 로그인시 자동 휴면 복구 처리

---

## 🖼️ 기능 살펴 보기
> 포스트맨 요청 응답 스크린샷
- [x] API 문서(요청, 응답)와 일치하는지 확인 - 필요시 API 문서 수정 가능
로그인 시 휴면 자동 해제만 확인

|휴면 계정  | 로그인 | 휴면 해제(ACTIVE)
|---------|--------|---------|
|![image](https://github.com/user-attachments/assets/663c4c2f-cdad-4d4c-a57f-6daa5878afc4)|![image](https://github.com/user-attachments/assets/39f5ccc8-3681-4544-9c62-2306adfea140)|![image](https://github.com/user-attachments/assets/3c3ef045-ed21-4063-acc1-94876c1e38ad)





---

## ✅ 작업 체크리스트
- [x] API 테스트 완료 (POSTMAN)
- [x] 스웨거 ui 관련 코드 추가
- [x] 기능별 예외 케이스 고려
- [x] log.info / 불필요한 주석 제거
- [x] 변수명, 클래스명, 메서드명 의미있게 작성
- [x] 반복 코드 메서드로 분리

---

## 📂 테스트 방법
- [x] 테스트 코드 작성
- [x] 시나리오 기반 테스트 유무
    - 6개월 1일 지난 회원 휴면처리
    - 휴면 후 1년 1일 지난 회원 탈퇴 처리 
![image](https://github.com/user-attachments/assets/e134252a-868e-4229-961d-f58dac060e66)

---

## 💬 기타 참고 사항
- 6개월, 1년 후 스케줄러는 테스트 코드로 로직 확인했습니다. 별도 스케줄러 시간 조절로 테스트 하지는 않았습니다.
- 휴면 1개월 전 메일 처리는 이후에 작업할 예정입니다!

---

## 📎 관련 이슈 / 문서
- 관련 이슈 번호: #88 
