### PR TITLE
Feat/rank: 인기 게시글 rankChange 관련 추가

### DIFF
--- a/src/main/java/com/even/zaro/dto/post/PostRankResponseDto.java
+++ b/src/main/java/com/even/zaro/dto/post/PostRankResponseDto.java
@@ -27,13 +27,21 @@ public class PostRankResponseDto {
     @Schema(description = "기준 순위", example = "1")
     private int baselineRankIndex;
 
-    public static PostRankResponseDto from(Post post, int baselineRankIndex) {
+    @Schema(description = "현재 순위", example = "2")
+    private int currentRankIndex;
+
+    @Schema(description = "순위 변화량", example = "직전순위 - 현재순위")
+    private int rankChange;
+
+    public static PostRankResponseDto from(Post post, int baselineRankIndex, int currentRankIndex, int rankChange) {
         return PostRankResponseDto.builder()
                 .postId(post.getId())
                 .title(post.getTitle())
                 .likeCount(post.getLikeCount())
                 .commentCount(post.getCommentCount())
                 .baselineRankIndex(baselineRankIndex)
+                .currentRankIndex(currentRankIndex)
+                .rankChange(rankChange)
                 .build();
     }
 }

--- a/src/main/java/com/even/zaro/service/PostRankBaselineMemoryStore.java
+++ b/src/main/java/com/even/zaro/service/PostRankBaselineMemoryStore.java
@@ -1,0 +1,37 @@
+package com.even.zaro.service;
+
+import com.even.zaro.entity.Post;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+@Component
+public class PostRankBaselineMemoryStore {
+
+    private final Map<Long, Integer> baselineRankIndexMap = new ConcurrentHashMap<>();
+    private final Map<Long, Integer> prevRankIndexMap = new ConcurrentHashMap<>();
+
+
+    public Map<Long, Integer> getBaselineRankIndexMap() {
+        return baselineRankIndexMap;
+    }
+
+    public Map<Long, Integer> getPrevRankIndexMap() {
+        return prevRankIndexMap;
+    }
+
+    public void updateBaselineRank(List<Post> posts) {
+        AtomicInteger baselineIndex = new AtomicInteger(1);
+        baselineRankIndexMap.clear();
+        posts.forEach(post -> baselineRankIndexMap.put(post.getId(), baselineIndex.getAndIncrement()));
+    }
+
+    public void updatePrevRank(List<Post> posts) {
+        AtomicInteger currentRankIndex = new AtomicInteger(1);
+        prevRankIndexMap.clear();
+        posts.forEach(post -> prevRankIndexMap.put(post.getId(), currentRankIndex.getAndIncrement()));
+    }
+}


### PR DESCRIPTION
## 📌 작업 개요
- 인기게시글 관련 직전 랭크 알 수 있는 로직 추가

---

## ✨ 주요 변경 사항
- 크게는 두가지가 추가되었습니다.
    - rankChange
    - currnetRankIndex

- 추가하는 이유
 : 직전 rank가 아닌 baseline을 기준으로 계산되어 null로 처리하는 오류 발생을 해결하기위해서 추가하게되었습니다.

---

## 🖼️ 기능 살펴 보기
> 
| 기본 호출 | 순위변동1 | 순위변동2 | 순위변동3 |
|------|------|------|------|
|![스크린샷 2025-06-11 오후 4 32 11](https://github.com/user-attachments/assets/cec6cb52-5e2d-45a2-b79c-00a95163d142)|![스크린샷 2025-06-11 오후 4 32 38](https://github.com/user-attachments/assets/86e58eb8-a15a-4cdd-ba75-676cfcbff1d1)|![스크린샷 2025-06-11 오후 4 32 56](https://github.com/user-attachments/assets/dd0e0580-698e-4286-8d08-7c729d9ccdef)|![스크린샷 2025-06-11 오후 4 33 11](https://github.com/user-attachments/assets/72f280ed-ce8e-46dd-a0d1-e5bca0f68041)|


---

## 📂 테스트 방법
- [x] 시나리오 기반 테스트 유무
     1. /api/posts/rank 요청 후 rankChange 확인 
     2. 순위 임시 조작
     3. 다시 /api/posts/rank 요청

---

💬 얼른 해결해보겠슴다..😬💪