### PR TITLE
Fix/auth validator 회원가입, 닉네임 변경, 비밀번호 변경 커스텀 validator 적용

### DIFF
--- a/src/main/java/com/even/zaro/controller/AuthController.java
+++ b/src/main/java/com/even/zaro/controller/AuthController.java
@@ -15,6 +15,7 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
@@ -42,7 +43,7 @@ public class AuthController {
 
     @Operation(summary = "회원가입", description = "이메일, 비밀번호, 닉네임으로 회원가입합니다.")
     @PostMapping("/signup")
-    public ResponseEntity<ApiResponse<SignUpResponseDto>> signup(@RequestBody SignUpRequestDto requestDto) {
+    public ResponseEntity<ApiResponse<SignUpResponseDto>> signup(@RequestBody @Valid SignUpRequestDto requestDto) {
         SignUpResponseDto responseDto = authService.signUp(requestDto);
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(ApiResponse.success("회원가입이 완료되었습니다.", responseDto));

--- a/src/main/java/com/even/zaro/controller/UserController.java
+++ b/src/main/java/com/even/zaro/controller/UserController.java
@@ -7,6 +7,7 @@ import com.even.zaro.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -41,7 +42,7 @@ public class UserController {
     @Operation(summary = "닉네임 변경", description = "로그인한 사용자의 닉네임을 변경합니다.", security = {@SecurityRequirement(name = "bearer-key")})
     @PatchMapping("/me/nickname")
     public ResponseEntity<ApiResponse<UpdateNicknameResponseDto>> updateNickname(
-            @RequestBody UpdateNicknameRequestDto requestDto,
+            @RequestBody @Valid UpdateNicknameRequestDto requestDto,
             @AuthenticationPrincipal JwtUserInfoDto userInfoDto
             ) {
         UpdateNicknameResponseDto responseDto = userService.updateNickname(userInfoDto.getUserId(), requestDto);
@@ -66,7 +67,7 @@ public class UserController {
     @Operation(summary = "비밀번호 변경", description = "로그인한 사용자의 비밀번호를 변경합니다.", security = {@SecurityRequirement(name = "bearer-key")})
     @PatchMapping("/me/password")
     public ResponseEntity<ApiResponse<Void>> updatePassword(
-            @RequestBody UpdatePasswordRequestDto requestDto,
+            @RequestBody @Valid UpdatePasswordRequestDto requestDto,
             @AuthenticationPrincipal JwtUserInfoDto userInfoDto) {
         userService.updatePassword(userInfoDto.getUserId(), requestDto);
         return ResponseEntity.ok(ApiResponse.success("비밀번호가 변경되었습니다."));

--- a/src/main/java/com/even/zaro/dto/auth/SignUpRequestDto.java
+++ b/src/main/java/com/even/zaro/dto/auth/SignUpRequestDto.java
@@ -1,6 +1,8 @@
 package com.even.zaro.dto.auth;
 
 import com.even.zaro.global.validator.annotation.ValidEmail;
+import com.even.zaro.global.validator.annotation.ValidNickname;
+import com.even.zaro.global.validator.annotation.ValidPassword;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
@@ -19,7 +21,12 @@ public class SignUpRequestDto {
     private String email;
 
     @Schema(description = "비밀번호", example = "Qwer1234!", required = true)
+    @NotBlank(message = "PASSWORD_REQUIRED")
+    @ValidPassword
     private String password;
+
     @Schema(description = "닉네임", example = "자취왕", required = true)
+    @NotBlank(message = "NICKNAME_REQUIRED")
+    @ValidNickname
     private String nickname;
 }

--- a/src/main/java/com/even/zaro/dto/auth/SignUpRequestDto.java
+++ b/src/main/java/com/even/zaro/dto/auth/SignUpRequestDto.java
@@ -1,5 +1,6 @@
 package com.even.zaro.dto.auth;
 
+import com.even.zaro.global.validator.annotation.ValidEmail;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
@@ -11,8 +12,12 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Schema(description = "회원가입 요청")
 public class SignUpRequestDto {
+
     @Schema(description = "이메일", example = "test@even.com", required = true)
+    @NotBlank(message = "EMAIL_REQUIRED")
+    @ValidEmail
     private String email;
+
     @Schema(description = "비밀번호", example = "Qwer1234!", required = true)
     private String password;
     @Schema(description = "닉네임", example = "자취왕", required = true)

--- a/src/main/java/com/even/zaro/dto/user/UpdateNicknameRequestDto.java
+++ b/src/main/java/com/even/zaro/dto/user/UpdateNicknameRequestDto.java
@@ -1,5 +1,6 @@
 package com.even.zaro.dto.user;
 
+import com.even.zaro.global.validator.annotation.ValidNickname;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
@@ -11,7 +12,7 @@ import lombok.Getter;
 public class UpdateNicknameRequestDto {
 
     @Schema(description = "새 닉네임", example = "이브니짱")
-    @NotBlank
-    @Pattern(regexp = "^[a-zA-Z0-9가-힣]{2,12}$")
+    @NotBlank(message = "NEW_NICKNAME_REQUIRED")
+    @ValidNickname
     private String newNickname;
 }

--- a/src/main/java/com/even/zaro/dto/user/UpdatePasswordRequestDto.java
+++ b/src/main/java/com/even/zaro/dto/user/UpdatePasswordRequestDto.java
@@ -1,6 +1,8 @@
 package com.even.zaro.dto.user;
 
+import com.even.zaro.global.validator.annotation.ValidPassword;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -9,8 +11,11 @@ import lombok.Getter;
 public class UpdatePasswordRequestDto {
 
     @Schema(description = "현재 비밀번호", example = "Old1234!")
+    @NotBlank(message = "CURRENT_PASSWORD_REQUIRED")
     private String currentPassword;
 
     @Schema(description = "새 비밀번호", example = "New1234!")
+    @NotBlank(message = "PASSWORD_REQUIRED")
+    @ValidPassword
     private String newPassword;
 }

--- a/src/main/java/com/even/zaro/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/even/zaro/global/exception/GlobalExceptionHandler.java
@@ -7,6 +7,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataAccessException;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
@@ -27,6 +29,18 @@ public class GlobalExceptionHandler {
                 .status(ex.getStatus())
                 .body(ErrorResponse.fail(ex.getCode(), ex.getMessage()));
     }
+
+    // ValidException  처리
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> handleValidation(MethodArgumentNotValidException ex) {
+        FieldError error = ex.getBindingResult().getFieldError();
+        String codeName = error.getDefaultMessage();
+
+        ErrorCode errorCode = ErrorCode.valueOf(codeName);
+        return ResponseEntity.badRequest()
+                .body(new ErrorResponse(errorCode.getCode(), errorCode.getDefaultMessage()));
+    }
+
 
     // 기타 예외 처리
     @ExceptionHandler(Exception.class)

--- a/src/main/java/com/even/zaro/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/even/zaro/global/exception/GlobalExceptionHandler.java
@@ -41,7 +41,6 @@ public class GlobalExceptionHandler {
                 .body(new ErrorResponse(errorCode.getCode(), errorCode.getDefaultMessage()));
     }
 
-
     // 기타 예외 처리
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ErrorResponse> handleGeneralException(Exception ex) {

--- a/src/main/java/com/even/zaro/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/even/zaro/global/exception/GlobalExceptionHandler.java
@@ -20,6 +20,7 @@ import java.util.List;
 @RestControllerAdvice
 public class GlobalExceptionHandler {
     private static final List<String> PRIORITY = List.of(
+            "CURRENT_PASSWORD_REQUIRED",
             "EMAIL_REQUIRED",
             "INVALID_EMAIL_FORMAT",
             "PASSWORD_REQUIRED",

--- a/src/main/java/com/even/zaro/global/validator/EmailValidator.java
+++ b/src/main/java/com/even/zaro/global/validator/EmailValidator.java
@@ -12,6 +12,7 @@ public class EmailValidator implements ConstraintValidator<ValidEmail, String> {
 
     @Override
     public boolean isValid(String value, ConstraintValidatorContext context) {
-        return value != null && Pattern.matches(EMAIL_REGEX, value);
+        if (value == null || value.isBlank()) return true;
+        return Pattern.matches(EMAIL_REGEX, value);
     }
 }

--- a/src/main/java/com/even/zaro/global/validator/EmailValidator.java
+++ b/src/main/java/com/even/zaro/global/validator/EmailValidator.java
@@ -1,0 +1,17 @@
+package com.even.zaro.global.validator;
+
+import com.even.zaro.global.validator.annotation.ValidEmail;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+import java.util.regex.Pattern;
+
+public class EmailValidator implements ConstraintValidator<ValidEmail, String> {
+
+    private static final String EMAIL_REGEX = "^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}$";
+
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext context) {
+        return value != null && Pattern.matches(EMAIL_REGEX, value);
+    }
+}

--- a/src/main/java/com/even/zaro/global/validator/NicknameValidator.java
+++ b/src/main/java/com/even/zaro/global/validator/NicknameValidator.java
@@ -1,0 +1,19 @@
+package com.even.zaro.global.validator;
+
+import com.even.zaro.global.validator.annotation.ValidEmail;
+import com.even.zaro.global.validator.annotation.ValidNickname;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+import java.util.regex.Pattern;
+
+public class NicknameValidator implements ConstraintValidator<ValidNickname, String> {
+
+    private static final String NICKNAME_REGEX = "^[a-zA-Z0-9가-힣_-]{2,12}$";
+
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext context) {
+        if (value == null || value.isBlank()) return true;
+        return Pattern.matches(NICKNAME_REGEX, value);
+    }
+}

--- a/src/main/java/com/even/zaro/global/validator/PasswordValidator.java
+++ b/src/main/java/com/even/zaro/global/validator/PasswordValidator.java
@@ -1,0 +1,19 @@
+package com.even.zaro.global.validator;
+
+import com.even.zaro.global.validator.annotation.ValidEmail;
+import com.even.zaro.global.validator.annotation.ValidPassword;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+import java.util.regex.Pattern;
+
+public class PasswordValidator implements ConstraintValidator<ValidPassword, String> {
+
+    private static final String PASSWORD_REGEX = "^(?=.*[A-Z])(?=.*[a-z])(?=.*\\d)(?=.*[_!@#$%^&*])[A-Za-z\\d_!@#$%^&*]{6,}$";
+
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext context) {
+        if (value == null || value.isBlank()) return true;
+        return Pattern.matches(PASSWORD_REGEX, value);
+    }
+}

--- a/src/main/java/com/even/zaro/global/validator/annotation/ValidEmail.java
+++ b/src/main/java/com/even/zaro/global/validator/annotation/ValidEmail.java
@@ -1,0 +1,19 @@
+package com.even.zaro.global.validator.annotation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.*;
+
+@Documented
+@Constraint(validatedBy = com.even.zaro.global.validator.EmailValidator.class)
+@Target({ElementType.FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ValidEmail {
+
+    String message() default "INVALID_EMAIL_FORMAT";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/com/even/zaro/global/validator/annotation/ValidNickname.java
+++ b/src/main/java/com/even/zaro/global/validator/annotation/ValidNickname.java
@@ -1,0 +1,19 @@
+package com.even.zaro.global.validator.annotation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.*;
+
+@Documented
+@Constraint(validatedBy = com.even.zaro.global.validator.NicknameValidator.class)
+@Target({ElementType.FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ValidNickname {
+
+    String message() default "INVALID_NICKNAME_FORMAT";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/com/even/zaro/global/validator/annotation/ValidPassword.java
+++ b/src/main/java/com/even/zaro/global/validator/annotation/ValidPassword.java
@@ -1,0 +1,19 @@
+package com.even.zaro.global.validator.annotation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.*;
+
+@Documented
+@Constraint(validatedBy = com.even.zaro.global.validator.PasswordValidator.class)
+@Target({ElementType.FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ValidPassword {
+
+    String message() default "INVALID_PASSWORD_FORMAT";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/com/even/zaro/service/AuthService.java
+++ b/src/main/java/com/even/zaro/service/AuthService.java
@@ -26,7 +26,6 @@ import java.util.regex.Pattern;
 @RequiredArgsConstructor
 public class AuthService {
     // 상수
-    private static final String EMAIL_REGEX = "^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}$";
     private static final String PASSWORD_REGEX = "^(?=.*[A-Z])(?=.*[a-z])(?=.*\\d)(?=.*[_!@#$%^&*])[A-Za-z\\d_!@#$%^&*]{6,}$";
     private static final String NICKNAME_REGEX = "^[a-zA-Z0-9가-힣_-]{2,12}$";
 
@@ -47,12 +46,6 @@ public class AuthService {
         String nickname = requestDto.getNickname();
 
         // 유효성 검사
-        if (email == null || email.isBlank()) {
-            throw new UserException(ErrorCode.EMAIL_REQUIRED);
-        }
-        if (!Pattern.matches(EMAIL_REGEX, email)) {
-            throw new UserException(ErrorCode.INVALID_EMAIL_FORMAT);
-        }
         if (password == null || password.isBlank()) {
             throw new UserException(ErrorCode.PASSWORD_REQUIRED);
         }

--- a/src/main/java/com/even/zaro/service/AuthService.java
+++ b/src/main/java/com/even/zaro/service/AuthService.java
@@ -25,10 +25,6 @@ import java.util.regex.Pattern;
 @Service
 @RequiredArgsConstructor
 public class AuthService {
-    // 상수
-    private static final String PASSWORD_REGEX = "^(?=.*[A-Z])(?=.*[a-z])(?=.*\\d)(?=.*[_!@#$%^&*])[A-Za-z\\d_!@#$%^&*]{6,}$";
-    private static final String NICKNAME_REGEX = "^[a-zA-Z0-9가-힣_-]{2,12}$";
-
     // 필드, 생성자
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
@@ -44,20 +40,6 @@ public class AuthService {
         String email = requestDto.getEmail();
         String password = requestDto.getPassword();
         String nickname = requestDto.getNickname();
-
-        // 유효성 검사
-        if (password == null || password.isBlank()) {
-            throw new UserException(ErrorCode.PASSWORD_REQUIRED);
-        }
-        if (!Pattern.matches(PASSWORD_REGEX, password)) {
-            throw new UserException(ErrorCode.INVALID_PASSWORD_FORMAT);
-        }
-        if (nickname == null || nickname.isBlank()) {
-            throw new UserException(ErrorCode.NICKNAME_REQUIRED);
-        }
-        if (!Pattern.matches(NICKNAME_REGEX, nickname)) {
-            throw new UserException(ErrorCode.INVALID_NICKNAME_FORMAT);
-        }
 
         // 중복 확인
         Optional<User> pendingUser = userRepository.findByEmailAndNickname(email, nickname);

--- a/src/test/java/com/even/zaro/unit/service/UserServiceTest.java
+++ b/src/test/java/com/even/zaro/unit/service/UserServiceTest.java
@@ -142,23 +142,24 @@ class UserServiceTest {
             assertEquals(ErrorCode.MAIL_NOT_VERIFIED, ex.getErrorCode());
         }
 
-        @Test
-        void shouldThrowException_whenNewNicknameIsBlank() {
-            UpdateNicknameRequestDto requestDto = new UpdateNicknameRequestDto("");
-
-            UserException ex = assertThrows(UserException.class, () -> userService.updateNickname(1L, requestDto));
-
-            assertEquals(ErrorCode.NEW_NICKNAME_REQUIRED, ex.getErrorCode());
-        }
-
-        @Test
-        void shouldThrowException_whenNicknameFormatIsInvalid() {
-            UpdateNicknameRequestDto requestDto = new UpdateNicknameRequestDto("형식파괴!!!");
-
-            UserException ex = assertThrows(UserException.class, () -> userService.updateNickname(1L, requestDto));
-
-            assertEquals(ErrorCode.INVALID_NICKNAME_FORMAT, ex.getErrorCode());
-        }
+        // 리팩토링으로 로직 테스트 불필요
+//        @Test
+//        void shouldThrowException_whenNewNicknameIsBlank() {
+//            UpdateNicknameRequestDto requestDto = new UpdateNicknameRequestDto("");
+//
+//            UserException ex = assertThrows(UserException.class, () -> userService.updateNickname(1L, requestDto));
+//
+//            assertEquals(ErrorCode.NEW_NICKNAME_REQUIRED, ex.getErrorCode());
+//        }
+//
+//        @Test
+//        void shouldThrowException_whenNicknameFormatIsInvalid() {
+//            UpdateNicknameRequestDto requestDto = new UpdateNicknameRequestDto("형식파괴!!!");
+//
+//            UserException ex = assertThrows(UserException.class, () -> userService.updateNickname(1L, requestDto));
+//
+//            assertEquals(ErrorCode.INVALID_NICKNAME_FORMAT, ex.getErrorCode());
+//        }
 
         @Test
         void shouldThrowException_whenNicknameAlreadyExists() {
@@ -314,14 +315,15 @@ class UserServiceTest {
             assertEquals(ErrorCode.MAIL_NOT_VERIFIED, ex.getErrorCode());
         }
 
-        @Test
-        void shouldThrowException_whenCurrentPasswordIsBlank() {
-            UpdatePasswordRequestDto requestDto = new UpdatePasswordRequestDto("", "New1234!");
-
-            UserException ex = assertThrows(UserException.class, () -> userService.updatePassword(1L, requestDto));
-
-            assertEquals(ErrorCode.CURRENT_PASSWORD_REQUIRED, ex.getErrorCode());
-        }
+        // 리팩토링으로 로직 테스트 불필요
+//        @Test
+//        void shouldThrowException_whenCurrentPasswordIsBlank() {
+//            UpdatePasswordRequestDto requestDto = new UpdatePasswordRequestDto("", "New1234!");
+//
+//            UserException ex = assertThrows(UserException.class, () -> userService.updatePassword(1L, requestDto));
+//
+//            assertEquals(ErrorCode.CURRENT_PASSWORD_REQUIRED, ex.getErrorCode());
+//        }
 
         @Test
         void shouldThrowException_whenCurrentPasswordIsIncorrect() {

--- a/src/test/java/com/even/zaro/unit/service/UserServiceTest.java
+++ b/src/test/java/com/even/zaro/unit/service/UserServiceTest.java
@@ -413,25 +413,26 @@ class UserServiceTest {
                 when(userRepository.findById(1L)).thenReturn(Optional.of(user));
             }
 
-            @Test
-            void shouldThrowException_whenNewPasswordIsBlank() {
-                UpdatePasswordRequestDto requestDto = new UpdatePasswordRequestDto("Old1234!", "");
-                when(passwordEncoder.matches("Old1234!", "OldEncoded1!")).thenReturn(true);
-
-                UserException ex = assertThrows(UserException.class, () -> userService.updatePassword(1L, requestDto));
-
-                assertEquals(ErrorCode.PASSWORD_REQUIRED, ex.getErrorCode());
-            }
-
-            @Test
-            void shouldThrowException_whenNewPasswordFormatIsInvalid() {
-                UpdatePasswordRequestDto requestDto = new UpdatePasswordRequestDto("Old1234!", "wrongFormat");
-                when(passwordEncoder.matches("Old1234!", "OldEncoded1!")).thenReturn(true);
-
-                UserException ex = assertThrows(UserException.class, () -> userService.updatePassword(1L, requestDto));
-
-                assertEquals(ErrorCode.INVALID_PASSWORD_FORMAT, ex.getErrorCode());
-            }
+            // 리팩토링으로 로직 테스트 불필요
+//            @Test
+//            void shouldThrowException_whenNewPasswordIsBlank() {
+//                UpdatePasswordRequestDto requestDto = new UpdatePasswordRequestDto("Old1234!", "");
+//                when(passwordEncoder.matches("Old1234!", "OldEncoded1!")).thenReturn(true);
+//
+//                UserException ex = assertThrows(UserException.class, () -> userService.updatePassword(1L, requestDto));
+//
+//                assertEquals(ErrorCode.PASSWORD_REQUIRED, ex.getErrorCode());
+//            }
+//
+//            @Test
+//            void shouldThrowException_whenNewPasswordFormatIsInvalid() {
+//                UpdatePasswordRequestDto requestDto = new UpdatePasswordRequestDto("Old1234!", "wrongFormat");
+//                when(passwordEncoder.matches("Old1234!", "OldEncoded1!")).thenReturn(true);
+//
+//                UserException ex = assertThrows(UserException.class, () -> userService.updatePassword(1L, requestDto));
+//
+//                assertEquals(ErrorCode.INVALID_PASSWORD_FORMAT, ex.getErrorCode());
+//            }
 
             @Test
             void shouldThrowException_whenCurrentPasswordIsSameAsNewPassword() {


### PR DESCRIPTION
## 📌 작업 개요
- 회원가입, 닉네임 변경, 비밀번호 변경 커스텀 validator 적용

---

## ✨ 주요 변경 사항
- 기존 서비스 레이어에서 하던 유효성 검사 부분, Validator를 만들어서 컨트롤러 도달 전 예외 처리
    - 회원가입 (이메일, 비밀번호, 닉네임 패턴 및 Not Blank에 커스텀 에러 코드 추가)
    - 닉네임 변경 (닉네임 패턴 및 Not Blank 커스텀 에러 코드 추가)
    - 비밀번호 변경 (비밀번호 패턴 및 Not Blank 커스텀 에러 코드 추가)
- 이메일, 비밀번호, 닉네임 Validator 및 커스텀 애노테이션 구현 


---

## 🖼️ 기능 살펴 보기
- 기존과 동일하게 예외 처리 잘 됨.

|이메일 Required | 이메일 Invalid |
|----------------|-------------|
|![image](https://github.com/user-attachments/assets/31168a85-8653-4a3f-b442-f8d5eb22f137)|![image](https://github.com/user-attachments/assets/94e25634-db35-4275-9aba-fe6b20da9a4f)|

|비밀번호 Required |비밀번호 Invalid |
|----------------|-------------|
|![image](https://github.com/user-attachments/assets/e0c51b68-d1cb-4d96-93ba-44fee0935b66)|![image](https://github.com/user-attachments/assets/a3f2296f-c405-4e60-9a0d-0d3898e709b4)|

|닉네임 Required |닉네임 Invalid |
|----------------|-------------|
|![image](https://github.com/user-attachments/assets/39192102-07da-46a6-9f58-e08d2cda5ee6)|![image](https://github.com/user-attachments/assets/4571a9c7-57ea-48ca-90bf-c4967e01f625)|

---

## ✅ 작업 체크리스트
- [x] API 테스트 완료 (POSTMAN)
- [x] 스웨거 ui 관련 코드 추가
- [x] 기능별 예외 케이스 고려
- [x] log.info / 불필요한 주석 제거
- [x] 변수명, 클래스명, 메서드명 의미있게 작성
- [x] 반복 코드 메서드로 분리

---

## 📂 테스트 방법
- [ ] 테스트 코드 작성
- [x] 시나리오 기반 테스트 유무
    - JMeter로 200명 user 테스트를 진행 (20명*10회)
    - 예외가 터졌을 때 더 큰 의미가 있기 때문에 실패 테스트 진행

#### 회원가입

|회원가입 실패(닉네임 패턴 오류) 테스트|결과|
|-------------|--------|
|![image](https://github.com/user-attachments/assets/8b90a18d-ce29-4d5b-a420-5a43919bb2ca)|![image](https://github.com/user-attachments/assets/1f3ebf05-aa8a-416c-bed3-37580ac3b38e)|

- 리팩토링 전에도 DB를 확인하지 않아서 성능에 큰 차이가 없습니다. ㅠㅠ
- 그렇지만.. 서비스 진입 전 해결된다는 것에서 CPU, 메모리, GC 자원을 아꼈다는 의미가 있다고 생각됩니다.

#### 닉네임 변경

|닉네임 변경 실패(닉네임 패턴 오류) 테스트|결과|
|-------------|--------|
|![image](https://github.com/user-attachments/assets/9d627cc5-bde2-46c4-9102-9d8d0a7fff49)|![image](https://github.com/user-attachments/assets/40debfc2-411e-4d58-aa28-f82587947bbb)|

- 리팩토링 전의 경우 DB를 먼저 확인 하기 때문에 차이가 조금 있습니다.
- Validator 적용 후 평균 응답시간 40% 이상 단축
- TPS도 증가하여 처리 성능 개선 확인

---

## 💬 기타 참고 사항
- 아무 생각 없이 회원가입 성공 테스트 하다.. 메일 보내지는 것을 잊고.. 에러가 막 나더라구요? 메일이 막히지만 않기를.... 제발 🙏 

---

## 📎 관련 이슈 / 문서
- 관련 이슈 번호: Fixes #159 
