### PR TITLE
feat: 인기게시글 순위 추가

### DIFF
--- a/src/main/java/com/even/zaro/dto/post/PostRankResponseDto.java
+++ b/src/main/java/com/even/zaro/dto/post/PostRankResponseDto.java
@@ -24,12 +24,16 @@ public class PostRankResponseDto {
     @Schema(description = "댓글 수", example = "3")
     private int commentCount;
 
-    public static PostRankResponseDto from(Post post) {
+    @Schema(description = "기준 순위", example = "1")
+    private int baselineRankIndex;
+
+    public static PostRankResponseDto from(Post post, int baselineRankIndex) {
         return PostRankResponseDto.builder()
                 .postId(post.getId())
                 .title(post.getTitle())
                 .likeCount(post.getLikeCount())
                 .commentCount(post.getCommentCount())
+                .baselineRankIndex(baselineRankIndex)
                 .build();
     }
 }

--- a/src/main/java/com/even/zaro/mapper/PostMapper.java
+++ b/src/main/java/com/even/zaro/mapper/PostMapper.java
@@ -50,12 +50,6 @@ public interface PostMapper {
     HomePostPreviewResponse.RandomBuyPostDto toRandomBuyDto(Post post);
 
 
-    @Mapping(source = "id", target = "postId")
-    @Mapping(source = "title", target = "title")
-    @Mapping(source = "likeCount", target = "likeCount")
-    @Mapping(source = "commentCount", target = "commentCount")
-    PostRankResponseDto toRankDto(Post post);
-
     default String stripHtmlTags(String html) {
         if (html == null) return "";
         html = html.replace("&lt;", "<").replace("&gt;", ">");

--- a/src/main/java/com/even/zaro/service/PostService.java
+++ b/src/main/java/com/even/zaro/service/PostService.java
@@ -19,6 +19,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 
 @Service
 @RequiredArgsConstructor
@@ -164,8 +165,11 @@ public class PostService {
     public List<PostRankResponseDto> getRankedPosts() {
         List<Post> posts = postRepository.findTopPosts(0, PageRequest.of(0, 5));
 
+
+        AtomicInteger rankIndex = new AtomicInteger(1);
+
         return posts.stream()
-                .map(postMapper::toRankDto)
+                .map(post -> PostRankResponseDto.from(post, rankIndex.getAndIncrement()))
                 .toList();
     }
 


### PR DESCRIPTION
## 📌 작업 개요
- 주간 인기게시글 response에 1~5순위 추가
---

## ✨ 주요 변경 사항
- Post entity에 추가하면 다른기능들에 영향이 갈까싶어 mapper 사용을 빼고 기존 dto에 수정해 사용
- response에 baselineRankIndex로 순위가 적혀 내려옴

---

## 🖼️ 기능 살펴 보기
> 
| 순위 변경되기전 | 4위 -> 1위 변경됨 |
|-----------|-----------|
|![스크린샷 2025-06-10 오후 5 33 41](https://github.com/user-attachments/assets/2a1bcb28-0954-4b80-93f9-d509e0f13ffa)|![스크린샷 2025-06-10 오후 5 38 34](https://github.com/user-attachments/assets/ceeb96d7-0251-447d-bf4f-c3debf8e0898)|
---

## 💬 기타 참고 사항
- 프론트 작업 마무리중에 세션에 순위가 저장되어 사용자가 새창을 열고 들어오면 sessionStorage 없으므로 무조건 🔺 표시되어 기존 사용자들의 화면과 불일치가 발생 -> 따라서 서버기준으로 통일되게 🔺🔻아이콘을 내려주기위해 추가했습니다.

