### PR TITLE
Test/notification sse : NotificationMapper, NotificationSseService 단위테스트 구현

### DIFF
--- a/src/test/java/com/even/zaro/unit/service/NotificationSseServiceTest.java
+++ b/src/test/java/com/even/zaro/unit/service/NotificationSseServiceTest.java
@@ -1,0 +1,24 @@
+package com.even.zaro.unit.service;
+
+import com.even.zaro.service.NotificationSseService;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class NotificationSseServiceTest {
+
+    @InjectMocks
+    private NotificationSseService notificationSseService;
+
+    @Nested
+    class ConnectTest {
+
+    }
+
+    @Nested
+    class SendTest {
+
+    }
+}

--- a/src/test/java/com/even/zaro/unit/service/NotificationSseServiceTest.java
+++ b/src/test/java/com/even/zaro/unit/service/NotificationSseServiceTest.java
@@ -1,20 +1,31 @@
 package com.even.zaro.unit.service;
 
+import com.even.zaro.dto.notification.NotificationDto;
+import com.even.zaro.entity.Notification;
+import com.even.zaro.global.util.NotificationMapper;
 import com.even.zaro.service.NotificationSseService;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
+import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
+import java.io.IOException;
+import java.util.Map;
+
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 public class NotificationSseServiceTest {
 
     @InjectMocks
     private NotificationSseService notificationSseService;
+
+    @Mock
+    private NotificationMapper notificationMapper;
 
     private final Long userId = 1L;
 
@@ -30,6 +41,48 @@ public class NotificationSseServiceTest {
 
     @Nested
     class SendTest {
+        @Test
+        void send_성공시_emitter에_이벤트_전송() throws IOException {
+            Notification notification = createNotification();
+            NotificationDto dto = createDto();
 
+            // 수동으로 SseEmitter 생성 후 등록
+            SseEmitter emitter = new SseEmitter(Long.MAX_VALUE);
+            getEmittersMap().put(userId, emitter);
+
+            when(notificationMapper.toDto(notification)).thenReturn(dto);
+
+            notificationSseService.send(userId, notification); // 예외 안 나면 성공
+        }
+
+
+        private Notification createNotification() {
+            return Notification.builder()
+                    .id(1L)
+                    .type(Notification.Type.FOLLOW)
+                    .actorUserId(2L)
+                    .targetId(3L)
+                    .build();
+        }
+
+        private NotificationDto createDto() {
+            return NotificationDto.builder()
+                    .id(1L)
+                    .type(Notification.Type.FOLLOW)
+                    .build();
+        }
+
+        // NotificationSseService 내부의 private Map<Long, SseEmitter> emitters 필드에 접근
+        // 리플렉션으로 접근해서 직접 조작
+        @SuppressWarnings("unchecked")
+        private Map<Long, SseEmitter> getEmittersMap() {
+            try {
+                var field = NotificationSseService.class.getDeclaredField("emitters");
+                field.setAccessible(true);
+                return (Map<Long, SseEmitter>) field.get(notificationSseService);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
     }
 }

--- a/src/test/java/com/even/zaro/unit/service/NotificationSseServiceTest.java
+++ b/src/test/java/com/even/zaro/unit/service/NotificationSseServiceTest.java
@@ -2,9 +2,13 @@ package com.even.zaro.unit.service;
 
 import com.even.zaro.service.NotificationSseService;
 import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @ExtendWith(MockitoExtension.class)
 public class NotificationSseServiceTest {
@@ -12,9 +16,16 @@ public class NotificationSseServiceTest {
     @InjectMocks
     private NotificationSseService notificationSseService;
 
+    private final Long userId = 1L;
+
     @Nested
     class ConnectTest {
+        @Test
+        void connect_호출시_emitter_등록되고_초기이벤트_전송시도() {
+            SseEmitter emitter = notificationSseService.connect(userId);
 
+            assertThat(emitter).isNotNull();
+        }
     }
 
     @Nested

--- a/src/test/java/com/even/zaro/unit/util/NotificationMapperTest.java
+++ b/src/test/java/com/even/zaro/unit/util/NotificationMapperTest.java
@@ -5,6 +5,8 @@ import com.even.zaro.entity.Comment;
 import com.even.zaro.entity.Notification;
 import com.even.zaro.entity.Post;
 import com.even.zaro.entity.User;
+import com.even.zaro.global.ErrorCode;
+import com.even.zaro.global.exception.notification.NotificationException;
 import com.even.zaro.global.util.NotificationMapper;
 import com.even.zaro.repository.CommentRepository;
 import com.even.zaro.repository.PostRepository;
@@ -19,6 +21,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -94,6 +97,19 @@ class NotificationMapperTest {
         assertThat(dto.getComment()).isEqualTo("댓글 내용");
         assertThat(dto.getCategory()).isEqualTo("TOGETHER");
         assertThat(dto.getPostId()).isEqualTo(post.getId());
+    }
+
+    @Test
+    void ACTOR_ID_없으면_예외발생() {
+        Notification noti = Notification.builder()
+                .id(notificationId)
+                .type(Notification.Type.FOLLOW)
+                .actorUserId(null)
+                .build();
+
+        NotificationException exception = assertThrows(NotificationException.class,
+                () -> notificationMapper.toDto(noti));
+        assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.ACTOR_USER_NOT_FOUND);
     }
 
     private Notification createNotification(Notification.Type type, Long targetId, boolean isRead) {

--- a/src/test/java/com/even/zaro/unit/util/NotificationMapperTest.java
+++ b/src/test/java/com/even/zaro/unit/util/NotificationMapperTest.java
@@ -52,13 +52,7 @@ class NotificationMapperTest {
 
     @Test
     void FOLLOW_알림_DTO_변환_성공() {
-        Notification noti = Notification.builder()
-                .id(notificationId)
-                .type(Notification.Type.FOLLOW)
-                .targetId(2L)
-                .actorUserId(actor.getId())
-                .isRead(false)
-                .build();
+        Notification noti = createNotification(Notification.Type.FOLLOW, 2L, false);
 
         when(userRepository.findById(actor.getId())).thenReturn(Optional.of(actor));
 
@@ -71,19 +65,9 @@ class NotificationMapperTest {
 
     @Test
     void LIKE_알림_DTO_변환_성공() {
-        Post post = Post.builder()
-                .id(10L)
-                .category(Post.Category.TOGETHER)
-                .thumbnailImage(null)
-                .build();
+        Post post = createPost(8L);
 
-        Notification noti = Notification.builder()
-                .id(notificationId)
-                .type(Notification.Type.LIKE)
-                .targetId(post.getId())
-                .actorUserId(actor.getId())
-                .isRead(true)
-                .build();
+        Notification noti = createNotification(Notification.Type.LIKE, post.getId(), false);
 
         when(userRepository.findById(actor.getId())).thenReturn(Optional.of(actor));
         when(postRepository.findById(post.getId())).thenReturn(Optional.of(post));
@@ -97,25 +81,10 @@ class NotificationMapperTest {
 
     @Test
     void COMMENT_알림_DTO_변환_성공() {
-        Post post = Post.builder()
-                .id(10L)
-                .category(Post.Category.TOGETHER)
-                .thumbnailImage(null)
-                .build();
+        Post post = createPost(10L);
+        Comment comment = createComment(5L, post);
 
-        Comment comment = Comment.builder()
-                .id(20L)
-                .content("댓글 내용")
-                .post(post)
-                .build();
-
-        Notification noti = Notification.builder()
-                .id(notificationId)
-                .type(Notification.Type.COMMENT)
-                .targetId(comment.getId())
-                .actorUserId(actor.getId())
-                .isRead(false)
-                .build();
+        Notification noti = createNotification(Notification.Type.COMMENT, comment.getId(), false);
 
         when(userRepository.findById(actor.getId())).thenReturn(Optional.of(actor));
         when(commentRepository.findById(comment.getId())).thenReturn(Optional.of(comment));
@@ -126,4 +95,31 @@ class NotificationMapperTest {
         assertThat(dto.getCategory()).isEqualTo("TOGETHER");
         assertThat(dto.getPostId()).isEqualTo(post.getId());
     }
+
+    private Notification createNotification(Notification.Type type, Long targetId, boolean isRead) {
+        return Notification.builder()
+                .id(notificationId)
+                .type(type)
+                .targetId(targetId)
+                .actorUserId(actor.getId())
+                .isRead(isRead)
+                .build();
+    }
+
+    private Post createPost(Long id) {
+        return Post.builder()
+                .id(id)
+                .category(Post.Category.TOGETHER)
+                .thumbnailImage(null)
+                .build();
+    }
+
+    private Comment createComment(Long id, Post post) {
+        return Comment.builder()
+                .id(id)
+                .content("댓글 내용")
+                .post(post)
+                .build();
+    }
+
 }

--- a/src/test/java/com/even/zaro/unit/util/NotificationMapperTest.java
+++ b/src/test/java/com/even/zaro/unit/util/NotificationMapperTest.java
@@ -1,4 +1,129 @@
 package com.even.zaro.unit.util;
 
-public class NotificationMapperTest {
+import com.even.zaro.dto.notification.NotificationDto;
+import com.even.zaro.entity.Comment;
+import com.even.zaro.entity.Notification;
+import com.even.zaro.entity.Post;
+import com.even.zaro.entity.User;
+import com.even.zaro.global.util.NotificationMapper;
+import com.even.zaro.repository.CommentRepository;
+import com.even.zaro.repository.PostRepository;
+import com.even.zaro.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class NotificationMapperTest {
+
+    @InjectMocks
+    private NotificationMapper notificationMapper;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private PostRepository postRepository;
+
+    @Mock
+    private CommentRepository commentRepository;
+
+    private final Long userId = 1L;
+    private final Long notificationId = 9L;
+
+    private User actor;
+
+    @BeforeEach
+    void setUp() {
+        actor = User.builder()
+                .id(userId)
+                .nickname("액터닉넴")
+                .profileImage(null)
+                .build();
+    }
+
+    @Test
+    void FOLLOW_알림_DTO_변환_성공() {
+        Notification noti = Notification.builder()
+                .id(notificationId)
+                .type(Notification.Type.FOLLOW)
+                .targetId(2L)
+                .actorUserId(actor.getId())
+                .isRead(false)
+                .build();
+
+        when(userRepository.findById(actor.getId())).thenReturn(Optional.of(actor));
+
+        NotificationDto dto = notificationMapper.toDto(noti);
+
+        assertThat(dto.getType()).isEqualTo(Notification.Type.FOLLOW);
+        assertThat(dto.getActorId()).isEqualTo(actor.getId());
+        assertThat(dto.getActorName()).isEqualTo(actor.getNickname());
+    }
+
+    @Test
+    void LIKE_알림_DTO_변환_성공() {
+        Post post = Post.builder()
+                .id(10L)
+                .category(Post.Category.TOGETHER)
+                .thumbnailImage(null)
+                .build();
+
+        Notification noti = Notification.builder()
+                .id(notificationId)
+                .type(Notification.Type.LIKE)
+                .targetId(post.getId())
+                .actorUserId(actor.getId())
+                .isRead(true)
+                .build();
+
+        when(userRepository.findById(actor.getId())).thenReturn(Optional.of(actor));
+        when(postRepository.findById(post.getId())).thenReturn(Optional.of(post));
+
+        NotificationDto dto = notificationMapper.toDto(noti);
+
+        assertThat(dto.getPostId()).isEqualTo(post.getId());
+        assertThat(dto.getCategory()).isEqualTo("TOGETHER");
+        assertThat(dto.getThumbnailImage()).isEqualTo(null);
+    }
+
+    @Test
+    void COMMENT_알림_DTO_변환_성공() {
+        Post post = Post.builder()
+                .id(10L)
+                .category(Post.Category.TOGETHER)
+                .thumbnailImage(null)
+                .build();
+
+        Comment comment = Comment.builder()
+                .id(20L)
+                .content("댓글 내용")
+                .post(post)
+                .build();
+
+        Notification noti = Notification.builder()
+                .id(notificationId)
+                .type(Notification.Type.COMMENT)
+                .targetId(comment.getId())
+                .actorUserId(actor.getId())
+                .isRead(false)
+                .build();
+
+        when(userRepository.findById(actor.getId())).thenReturn(Optional.of(actor));
+        when(commentRepository.findById(comment.getId())).thenReturn(Optional.of(comment));
+
+        NotificationDto dto = notificationMapper.toDto(noti);
+
+        assertThat(dto.getComment()).isEqualTo("댓글 내용");
+        assertThat(dto.getCategory()).isEqualTo("TOGETHER");
+        assertThat(dto.getPostId()).isEqualTo(post.getId());
+    }
 }


### PR DESCRIPTION
## 📌 작업 개요
- NotificationMapper, NotificationSseService 단위테스트 구현

---

## ✨ 주요 변경 사항
- NotificationMapper 단위테스트 구현
  - service에서 호출해서 쓰는 비즈니스로직이 많아서, unit.util에 단위테스트 구현했습니당
- NotificationSseService 단위테스트 구현
  - connect 메서드, send 메서드 성공/예외 분기
  - send는 이미 연결되어 있는 emitter가 존재한다고 가정 후 구현
  
---

## 🖼️ 기능 살펴 보기
> NotificationMapperTest
![image](https://github.com/user-attachments/assets/52e3d2d1-f120-4f4d-8344-2339894eb5dc)

> NotificationSseServiceTest
![image](https://github.com/user-attachments/assets/4e00adba-7dd0-4200-9ddf-fc68131e10d7)

---

## ✅ 작업 체크리스트
- [ ] API 테스트 완료 (POSTMAN)
- [ ] 스웨거 ui 관련 코드 추가
- [x] 기능별 예외 케이스 고려
- [ ] log.info / 불필요한 주석 제거
- [x] 변수명, 클래스명, 메서드명 의미있게 작성
- [x] 반복 코드 메서드로 분리

---

## 📂 테스트 방법
- [x] 테스트 코드 작성
- [x] 시나리오 기반 테스트 유무
    - ex: ID 중복 시 예외 처리 발생

---

## 💬 기타 참고 사항
- UserException등은 알림매퍼테스트에서 테스트 하지 않았습니다 (책임 분리, 멘토링 반영)
- sse 참 어렵다 :) .. ~

---

## 📎 관련 이슈 / 문서

