### PR TITLE
Fix/user 회원 정책 수정 및 리팩토링

### DIFF
--- a/src/main/java/com/even/zaro/controller/CommentController.java
+++ b/src/main/java/com/even/zaro/controller/CommentController.java
@@ -39,8 +39,8 @@ public class CommentController {
                 {postId} 게시글에 댓글을 작성합니다.
         
                 - 일반 댓글 또는 답글(멘션)을 작성할 수 있습니다.
-                - 답글의 경우, `taggedNickname` 필드에 멘션할 사용자의 닉네임을 포함해 주세요.
-                - 멘션을 지우거나 일반 댓글인 경우, `taggedNickname`을 null로 보내거나 생략해도 됩니다.
+                - 답글의 경우, `mentionedNickname` 필드에 멘션할 사용자의 닉네임을 포함해 주세요.
+                - 멘션을 지우거나 일반 댓글인 경우, `mentionedNickname`을 null로 보내거나 생략해도 됩니다.
                 """,
             security = {@SecurityRequirement(name = "bearer-key")})
     @PostMapping("/posts/{postId}/comments")

--- a/src/main/java/com/even/zaro/entity/User.java
+++ b/src/main/java/com/even/zaro/entity/User.java
@@ -11,6 +11,7 @@ import org.hibernate.annotations.UpdateTimestamp;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.UUID;
 
 @Entity
 @Getter
@@ -142,5 +143,11 @@ public class User {
     public void softDeleted() {
          this.status = Status.DELETED;
          this.deletedAt = LocalDateTime.now();
+    }
+
+    public void anonymize() {
+        this.nickname = "삭제된 사용자";
+        this.profileImage = null;
+        this.email = "deleted_" + UUID.randomUUID() + "@anonymized.even.com";
     }
 }

--- a/src/main/java/com/even/zaro/global/ErrorCode.java
+++ b/src/main/java/com/even/zaro/global/ErrorCode.java
@@ -60,6 +60,8 @@ public enum ErrorCode {
 
         // 계정
     MAIL_NOT_VERIFIED(HttpStatus.FORBIDDEN, "이메일 인증이 필요합니다. 메일함을 확인해주세요."),
+    DORMANT_USER(HttpStatus.FORBIDDEN, "휴면 계정입니다."),
+    DELETED_USER(HttpStatus.FORBIDDEN, "탈퇴한 회원입니다."),
     CURRENT_PASSWORD_REQUIRED(HttpStatus.BAD_REQUEST, "현재 비밀번호는 필수 입력 값입니다."),
     CURRENT_PASSWORD_WRONG(HttpStatus.FORBIDDEN, "현재 비밀번호가 올바르지 않습니다."),
     CURRENT_PASSWORD_EQUALS_NEW_PASSWORD(HttpStatus.BAD_REQUEST,"이전과 다른 비밀번호를 입력해주세요."),

--- a/src/main/java/com/even/zaro/global/scheduler/UserScheduler.java
+++ b/src/main/java/com/even/zaro/global/scheduler/UserScheduler.java
@@ -25,16 +25,16 @@ public class UserScheduler {
     private final EmailService emailService;
 
     // PENDING 회원 삭제
-    @Scheduled(cron = "0 15 3 * * *") // 매일 3시 15분
+    @Scheduled(cron = "0 15 18 * * *") // 매일 3시 15분(kst)
     @Transactional
     public void deleteExpiredPendingUsers() {
         LocalDateTime threshold = LocalDateTime.now().minusDays(1);
-        userRepository.deleteByStatusAndCreatedAtBefore(Status.PENDING, threshold);
-        log.info("[Scheduler] PENDING 회원 삭제 ! (PENDING for 1day = {})", threshold);
+        int deletedCount = userRepository.deleteByStatusAndCreatedAtBefore(Status.PENDING, threshold);
+        log.info("[Scheduler] PENDING 회원 삭제! (기준일: {}, 삭제 수: {})", threshold, deletedCount);
     }
 
     // 휴면 처리, 탈퇴 처리
-    @Scheduled(cron = "0 30 3 * * *")// 매일 3시 30분
+    @Scheduled(cron = "0 30 18 * * *") // 매일 3시 30분(kst)
     @Transactional
     public void handleDormantAndSoftDelete() {
         LocalDateTime now = LocalDateTime.now();
@@ -49,7 +49,7 @@ public class UserScheduler {
     }
 
     // 탈퇴 3년 경과 -> 회원 정보 영구 삭제
-    @Scheduled(cron = "0 45 3 * * *") // 매일 3시 45분
+    @Scheduled(cron = "0 45 18 * * *") // 매일 3시 45분(kst)
     @Transactional
     public void deleteWithdrawnUsers() {
         LocalDateTime threshold = LocalDateTime.now().minusYears(3);
@@ -59,7 +59,7 @@ public class UserScheduler {
     }
 
     // 탈퇴 30일 경과 -> 회원 정보 임의 값 변경
-    @Scheduled(cron = "0 0 4 * * *") // 매일 4시
+    @Scheduled(cron = "0 0 19 * * *") // 매일 4시(kst)
     @Transactional
     public void anonymizeWithdrawnUsers() {
         LocalDateTime threshold = LocalDateTime.now().minusDays(30);
@@ -70,7 +70,7 @@ public class UserScheduler {
     }
 
     // 휴면 예정 메일 전송
-    @Scheduled(cron = "0 0 14 * * *") // 매일 오후 2시
+    @Scheduled(cron = "0 0 5 * * *") // 매일 오후 2시(kst)
     @Transactional
     public void sendDormancyPendingEmail() {
         LocalDateTime now = LocalDateTime.now();

--- a/src/main/java/com/even/zaro/global/scheduler/UserScheduler.java
+++ b/src/main/java/com/even/zaro/global/scheduler/UserScheduler.java
@@ -48,7 +48,7 @@ public class UserScheduler {
         log.info("[Scheduler] Dormant 1년 경과 -> 탈퇴 처리 ! (Dormant starting date = {})", now.minusYears(1));
     }
 
-    // 탈퇴 30일 경과 -> 회원 정보 영구 삭제
+    // 탈퇴 3년 경과 -> 회원 정보 영구 삭제
     @Scheduled(cron = "0 45 3 * * *") // 매일 3시 45분
     @Transactional
     public void deleteWithdrawnUsers() {
@@ -56,6 +56,17 @@ public class UserScheduler {
         List<User> users = userRepository.findByStatusAndDeletedAtBefore(Status.DELETED, threshold);
         userRepository.deleteAll(users);
         log.info("[Scheduler] 탈퇴 회원 영구 삭제 ! (withdrawal date = {})", threshold);
+    }
+
+    // 탈퇴 30일 경과 -> 회원 정보 임의 값 변경
+    @Scheduled(cron = "0 0 4 * * *") // 매일 4시
+    @Transactional
+    public void anonymizeWithdrawnUsers() {
+        LocalDateTime threshold = LocalDateTime.now().minusDays(30);
+        List<User> users = userRepository.findByStatusAndDeletedAtBefore(Status.DELETED, threshold);
+        users.forEach(User::anonymize);
+        userRepository.saveAll(users);
+        log.info("[Scheduler] 탈퇴 회원 익명화 ! (withdrawal date = {})", threshold);
     }
 
     // 휴면 예정 메일 전송

--- a/src/main/java/com/even/zaro/global/scheduler/UserScheduler.java
+++ b/src/main/java/com/even/zaro/global/scheduler/UserScheduler.java
@@ -52,7 +52,7 @@ public class UserScheduler {
     @Scheduled(cron = "0 45 3 * * *") // 매일 3시 45분
     @Transactional
     public void deleteWithdrawnUsers() {
-        LocalDateTime threshold = LocalDateTime.now().minusDays(30);
+        LocalDateTime threshold = LocalDateTime.now().minusYears(3);
         List<User> users = userRepository.findByStatusAndDeletedAtBefore(Status.DELETED, threshold);
         userRepository.deleteAll(users);
         log.info("[Scheduler] 탈퇴 회원 영구 삭제 ! (withdrawal date = {})", threshold);

--- a/src/main/java/com/even/zaro/mapper/CommentMapper.java
+++ b/src/main/java/com/even/zaro/mapper/CommentMapper.java
@@ -52,8 +52,8 @@ public interface CommentMapper {
 
     @Mapping(target = "content", expression = "java(comment.isReported() ? \"신고로 삭제된 댓글입니다.\" : comment.getContent())")
     @Mapping(source = "comment.user.id", target = "userId")
-    @Mapping(source = "comment.user.nickname", target = "nickname")
-    @Mapping(source = "comment.user.profileImage", target = "profileImage")
+    @Mapping(target = "nickname", expression = "java(comment.getUser().getStatus() == com.even.zaro.entity.Status.DELETED ? \"알 수 없는 사용자\" : comment.getUser().getNickname())")
+    @Mapping(target = "profileImage", expression = "java(comment.getUser().getStatus() == com.even.zaro.entity.Status.DELETED ? null : comment.getUser().getProfileImage())")
     @Mapping(source = "comment.user.liveAloneDate", target = "liveAloneDate")
     @Mapping(target = "createdAt", source = "comment.createdAt")
     @Mapping(target = "updatedAt", source = "comment.updatedAt")

--- a/src/main/java/com/even/zaro/mapper/PostMapper.java
+++ b/src/main/java/com/even/zaro/mapper/PostMapper.java
@@ -28,8 +28,8 @@ public interface PostMapper {
     PostDetailResponse toPostDetailDto(Post post);
 
     @Mapping(source = "id", target = "postId")
-    @Mapping(source = "user.nickname", target = "writerNickname")
-    @Mapping(source = "user.profileImage", target = "writerProfileImage")
+    @Mapping(target = "writerNickname", expression = "java(post.getUser().getStatus() == com.even.zaro.entity.Status.DELETED ? \"알 수 없는 사용자\" : post.getUser().getNickname())")
+    @Mapping(target = "writerProfileImage", expression = "java(post.getUser().getStatus() == com.even.zaro.entity.Status.DELETED ? null : post.getUser().getProfileImage())")
     @Mapping(target = "content", expression = "java(stripHtmlTags(post.getContent()))")
     PostPreviewDto toPostPreviewDto(Post post);
 

--- a/src/main/java/com/even/zaro/repository/UserRepository.java
+++ b/src/main/java/com/even/zaro/repository/UserRepository.java
@@ -5,6 +5,7 @@ import com.even.zaro.entity.Status;
 import com.even.zaro.entity.User;
 import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
@@ -25,7 +26,9 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByNickname(String nickname);
 
-    List<User> deleteByStatusAndCreatedAtBefore(Status status, LocalDateTime threshold);
+    @Modifying(clearAutomatically = true)
+    @Query("DELETE FROM User u WHERE u.status = :status AND u.createdAt < :threshold")
+    int deleteByStatusAndCreatedAtBefore(@Param("status") Status status, @Param("threshold") LocalDateTime threshold);
     List<User> findByStatusAndLastLoginAtBefore(Status status, LocalDateTime time);
     List<User> findByStatusAndUpdatedAtBefore(Status status, LocalDateTime time);
     List<User> findByStatusAndDeletedAtBefore(Status status, LocalDateTime threshold);

--- a/src/main/java/com/even/zaro/service/CommentReportService.java
+++ b/src/main/java/com/even/zaro/service/CommentReportService.java
@@ -35,7 +35,7 @@ public class CommentReportService {
         request.validateReasonTextOrThrow();
 
        User user = userService.findUserById(userId);
-        userService.validateNotPending(user);
+        userService.validateActiveUser(user);
 
         if (commentReportRepository.existsByCommentAndUser(comment, user)) {
             throw new CommentException(ErrorCode.ALREADY_REPORTED_COMMENT);

--- a/src/main/java/com/even/zaro/service/PostLikeService.java
+++ b/src/main/java/com/even/zaro/service/PostLikeService.java
@@ -2,13 +2,11 @@ package com.even.zaro.service;
 
 import com.even.zaro.entity.Post;
 import com.even.zaro.entity.PostLike;
-import com.even.zaro.entity.Status;
 import com.even.zaro.entity.User;
 import com.even.zaro.global.ErrorCode;
 import com.even.zaro.global.exception.post.PostException;
 import com.even.zaro.repository.PostLikeRepository;
 import com.even.zaro.repository.PostRepository;
-import com.even.zaro.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -29,7 +27,7 @@ public class PostLikeService {
         }
 
         User user = userService.findUserById(userId);
-        userService.validateNotPending(user);
+        userService.validateActiveUser(user);
 
         Post post = postService.findUndeletedPostOrThrow(postId);
 
@@ -45,7 +43,7 @@ public class PostLikeService {
     @Transactional
     public void unlikePost(Long postId, Long userId) {
         User user = userService.findUserById(userId);
-        userService.validateNotPending(user);
+        userService.validateActiveUser(user);
         Post post = postService.findUndeletedPostOrThrow(postId);
 
         PostLike postLike = postLikeRepository.findByUserIdAndPostId(userId, postId)

--- a/src/main/java/com/even/zaro/service/PostReportService.java
+++ b/src/main/java/com/even/zaro/service/PostReportService.java
@@ -25,7 +25,7 @@ public class PostReportService {
         Post post = postService.findPostOrThrow(postId);
 
         User user = userService.findUserById(userId);
-        userService.validateNotPending(user);
+        userService.validateActiveUser(user);
 
         post.validateNotOwner(user);
         request.validateReasonTextOrThrow();

--- a/src/main/java/com/even/zaro/service/PostService.java
+++ b/src/main/java/com/even/zaro/service/PostService.java
@@ -3,6 +3,7 @@ package com.even.zaro.service;
 import com.even.zaro.dto.PageResponse;
 import com.even.zaro.dto.post.*;
 import com.even.zaro.entity.Post;
+import com.even.zaro.entity.Status;
 import com.even.zaro.entity.User;
 import com.even.zaro.global.event.event.PostDeletedEvent;
 import com.even.zaro.global.event.event.PostSavedEvent;
@@ -19,6 +20,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -129,14 +131,20 @@ public class PostService {
         User postOwner  = post.getUser();
         User loginUser = userService.findUserById(currentUserId);
 
+        boolean isDeleted = postOwner.getStatus() == Status.DELETED;
+
+        String nickname =  isDeleted ? "알 수 없는 사용자" : response.getUser().getNickname();
+        String profileImage = isDeleted ? null : response.getUser().getProfileImage();
+        LocalDate liveAloneDate = isDeleted ? null : response.getUser().getLiveAloneDate();
+
         boolean isFollowing = !loginUser.equals(postOwner) &&
                 followRepository.existsByFollowerAndFollowee(loginUser, postOwner);
 
         PostDetailResponse.UserInfo followUser = PostDetailResponse.UserInfo.builder()
                 .userId(response.getUser().getUserId())
-                .nickname(response.getUser().getNickname())
-                .profileImage(response.getUser().getProfileImage())
-                .liveAloneDate(response.getUser().getLiveAloneDate())
+                .nickname(nickname)
+                .profileImage(profileImage)
+                .liveAloneDate(liveAloneDate)
                 .following(isFollowing)
                 .build();
 

--- a/src/main/java/com/even/zaro/service/PostService.java
+++ b/src/main/java/com/even/zaro/service/PostService.java
@@ -43,7 +43,7 @@ public class PostService {
         validateTagForCategory(category, tag);
 
         User user = userService.findUserById(userId);
-        userService.validateNotPending(user);
+        userService.validateActiveUser(user);
 
         String thumbnailImage = resolveThumbnail(request.getThumbnailImage(), request.getPostImageList());
 
@@ -68,7 +68,7 @@ public class PostService {
         Post post = findPostOrThrow(postId);
 
         User user = userService.findUserById(userId);
-        userService.validateNotPending(user);
+        userService.validateActiveUser(user);
 
         validatePostNotOwner(post, user);
 
@@ -130,7 +130,7 @@ public class PostService {
         Post post = findPostOrThrow(postId);
 
         User user = userService.findUserById(userId);
-        userService.validateNotPending(user);
+        userService.validateActiveUser(user);
 
         validatePostNotOwner(post, user);
 

--- a/src/main/java/com/even/zaro/service/ProfileService.java
+++ b/src/main/java/com/even/zaro/service/ProfileService.java
@@ -34,7 +34,7 @@ public class ProfileService {
 
     // 유저 기본 프로필 조회
     public UserProfileDto getUserProfile(Long userId) {
-        User user = userService.findUserById(userId);
+        User user = userService.findActiveUserById(userId);
 
         int postCount = postRepository.countByUserAndIsDeletedFalse(user);
 
@@ -52,7 +52,7 @@ public class ProfileService {
 
     // 유저가 쓴 게시물 list 조회
     public PageResponse<UserPostDto> getUserPosts(Long userId, Pageable pageable) {
-        User user = userService.findUserById(userId);
+        User user = userService.findActiveUserById(userId);
 
         Page<UserPostDto> page = postRepository.findByUserAndIsDeletedFalse(user, pageable)
                 .map(post -> UserPostDto.builder()
@@ -72,7 +72,7 @@ public class ProfileService {
 
     // 유저가 좋아요 누른 게시물 list 조회
     public PageResponse<UserPostDto> getUserLikedPosts(Long userId, Pageable pageable) {
-        User user = userService.findUserById(userId);
+        User user = userService.findActiveUserById(userId);
 
         Page<UserPostDto> page = postLikeRepository.findByUser(user, pageable)
                 .map(postLike -> UserPostDto.builder()
@@ -92,7 +92,7 @@ public class ProfileService {
 
     // 유저가 작성한 댓글 list 조회
     public PageResponse<UserCommentDto> getUserComments(Long userId, Pageable pageable) {
-        User user = userService.findUserById(userId);
+        User user = userService.findActiveUserById(userId);
 
         Page<UserCommentDto> page = commentRepository.findByUserAndIsDeletedFalse(user, pageable)
                 .map(comment -> {

--- a/src/main/java/com/even/zaro/service/UserService.java
+++ b/src/main/java/com/even/zaro/service/UserService.java
@@ -167,9 +167,13 @@ public class UserService {
                 .orElseThrow(() -> new UserException(ErrorCode.USER_NOT_FOUND));
     }
 
-    public void validateNotPending(User user) {
+    public void validateActiveUser(User user) {
         if (user.getStatus() == Status.PENDING) {
             throw new UserException(ErrorCode.MAIL_NOT_VERIFIED);
+        } else if (user.getStatus() == Status.DORMANT) {
+            throw new UserException(ErrorCode.DORMANT_USER);
+        } else if (user.getStatus() == Status.DELETED) {
+            throw new UserException(ErrorCode.DELETED_USER);
         }
     }
 }

--- a/src/main/java/com/even/zaro/service/UserService.java
+++ b/src/main/java/com/even/zaro/service/UserService.java
@@ -51,7 +51,7 @@ public class UserService {
     @Transactional
     public UpdateProfileImageResponseDto updateProfileImage(Long userId, UpdateProfileImageRequestDto requestDto) {
         User user = findUserById(userId);
-        validateNotPending(user);
+        validateActiveUser(user);
 
         user.updateProfileImage(requestDto.getProfileImage());
 
@@ -61,7 +61,7 @@ public class UserService {
     @Transactional
     public UpdateNicknameResponseDto updateNickname(Long userId, UpdateNicknameRequestDto requestDto) {
         User user = findUserById(userId);
-        validateNotPending(user);
+        validateActiveUser(user);
 
         String newNickname = requestDto.getNewNickname();
 
@@ -98,7 +98,7 @@ public class UserService {
     @Transactional
     public UpdateProfileResponseDto updateProfile(Long userId, UpdateProfileRequestDto requestDto) {
         User user = findUserById(userId);
-        validateNotPending(user);
+        validateActiveUser(user);
 
         user.updateBirthday(requestDto.getBirthday());
         user.updateLiveAloneDate(requestDto.getLiveAloneDate());
@@ -116,7 +116,7 @@ public class UserService {
     @Transactional
     public void updatePassword(Long userId, UpdatePasswordRequestDto requestDto) {
         User user = findUserById(userId);
-        validateNotPending(user);
+        validateActiveUser(user);
 
         String currentPassword = requestDto.getCurrentPassword();
         String newPassword = requestDto.getNewPassword();

--- a/src/main/java/com/even/zaro/service/UserService.java
+++ b/src/main/java/com/even/zaro/service/UserService.java
@@ -167,6 +167,15 @@ public class UserService {
                 .orElseThrow(() -> new UserException(ErrorCode.USER_NOT_FOUND));
     }
 
+    public User findActiveUserById(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserException(ErrorCode.USER_NOT_FOUND));
+        if (user.getStatus() != Status.ACTIVE) {
+            throw new UserException(ErrorCode.USER_NOT_FOUND);
+        }
+        return user;
+    }
+
     public void validateActiveUser(User user) {
         if (user.getStatus() == Status.PENDING) {
             throw new UserException(ErrorCode.MAIL_NOT_VERIFIED);

--- a/src/test/java/com/even/zaro/unit/service/UserServiceTest.java
+++ b/src/test/java/com/even/zaro/unit/service/UserServiceTest.java
@@ -390,7 +390,7 @@ class UserServiceTest {
         void shouldThrowException_whenUserStatusIsPending() {
             User user = User.builder().status(Status.PENDING).build();
 
-            UserException ex = assertThrows(UserException.class, () -> userService.validateNotPending(user));
+            UserException ex = assertThrows(UserException.class, () -> userService.validateActiveUser(user));
 
             assertEquals(ErrorCode.MAIL_NOT_VERIFIED, ex.getErrorCode());
         }


### PR DESCRIPTION
## 📌 작업 개요
- 회원 정책 수정 및 리팩토링

---

## ✨ 주요 변경 사항
- 회원 리팩토링
   - pending 회원 검증 active 회원 검증 로직(deleted, dormant 추가)으로 수정
   - 프로필 조회시 active 회원만 조회 가능하도록 메서드 추가 및 적용
- 회원 정책 수정
   - 회원 탈퇴 후 정보 30일 후 삭제 -> 3년 후 삭제
   - 탈퇴 30일 후 개인정보 임의값으로 변경 스케줄러 추가
- 게시글 리스트, 상세, 댓글 리스트 조회시 탈퇴 회원 "알 수 없는 사용자", 프로필 이미지 null, liveAloneDate null 처리

---

## 🖼️ 기능 살펴 보기
> 포스트맨 요청 응답 스크린샷
- [x] API 문서(요청, 응답)와 일치하는지 확인 - 필요시 API 문서 수정 가능

탈퇴 회원 "알 수 없는 사용자" 처리

|게시글 리스트 | 게시글 상세| 댓글 리스트|
|------|------|------|
|![image](https://github.com/user-attachments/assets/37cbece8-59f4-45b3-8e31-d16b8c374d7e)|![image](https://github.com/user-attachments/assets/8b822b60-ac72-4168-bb52-7834c216ea55)|![image](https://github.com/user-attachments/assets/44cf4e28-91a0-4bf1-8a2a-665f512e35d1)|

---

## ✅ 작업 체크리스트
- [x] API 테스트 완료 (POSTMAN)
- [x] 스웨거 ui 관련 코드 추가
- [x] 기능별 예외 케이스 고려
- [x] log.info / 불필요한 주석 제거
- [x] 변수명, 클래스명, 메서드명 의미있게 작성
- [x] 반복 코드 메서드로 분리

---

## 📂 테스트 방법
- [ ] 테스트 코드 작성
- [ ] 시나리오 기반 테스트 유무
    - ex: ID 중복 시 예외 처리 발생

---

## 💬 기타 참고 사항
- post, profile 수정이 있습니다. 확인 바랍니다.

---

## 📎 관련 이슈 / 문서
- 관련 이슈 번호: FIXES #168 
