### PR TITLE
fix/sse-notification : signIn 시 내려주는 쿠키에 SameSite=None; Secure 설정 추가

### DIFF
--- a/src/main/java/com/even/zaro/controller/AuthController.java
+++ b/src/main/java/com/even/zaro/controller/AuthController.java
@@ -52,7 +52,25 @@ public class AuthController {
     @PostMapping("/signin")
     public ResponseEntity<ApiResponse<SignInResponseDto>> signIn(@RequestBody SignInRequestDto requestDto) {
         SignInResponseDto responseDto = authService.signIn(requestDto);
-        return ResponseEntity.ok(ApiResponse.success("로그인에 성공했습니다.", responseDto));
+
+        ResponseCookie accessTokenCookie = ResponseCookie.from("access_token", responseDto.getAccessToken())
+                .httpOnly(true)
+                .secure(true) // HTTPS(배포) 환경에서만 작동, 로컬에서는 false로 바꿔야함
+                .sameSite("None") // 크로스도메인 허용
+                .path("/")
+                .build();
+
+        ResponseCookie refreshTokenCookie = ResponseCookie.from("refresh_token", responseDto.getRefreshToken())
+                .httpOnly(true)
+                .secure(true)
+                .sameSite("None")
+                .path("/")
+                .build();
+
+        return ResponseEntity.ok()
+                .header(HttpHeaders.SET_COOKIE, accessTokenCookie.toString())
+                .header(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString())
+                .body(ApiResponse.success("로그인에 성공했습니다.", responseDto));
     }
 
     @Operation(summary = "카카오 회원가입/로그인", description = "카카오 access token을 받아 회원가입/로그인 처리합니다.")
@@ -60,7 +78,25 @@ public class AuthController {
     public ResponseEntity<ApiResponse<SignInResponseDto>> signInWithKakao(
             @RequestBody @Parameter(description = "카카오 access token") KakaoSignInRequestDto requestDto) {
         SignInResponseDto responseDto = authService.SignInWithKakao(requestDto.getAccessToken());
-        return ResponseEntity.ok(ApiResponse.success("카카오 로그인에 성공했습니다.", responseDto));
+
+        ResponseCookie accessTokenCookie = ResponseCookie.from("access_token", responseDto.getAccessToken())
+                .httpOnly(true)
+                .secure(true) // HTTPS(배포) 환경에서만 작동, 로컬에서는 false로 바꿔야함
+                .sameSite("None") // 크로스도메인 허용
+                .path("/")
+                .build();
+
+        ResponseCookie refreshTokenCookie = ResponseCookie.from("refresh_token", responseDto.getRefreshToken())
+                .httpOnly(true)
+                .secure(true)
+                .sameSite("None")
+                .path("/")
+                .build();
+
+        return ResponseEntity.ok()
+                .header(HttpHeaders.SET_COOKIE, accessTokenCookie.toString())
+                .header(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString())
+                .body(ApiResponse.success("카카오 로그인에 성공했습니다.", responseDto));
     }
 
     @Operation(summary = "Access Token 재발급", description = "Refresh 토큰을 입력해 Access Token을 재발급 받습니다. 상단 Authorize에 Refresh Token을 입력하세요.",


### PR DESCRIPTION
## 📌 작업 개요
- signIn 시 내려주는 쿠키에 SameSite=None; Secure 설정 추가

---

## ✨ 주요 변경 사항
- sse 연결 버그
  - local3000 & local8080에서는 잘됨
  - local3000 & ec2 환경, vercel & shop 환경에서 sse 인증오류
  - 쿠키 내려줄 때 SameSite=Lax, Strict 이라서 크로스도메인 환경에는 GET 요청에 쿠키가 안 붙음
   (sse가 쿠키에서 토큰을 꺼내씀)
  - 따라서 SignIn 컨트롤러에 Set-Cookie 설정하여 내려주는 부분을 추가
---

## 🖼️ 기능 살펴 보기
> ![image](https://github.com/user-attachments/assets/ea4770ec-f9c4-416b-ae97-bfa3cda3ca9e)

- 로컬환경에서 로그인 기능 그대로 잘 됨
  - 배포에서만 `.sameSite("None") // 크로스도메인 허용` 적용으로 콘솔의 쿠키 맨 뒤 바뀌어야함
- 배포환경 테스트 필요

---

## ✅ 작업 체크리스트
- [ ] API 테스트 완료 (POSTMAN)
- [ ] 스웨거 ui 관련 코드 추가
- [ ] 기능별 예외 케이스 고려
- [ ] log.info / 불필요한 주석 제거
- [ ] 변수명, 클래스명, 메서드명 의미있게 작성
- [ ] 반복 코드 메서드로 분리

---

## 📂 테스트 방법
- [ ] 테스트 코드 작성
- [ ] 시나리오 기반 테스트 유무
    - ex: ID 중복 시 예외 처리 발생

---

## 💬 기타 참고 사항
- @nahyukk 배포 후 확인하고 수정할 것 있다면 말씀드리겠습니다... 🙇🏻‍♀️

---

## 📎 관련 이슈 / 문서

