### PR TITLE
fix/ping : Vercel, EC2 앞단 Nginx에서 버퍼링 비활성화

### DIFF
--- a/src/main/java/com/even/zaro/controller/NotificationController.java
+++ b/src/main/java/com/even/zaro/controller/NotificationController.java
@@ -8,6 +8,7 @@ import com.even.zaro.service.NotificationSseService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
@@ -65,8 +66,17 @@ public class NotificationController {
     }
 
     @GetMapping(value = "/subscribe", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
-    public SseEmitter subscribe(@AuthenticationPrincipal JwtUserInfoDto userInfoDto) {
+    public SseEmitter subscribe(
+            @AuthenticationPrincipal JwtUserInfoDto userInfoDto, HttpServletResponse response
+    ) {
         log.info("[SSE] /subscribe 진입: userId = {}", userInfoDto.getUserId());
+
+        // SSE 관련 헤더 세팅
+        response.setContentType("text/event-stream;charset=UTF-8");
+        response.setHeader("Cache-Control", "no-cache");
+        response.setHeader("Connection", "keep-alive");
+        response.setHeader("X-Accel-Buffering", "no"); // 버퍼링 방지
+
         return notificationSseService.connect(userInfoDto.getUserId());
     }
 }


### PR DESCRIPTION
## 📌 작업 개요
-  Vercel, EC2 앞단 Nginx에서 버퍼링 비활성화

---

## ✨ 주요 변경 사항
- sse 관련 헤더 직접적인 세팅
  - 프록시 버퍼링 비활성화

---

## 🖼️ 기능 살펴 보기
> 로컬환경 잘 작동
![image](https://github.com/user-attachments/assets/ae86770d-8a6f-4447-ad32-2d24e4d6ab1a)

---

## ✅ 작업 체크리스트
- [ ] API 테스트 완료 (POSTMAN)
- [ ] 스웨거 ui 관련 코드 추가
- [ ] 기능별 예외 케이스 고려
- [ ] log.info / 불필요한 주석 제거
- [ ] 변수명, 클래스명, 메서드명 의미있게 작성
- [ ] 반복 코드 메서드로 분리

---

## 📂 테스트 방법
- [x] local3000<->local8080

---

## 💬 기타 참고 사항
- 제발

---

## 📎 관련 이슈 / 문서
- [SSE 사용중, 로컬에서는 되는데 서버 환경에서는 핑이 안 온다면?](https://velog.io/@hyu-jo/SSE-%EC%82%AC%EC%9A%A9%EC%A4%91-%EB%A1%9C%EC%BB%AC%EC%97%90%EC%84%9C%EB%8A%94-%EB%90%98%EB%8A%94%EB%8D%B0-%EC%84%9C%EB%B2%84-%ED%99%98%EA%B2%BD%EC%97%90%EC%84%9C%EB%8A%94-%ED%95%91%EC%9D%B4-%EC%95%88-%EC%98%A8%EB%8B%A4%EB%A9%B4)
