### PR TITLE
Ref/auth 회원가입 PENDING 회원 처리 및 예외 추가

### DIFF
--- a/src/main/java/com/even/zaro/global/ErrorCode.java
+++ b/src/main/java/com/even/zaro/global/ErrorCode.java
@@ -39,6 +39,7 @@ public enum ErrorCode {
 
     EMAIL_NOT_FOUND(HttpStatus.NOT_FOUND, "가입된 이메일이 아닙니다."),
     INCORRECT_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
+    ALREADY_SIGNED_UP_NOT_VERIFIED_YET(HttpStatus.CONFLICT, "이미 가입한 계정입니다. 인증 메일을 다시 전송했습니다."),
 
     INVALID_OAUTH_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 소셜 인증 토큰입니다."),
 

--- a/src/main/java/com/even/zaro/global/scheduler/UserScheduler.java
+++ b/src/main/java/com/even/zaro/global/scheduler/UserScheduler.java
@@ -22,6 +22,14 @@ public class UserScheduler {
     private final DormancyNoticeLogRepository dormancyNoticeLogRepository;
     private final EmailService emailService;
 
+    // PENDING 회원 삭제
+    @Scheduled(cron = "0 15 3 * * *") // 매일 3시 15분
+    @Transactional
+    public void deleteExpiredPendingUsers() {
+        LocalDateTime threshold = LocalDateTime.now().minusDays(1);
+        userRepository.deleteByStatusAndCreatedAtBefore(Status.PENDING, threshold);
+    }
+
     // 휴면 처리, 탈퇴 처리
     @Scheduled(cron = "0 30 3 * * *")// 매일 3시 30분
     @Transactional

--- a/src/main/java/com/even/zaro/repository/UserRepository.java
+++ b/src/main/java/com/even/zaro/repository/UserRepository.java
@@ -23,6 +23,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByNickname(String nickname);
 
+    List<User> deleteByStatusAndCreatedAtBefore(Status status, LocalDateTime threshold);
     List<User> findByStatusAndLastLoginAtBefore(Status status, LocalDateTime time);
     List<User> findByStatusAndUpdatedAtBefore(Status status, LocalDateTime time);
     List<User> findByStatusAndDeletedAtBefore(Status status, LocalDateTime threshold);

--- a/src/main/java/com/even/zaro/repository/UserRepository.java
+++ b/src/main/java/com/even/zaro/repository/UserRepository.java
@@ -17,6 +17,8 @@ public interface UserRepository extends JpaRepository<User, Long> {
     boolean existsByEmail(String email);
     Optional<User> findByEmail(String email);
 
+    Optional<User> findByEmailAndNickname(String email, String nickname);
+
     Optional<User> findByProviderAndProviderId(Provider provider, String providerId);
 
     boolean existsByNickname(String nickname);

--- a/src/main/java/com/even/zaro/service/AuthService.java
+++ b/src/main/java/com/even/zaro/service/AuthService.java
@@ -67,6 +67,14 @@ public class AuthService {
         }
 
         // 중복 확인
+        Optional<User> pendingUser = userRepository.findByEmailAndNickname(email, nickname);
+
+        if (pendingUser.isPresent() && pendingUser.get().getStatus() == Status.PENDING) {
+            // 인증 메일 재전송
+            emailVerificationService.resendVerificationEmail(pendingUser.get().getEmail());
+            throw new UserException(ErrorCode.ALREADY_SIGNED_UP_NOT_VERIFIED_YET);
+        }
+
         if (userRepository.existsByEmail(email)) {
             throw new UserException(ErrorCode.EMAIL_ALREADY_EXISTED);
         }

--- a/src/test/java/com/even/zaro/integration/user/UserSchedulerIntegrationTest.java
+++ b/src/test/java/com/even/zaro/integration/user/UserSchedulerIntegrationTest.java
@@ -40,7 +40,7 @@ public class UserSchedulerIntegrationTest {
     private EntityManager em;
 
     @Nested
-    class dormantUserTest {
+    class DormantUserTest {
         @Test
         void shouldSetUserToDormantIfInactiveFor6Months() {
             LocalDateTime now = LocalDateTime.now();
@@ -94,26 +94,29 @@ public class UserSchedulerIntegrationTest {
         }
     }
 
-    @Test
-    void shouldDeleteUsersWithdrawnOver30DaysAgo_fromDatabase() {
-        User user = User.builder()
-                .email("test@even.com")
-                .nickname("이브니")
-                .password("Password1!")
-                .provider(Provider.LOCAL)
-                .status(Status.DELETED)
-                .deletedAt(LocalDateTime.now().minusDays(31))
-                .build();
+    @Nested
+    class DeleteUserTest {
+        @Test
+        void shouldDeleteUsersWithdrawnOver30DaysAgo_fromDatabase() {
+            User user = User.builder()
+                    .email("test@even.com")
+                    .nickname("이브니")
+                    .password("Password1!")
+                    .provider(Provider.LOCAL)
+                    .status(Status.DELETED)
+                    .deletedAt(LocalDateTime.now().minusDays(31))
+                    .build();
 
-        userRepository.save(user);
+            userRepository.save(user);
 
-        userScheduler.deleteWithdrawnUsers();
+            userScheduler.deleteWithdrawnUsers();
 
-        assertThat(userRepository.findById(user.getId())).isEmpty();
+            assertThat(userRepository.findById(user.getId())).isEmpty();
+        }
     }
 
     @Nested
-    class dormantPendingTest {
+    class DormantPendingTest {
         @Test
         void shouldSendEmailAndSaveLog_ifNotAlreadySent() {
             LocalDateTime loginAt = LocalDateTime.now().minusMonths(5).minusDays(1);

--- a/src/test/java/com/even/zaro/unit/service/AuthServiceTest.java
+++ b/src/test/java/com/even/zaro/unit/service/AuthServiceTest.java
@@ -1,12 +1,17 @@
 package com.even.zaro.unit.service;
 
 import com.even.zaro.dto.auth.SignUpRequestDto;
+import com.even.zaro.entity.Provider;
+import com.even.zaro.entity.Status;
+import com.even.zaro.entity.User;
 import com.even.zaro.global.ErrorCode;
 import com.even.zaro.global.exception.user.UserException;
 import com.even.zaro.global.jwt.JwtUtil;
 import com.even.zaro.repository.UserRepository;
 import com.even.zaro.service.AuthService;
+import com.even.zaro.service.EmailVerificationService;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -16,8 +21,10 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
 
 import java.util.Date;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.*;
@@ -42,31 +49,60 @@ class AuthServiceTest {
     @Mock
     private ValueOperations<String, String> valueOperations;
 
-    @DisplayName("회원가입시 닉네임 중복 예외처리")
-    @Test
-    void nicknameAlreadyExists_shouldThrowException() {
-        //given
-        when(userRepository.existsByNickname("이브니")).thenReturn(true);
+    @Mock
+    private EmailVerificationService emailVerificationService;
 
-        //when
-        SignUpRequestDto requestDto = new SignUpRequestDto("test2@even.com", "Test1234!", "이브니");
+    @Nested
+    class SignUpTest {
+        @DisplayName("회원가입시 닉네임 중복 예외처리")
+        @Test
+        void shouldThrowException_nicknameAlreadyExists() {
+            //given
+            when(userRepository.existsByNickname("이브니")).thenReturn(true);
 
-        //then
-        UserException userException = assertThrows(UserException.class, () -> authService.signUp(requestDto));
-        assertEquals(ErrorCode.NICKNAME_ALREADY_EXISTED, userException.getErrorCode());
+            //when
+            SignUpRequestDto requestDto = new SignUpRequestDto("test2@even.com", "Test1234!", "이브니");
+
+            //then
+            UserException userException = assertThrows(UserException.class, () -> authService.signUp(requestDto));
+            assertEquals(ErrorCode.NICKNAME_ALREADY_EXISTED, userException.getErrorCode());
+        }
+
+        @Test
+        void shouldThrowExceptionAndResendVerificationEmail_ifAlreadySignedUpButNotVerified() {
+            User pendingUser = User.builder()
+                    .email("test@even.com")
+                    .nickname("이브니")
+                    .provider(Provider.LOCAL)
+                    .status(Status.PENDING)
+                    .build();
+
+            when(userRepository.findByEmailAndNickname("test@even.com", "이브니"))
+                    .thenReturn(Optional.of(pendingUser));
+
+            UserException ex = assertThrows(UserException.class, () -> {
+                authService.signUp(new SignUpRequestDto("test@even.com", "Password1!", "이브니"));
+            });
+
+            assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.ALREADY_SIGNED_UP_NOT_VERIFIED_YET);
+            verify(emailVerificationService).resendVerificationEmail(pendingUser.getEmail());
+        }
     }
 
-    @Test
-    void signOut_shouldStoreAccessTokenInBlacklist() {
-        String testAccessToken = "test-token";
+    @Nested
+    class SignOutTest {
+        @Test
+        void shouldStoreAccessTokenInBlacklist() {
+            String testAccessToken = "test-token";
 
-        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
-        when(jwtUtil.getAccessTokenExpiration(anyString()))
-                .thenReturn(new Date(System.currentTimeMillis() + 1000 * 60 * 15));
+            when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+            when(jwtUtil.getAccessTokenExpiration(anyString()))
+                    .thenReturn(new Date(System.currentTimeMillis() + 1000 * 60 * 15));
 
-        authService.signOut(1L, testAccessToken);
+            authService.signOut(1L, testAccessToken);
 
-        verify(redisTemplate).opsForValue();
-        verify(valueOperations).set(eq("BL:" + testAccessToken), eq("logout"), anyLong(), eq(TimeUnit.MILLISECONDS));
+            verify(redisTemplate).opsForValue();
+            verify(valueOperations).set(eq("BL:" + testAccessToken), eq("logout"), anyLong(), eq(TimeUnit.MILLISECONDS));
+        }
     }
 }


### PR DESCRIPTION
## 📌 작업 개요
- 회원가입 PENDING 회원 처리 및 예외 추가

---

## ✨ 주요 변경 사항
- 회원가입 PENDING 회원 처리
- 회원가입시 닉네임+이메일 동일 예외 추가 - 메일 재전송 및 인증 유도 예외처리
- 기존 테스트 코드 Nested로 구조 조금 변경했습니다.

---

## 🖼️ 기능 살펴 보기
> 포스트맨 요청 응답 스크린샷
- [x] API 문서(요청, 응답)와 일치하는지 확인 - 필요시 API 문서 수정 가능

![image](https://github.com/user-attachments/assets/97e4e502-a1b7-4a68-86b5-a80dbad79c4e)
![image](https://github.com/user-attachments/assets/cfcd839d-80f0-4ce8-8f77-edf964e20fdb)


---

## ✅ 작업 체크리스트
- [x] API 테스트 완료 (POSTMAN)
- [x] 스웨거 ui 관련 코드 추가
- [x] 기능별 예외 케이스 고려
- [x] log.info / 불필요한 주석 제거
- [x] 변수명, 클래스명, 메서드명 의미있게 작성
- [x] 반복 코드 메서드로 분리

---

## 📂 테스트 방법
- [x] 테스트 코드 작성
- [x] 시나리오 기반 테스트 유무
    - 가입 1일 후 PENDING 회원 삭제
    - 닉네임+이메일 중복시 예외처리 및 인증 메일 재전송


---

## 💬 기타 참고 사항


---

## 📎 관련 이슈 / 문서
- 관련 이슈 번호: Fixes #88 
