### PR TITLE
Fix/sse notification : sse 인증을 header사용으로 ref -> 불필요 설정 롤백, 연결유지용 ping 전송 코드 추가

### DIFF
--- a/src/main/java/com/even/zaro/controller/AuthController.java
+++ b/src/main/java/com/even/zaro/controller/AuthController.java
@@ -53,24 +53,7 @@ public class AuthController {
     public ResponseEntity<ApiResponse<SignInResponseDto>> signIn(@RequestBody SignInRequestDto requestDto) {
         SignInResponseDto responseDto = authService.signIn(requestDto);
 
-        ResponseCookie accessTokenCookie = ResponseCookie.from("access_token", responseDto.getAccessToken())
-                .httpOnly(true)
-                .secure(true) // HTTPS(배포) 환경에서만 작동, 로컬에서는 false로 바꿔야함
-                .sameSite("None") // 크로스도메인 허용
-                .path("/")
-                .build();
-
-        ResponseCookie refreshTokenCookie = ResponseCookie.from("refresh_token", responseDto.getRefreshToken())
-                .httpOnly(true)
-                .secure(true)
-                .sameSite("None")
-                .path("/")
-                .build();
-
-        return ResponseEntity.ok()
-                .header(HttpHeaders.SET_COOKIE, accessTokenCookie.toString())
-                .header(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString())
-                .body(ApiResponse.success("로그인에 성공했습니다.", responseDto));
+        return ResponseEntity.ok(ApiResponse.success("로그인에 성공했습니다.", responseDto));
     }
 
     @Operation(summary = "카카오 회원가입/로그인", description = "카카오 access token을 받아 회원가입/로그인 처리합니다.")
@@ -78,25 +61,7 @@ public class AuthController {
     public ResponseEntity<ApiResponse<SignInResponseDto>> signInWithKakao(
             @RequestBody @Parameter(description = "카카오 access token") KakaoSignInRequestDto requestDto) {
         SignInResponseDto responseDto = authService.SignInWithKakao(requestDto.getAccessToken());
-
-        ResponseCookie accessTokenCookie = ResponseCookie.from("access_token", responseDto.getAccessToken())
-                .httpOnly(true)
-                .secure(true) // HTTPS(배포) 환경에서만 작동, 로컬에서는 false로 바꿔야함
-                .sameSite("None") // 크로스도메인 허용
-                .path("/")
-                .build();
-
-        ResponseCookie refreshTokenCookie = ResponseCookie.from("refresh_token", responseDto.getRefreshToken())
-                .httpOnly(true)
-                .secure(true)
-                .sameSite("None")
-                .path("/")
-                .build();
-
-        return ResponseEntity.ok()
-                .header(HttpHeaders.SET_COOKIE, accessTokenCookie.toString())
-                .header(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString())
-                .body(ApiResponse.success("카카오 로그인에 성공했습니다.", responseDto));
+        return ResponseEntity.ok(ApiResponse.success("카카오 로그인에 성공했습니다.", responseDto));
     }
 
     @Operation(summary = "Access Token 재발급", description = "Refresh 토큰을 입력해 Access Token을 재발급 받습니다. 상단 Authorize에 Refresh Token을 입력하세요.",

--- a/src/main/java/com/even/zaro/global/jwt/JwtAuthFilter.java
+++ b/src/main/java/com/even/zaro/global/jwt/JwtAuthFilter.java
@@ -26,10 +26,10 @@ public class JwtAuthFilter extends OncePerRequestFilter {
         // 헤더에서 토큰 추출
         String token = jwtUtil.resolveToken(request);
 
-        // Authorization 헤더 없을 경우 쿠키에서 추출 (SSE)
-        if (token == null) {
-            token = jwtUtil.extractTokenFromCookies(request);
-        }
+//        // Authorization 헤더 없을 경우 쿠키에서 추출 (SSE)
+//        if (token == null) {
+//            token = jwtUtil.extractTokenFromCookies(request);
+//        }
 
         // 토큰 유효성 검사
         if (token != null && jwtUtil.validateAccessToken(token)) {


### PR DESCRIPTION
## 📌 작업 개요
- sse 인증을 header사용으로 ref -> 불필요 설정 롤백, 연결유지용 ping 전송 코드 추가

---

## ✨ 주요 변경 사항
- sse 인증을 쿠키->header사용으로 ref 하게되어 생긴 사항들
  - 트러블슈팅 ing 참고 : #157  
  
- 불필요 설정 롤백
  - #152 의 쿠키설정을 이전 코드로 롤백
  - 쿠키 안 쓰므로, JwtAuthFilter의 쿠키토큰추출 코드 주석처리 (어차피 If문 들어갈 일이 없어지긴 해서 유지해도 되긴합니다)
  
-  연결유지용 ping 전송 코드 추가
  - FE에서 SSE+EventSourcePolyfill 라이브러리로 헤더 사용
  - 이 경우 heartbeatTimeout으로 45초 이내에 새로운 이벤트 전송이 없으면, 연결을 끊고 자동 재연결이 됨 (현재경우 넉넉히 65초로 세팅해둠)
  - 자동 재연결 시, 자동 헤더 인증은 불가능한 문제 발발
  - 따라서 BE에서 30초마다 연결유지용 Ping을 전송해, 연결을 유지하도록 설정함
  
---

## 🖼️ 기능 살펴 보기

> 서버 실행 시 @PostConstruct로 Ping 작업 초기화
> ![image](https://github.com/user-attachments/assets/ac86cc98-e7dd-4d86-8407-7ffc3c2acb80)


> 30초마다 자동전송되는 ping으로, 알림event 전송이 없어도 sse연결이 끊기지 않음
> ![image](https://github.com/user-attachments/assets/d592bcdf-2153-4e72-915f-34c8e142296b)
> ![image](https://github.com/user-attachments/assets/57e8bb7a-53b0-4ba5-8c77-04ab55d41874)


---

## ✅ 작업 체크리스트
- [ ] API 테스트 완료 (POSTMAN)
- [ ] 스웨거 ui 관련 코드 추가
- [ ] 기능별 예외 케이스 고려
- [ ] log.info / 불필요한 주석 제거
- [ ] 변수명, 클래스명, 메서드명 의미있게 작성
- [ ] 반복 코드 메서드로 분리

---

## 📂 테스트 방법
- local 3000 & local 8080

---

## 💬 기타 참고 사항
- fe 쪽 코드 곧 pr 날릴 예정

---

## 📎 관련 이슈 / 문서
- ping 에 대한 간단 설명임다
- https://velog.io/@eunoia73/SSE-%EC%97%B0%EA%B2%B0-%EC%9C%A0%EC%A7%80-%EC%8B%9C%EA%B0%84%EA%B3%BC-Ping-%EB%A9%94%EC%8B%9C%EC%A7%80-%ED%99%9C%EC%9A%A9
