### PR TITLE
ref : 인근 장소 조회 API 예외 처리 방법 수정

### DIFF
--- a/src/main/java/com/even/zaro/controller/MapController.java
+++ b/src/main/java/com/even/zaro/controller/MapController.java
@@ -15,8 +15,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
-
 @RestController
 @RequestMapping("/api/map")
 @Slf4j
@@ -51,6 +49,10 @@ public class MapController {
             @AuthenticationPrincipal JwtUserInfoDto userInfo) {
 
         PlaceResponse placesByCoordinate = mapService.getPlacesByCoordinate(lat, lng, distanceKm);
+
+        if (placesByCoordinate == null) {
+            ResponseEntity.ok(ApiResponse.success("인근에 조회된 장소가 없습니다."));
+        }
 
         return ResponseEntity.ok(ApiResponse.success("인근 장소 리스트를 성공적으로 조회했습니다.", placesByCoordinate));
     }

--- a/src/main/java/com/even/zaro/controller/MapController.java
+++ b/src/main/java/com/even/zaro/controller/MapController.java
@@ -51,7 +51,7 @@ public class MapController {
         PlaceResponse placesByCoordinate = mapService.getPlacesByCoordinate(lat, lng, distanceKm);
 
         if (placesByCoordinate == null) {
-            ResponseEntity.ok(ApiResponse.success("인근에 조회된 장소가 없습니다."));
+            return ResponseEntity.ok(ApiResponse.success("인근에 조회된 장소가 없습니다."));
         }
 
         return ResponseEntity.ok(ApiResponse.success("인근 장소 리스트를 성공적으로 조회했습니다.", placesByCoordinate));

--- a/src/main/java/com/even/zaro/controller/MapController.java
+++ b/src/main/java/com/even/zaro/controller/MapController.java
@@ -50,10 +50,9 @@ public class MapController {
 
         PlaceResponse placesByCoordinate = mapService.getPlacesByCoordinate(lat, lng, distanceKm);
 
-        if (placesByCoordinate == null) {
-            return ResponseEntity.ok(ApiResponse.success("인근에 조회된 장소가 없습니다."));
+        if (placesByCoordinate.getTotalCount() == 0) {
+            return ResponseEntity.ok(ApiResponse.success("인근에 조회된 장소가 없습니다.", placesByCoordinate));
         }
-
         return ResponseEntity.ok(ApiResponse.success("인근 장소 리스트를 성공적으로 조회했습니다.", placesByCoordinate));
     }
 

--- a/src/main/java/com/even/zaro/service/MapService.java
+++ b/src/main/java/com/even/zaro/service/MapService.java
@@ -51,7 +51,8 @@ public class MapService {
 
         // 조회된 장소가 없을 때
         if (placeByCoordinate.isEmpty()) {
-            throw new MapException(ErrorCode.BY_COORDINATE_NOT_FOUND_PLACE_LIST);
+//            throw new MapException(ErrorCode.BY_COORDINATE_NOT_FOUND_PLACE_LIST);
+            return null;
         }
 
         List<PlaceResponse.PlaceInfo> placeInfos =  placeByCoordinate.stream()

--- a/src/main/java/com/even/zaro/service/MapService.java
+++ b/src/main/java/com/even/zaro/service/MapService.java
@@ -49,12 +49,6 @@ public class MapService {
 
         List<Place> placeByCoordinate = mapQueryRepository.findPlaceByCoordinate(lat, lng, distanceKm);
 
-        // 조회된 장소가 없을 때
-        if (placeByCoordinate.isEmpty()) {
-//            throw new MapException(ErrorCode.BY_COORDINATE_NOT_FOUND_PLACE_LIST);
-            return null;
-        }
-
         List<PlaceResponse.PlaceInfo> placeInfos =  placeByCoordinate.stream()
                 .sorted(Comparator.comparingInt(Place::getFavoriteCount).reversed()) // 내림차순 정렬
                 .map(place -> PlaceResponse.PlaceInfo.builder()


### PR DESCRIPTION
## 📌 작업 개요
- 인근 장소 조회 API 예외 처리 방법 수정 ( 예외를 던지는 것이 아닌 정상 응답에 데이터 null)

---

## ✨ 주요 변경 사항
- 조회된 데이터 없을 시 서비스단에서 null 반환
- 컨트롤러에서 null 일시, "인근에 조회된 장소가 없습니다" 메시지 응답

---

## 🖼️ 기능 살펴 보기
>  <img width="696" alt="image" src="https://github.com/user-attachments/assets/07760e4f-9fb7-49de-b8e2-0d0c27cbc47f" />
- 인근 장소 없을 시 조회된 장소 없습니다 문구 응답

---

## ✅ 작업 체크리스트
- [x] API 테스트 완료 (POSTMAN)
- [ ] 스웨거 ui 관련 코드 추가
- [x] 기능별 예외 케이스 고려
- [ ] log.info / 불필요한 주석 제거
- [ ] 변수명, 클래스명, 메서드명 의미있게 작성
- [ ] 반복 코드 메서드로 분리

---

## 📂 테스트 방법
- [ ] 테스트 코드 작성
- [ ] 시나리오 기반 테스트 유무
- [x] SwaggerUI

---

## 💬 기타 참고 사항
- 프론트단에서 인근 조회 API를 호출할 때마다 console에 오류가 누적되어 정돈하기 위해 작업했습니다.
- 백엔드단에서 예외를 던져버리면 프론트의 client 코드를 수정하는 것이 아닌 이상 
   console 에러가 찍히는 것을 피할수가 없었기 때문에 취한 조치입니다,,

---

## 📎 관련 이슈 / 문서

