### PR TITLE
Fix/signout token 로그아웃 API 수정

### DIFF
--- a/src/main/java/com/even/zaro/controller/AuthController.java
+++ b/src/main/java/com/even/zaro/controller/AuthController.java
@@ -2,7 +2,6 @@ package com.even.zaro.controller;
 
 import com.even.zaro.dto.auth.*;
 import com.even.zaro.dto.jwt.JwtUserInfoDto;
-import com.even.zaro.entity.PasswordResetToken;
 import com.even.zaro.global.ApiResponse;
 import com.even.zaro.global.ErrorCode;
 import com.even.zaro.global.exception.user.UserException;
@@ -12,16 +11,15 @@ import com.even.zaro.service.EmailVerificationService;
 import com.even.zaro.service.PasswordResetService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.parameters.P;
 import org.springframework.web.bind.annotation.*;
 
 import java.io.IOException;
@@ -74,10 +72,11 @@ public class AuthController {
     @Operation(summary = "로그아웃", description = "헤더의 access-token를 받아 로그아웃 처리를 합니다.",
             security = {@SecurityRequirement(name = "bearer-key")})
     @PostMapping("/signout")
-    public ResponseEntity<ApiResponse<Void>> signOut(@RequestHeader("Authorization") String accessToken,
+    public ResponseEntity<ApiResponse<Void>> signOut(HttpServletRequest request,
                                                      @AuthenticationPrincipal JwtUserInfoDto userInfoDto) {
-        String token = jwtUtil.extractBearerPrefix(accessToken);
+        String token = jwtUtil.extractBearerPrefix(request.getHeader("Authorization"));
         authService.signOut(userInfoDto.getUserId(), token);
+
         return ResponseEntity.ok(ApiResponse.success("로그아웃 되었습니다."));
     }
 


### PR DESCRIPTION
## 📌 작업 개요
- 로그아웃 API 수정 

---

## ✨ 주요 변경 사항
- 토큰 헤더 자동 추출으로 변경
    - 기존 헤더에서 한번 더 전송 필요 -> 헤더에서 자동 추출로 변경
- 리프레시 토큰 쿠키에서 삭제
    - 프론트에서 리프레시 토큰은 쿠키에 저장시 HttpOnly로 저장했기에 서버에서 변경해줘야 반영되는 것을 확인.
    - 로그아웃 컨트롤러에서 리프레시 토큰 쿠키에서 삭제하는 로직 추가 

---

## 🖼️ 기능 살펴 보기
> 포스트맨 요청 응답 스크린샷
- [x] API 문서(요청, 응답)와 일치하는지 확인 - 필요시 API 문서 수정 가능

|기존 - 헤더에서 한번 더 전송 필요| 변경 후 - 헤더에서 자동 추출|
|-----------|-----------|
|![image](https://github.com/user-attachments/assets/38395368-5c95-4d26-aa00-81f0facce1d0)|![image](https://github.com/user-attachments/assets/0a3a1b7d-e255-419c-a2f0-270006ca5e07)|

---

## ✅ 작업 체크리스트
- [x] API 테스트 완료 (POSTMAN)
- [x] 스웨거 ui 관련 코드 추가
- [ ] 기능별 예외 케이스 고려
- [ ] log.info / 불필요한 주석 제거
- [ ] 변수명, 클래스명, 메서드명 의미있게 작성
- [ ] 반복 코드 메서드로 분리

---

## 📂 테스트 방법
- [ ] 테스트 코드 작성
- [ ] 시나리오 기반 테스트 유무
    - ex: ID 중복 시 예외 처리 발생

---

## 💬 기타 참고 사항
- 리프레시 토큰은 쿠키에서 잘 삭제되는지 프론트 작업하면서 확인해야할 것 같습니다!

---

## 📎 관련 이슈 / 문서

