### PR TITLE
Ref/map,group,favorite 그룹 삭제 시 포함된 즐겨찾기 일괄 soft 삭제처리, 조회 시 빈값일 때 예외대신 빈 배열 응답

### DIFF
--- a/src/main/java/com/even/zaro/controller/GroupController.java
+++ b/src/main/java/com/even/zaro/controller/GroupController.java
@@ -33,9 +33,11 @@ public class GroupController {
             @PathVariable("userId") long userId) {
         List<GroupResponse> groupList = groupService.getFavoriteGroups(userId);
 
+        if (groupList.isEmpty()) {
+            return ResponseEntity.ok(ApiResponse.success("그룹 리스트가 아직 추가되지 않았습니다.", groupList));
+        }
         return ResponseEntity.ok(ApiResponse.success("해당 유저의 즐겨찾기 그룹 리스트를 조회했습니다.", groupList));
     }
-
 
     @Operation(summary = "내 그룹 리스트 조회", description = "내 그룹 리스트를 조회합니다.", security = {@SecurityRequirement(name = "bearer-key")})
     @GetMapping
@@ -43,6 +45,9 @@ public class GroupController {
             @AuthenticationPrincipal JwtUserInfoDto userInfoDto) {
         List<GroupResponse> groupList = groupService.getFavoriteGroups(userInfoDto.getUserId());
 
+        if (groupList.isEmpty()) {
+            return ResponseEntity.ok(ApiResponse.success("그룹 리스트가 아직 추가되지 않았습니다.", groupList));
+        }
         return ResponseEntity.ok(ApiResponse.success("나의 즐겨찾기 그룹 리스트를 조회했습니다.", groupList));
     }
 

--- a/src/main/java/com/even/zaro/repository/FavoriteRepository.java
+++ b/src/main/java/com/even/zaro/repository/FavoriteRepository.java
@@ -19,4 +19,6 @@ public interface FavoriteRepository extends JpaRepository<Favorite, Long> {
     boolean existsByPlaceAndUser(Place place, User user);
 
     List<Favorite> findAllByGroup(FavoriteGroup group);
+
+    List<Favorite> findByPlaceAndUserAndDeletedTrue(Place place, User user);
 }

--- a/src/main/java/com/even/zaro/repository/FavoriteRepository.java
+++ b/src/main/java/com/even/zaro/repository/FavoriteRepository.java
@@ -17,4 +17,6 @@ public interface FavoriteRepository extends JpaRepository<Favorite, Long> {
     List<Favorite> findAllByGroupAndDeletedFalse(FavoriteGroup group);
 
     boolean existsByPlaceAndUser(Place place, User user);
+
+    List<Favorite> findAllByGroup(FavoriteGroup group);
 }

--- a/src/main/java/com/even/zaro/service/FavoriteService.java
+++ b/src/main/java/com/even/zaro/service/FavoriteService.java
@@ -50,6 +50,13 @@ public class FavoriteService {
         // 해당 장소가 이미 저장되어있는지 없다면 장소 추가
         Place place = checkDuplicateByKakoPlaceId(request);
 
+        // 해당 장소에 대해서 유저가 삭제한 즐겨찾기를 가지고 있는지 확인
+        List<Favorite> beforeDelete = favoriteRepository.findByPlaceAndUserAndDeletedTrue(place, user);
+        if (beforeDelete.size() > 0) {
+            favoriteRepository.deleteAll(beforeDelete); // 기존의 즐겨찾기 hard 삭제
+            log.info("이전에 삭제한 즐겨찾기입니다. Hard 삭제 후 다시 추가합니다. "); // 응답으로 내릴 필요 없음 추적용
+        }
+
         // 해당 유저가 이미 그 장소를 추가했는지 확인
         boolean check = favoriteRepository.existsByPlaceAndUser(place, user);
 

--- a/src/main/java/com/even/zaro/service/GroupService.java
+++ b/src/main/java/com/even/zaro/service/GroupService.java
@@ -57,10 +57,6 @@ public class GroupService {
         // userId 값이 일치하고, 삭제된 데이터를 제외하고 조회
         List<FavoriteGroup> activeGroups = favoriteGroupRepository.findAllByUserAndDeletedFalse(user);
 
-        if (activeGroups.isEmpty()) {
-            throw new GroupException(ErrorCode.GROUP_LIST_NOT_FOUND);
-        }
-
         return groupMapper.toGroupResponseList(activeGroups);
     }
 

--- a/src/main/java/com/even/zaro/service/GroupService.java
+++ b/src/main/java/com/even/zaro/service/GroupService.java
@@ -3,9 +3,11 @@ package com.even.zaro.service;
 import com.even.zaro.dto.group.GroupCreateRequest;
 import com.even.zaro.dto.group.GroupEditRequest;
 import com.even.zaro.dto.group.GroupResponse;
+import com.even.zaro.entity.Favorite;
 import com.even.zaro.entity.FavoriteGroup;
 import com.even.zaro.entity.User;
 import com.even.zaro.global.ErrorCode;
+import com.even.zaro.global.exception.favorite.FavoriteException;
 import com.even.zaro.global.exception.group.GroupException;
 import com.even.zaro.global.exception.user.UserException;
 import com.even.zaro.mapper.GroupMapper;
@@ -73,6 +75,9 @@ public class GroupService {
         if (group.isDeleted()) {
             throw new GroupException(ErrorCode.GROUP_ALREADY_DELETE);
         }
+
+        // 그룹 내의 즐겨찾기 전부 삭제 처리
+        favoriteRepository.findAllByGroup(group).forEach(Favorite::setDeleteTrue);
 
         group.setIsDeleted();
 


### PR DESCRIPTION
## 📌 작업 개요
- 그룹 삭제 시 포함된 즐겨찾기 일괄 soft 삭제처리, 조회 시 빈값일 때 예외대신 빈 배열 응답

---

## ✨ 주요 변경 사항
1. 그룹 삭제 시 그룹에 포함된 즐겨찾기 일괄 soft 삭제 처리
2. 즐겨찾기 추가 시, 이전에 삭제했던 즐겨찾기라면 완전 삭제 후 새 데이터로 즐겨찾기 추가
3. 그룹 리스트 조회 시, 조회된 값이 없을 시 예외를 던지는 대신 빈 배열 응답

---

## 🖼️ 기능 살펴 보기
## 1. 그룹 삭제 시 그룹에 포함된 즐겨찾기 일괄 soft 삭제 처리
> <img width="1141" alt="스크린샷 2025-06-17 오전 1 30 51" src="https://github.com/user-attachments/assets/5ea45417-e26e-483c-9108-665c74800b36" />
- 그룹 id 7에 속한 즐겨찾기들

>  <img width="1419" alt="image" src="https://github.com/user-attachments/assets/5dd825d6-abff-437f-82cc-f09d01c58a99" />
- 그룹 id 7에 대하여 삭제

>  <img width="957" alt="image" src="https://github.com/user-attachments/assets/d4c48d49-8d0e-4414-b984-0abfd029617a" />
- 즐겨찾기들 모두 soft삭제 처리 반영
---------------

## 2. 즐겨찾기 추가 시, 이전에 삭제했던 즐겨찾기라면 완전 삭제 후 새 데이터로 즐겨찾기 추가
> <img width="957" alt="image" src="https://github.com/user-attachments/assets/d4c48d49-8d0e-4414-b984-0abfd029617a" />
- 방금 테스트의 데이터들. 이미 삭제처리 되어있음. 각 kakaoPlaceId는 1,2,3,4 임

>  <img width="1464" alt="image" src="https://github.com/user-attachments/assets/e27ea327-7328-4d6a-80dc-5d539bd217ef" />
- 그룹 새로 추가

>  <img width="1514" alt="image" src="https://github.com/user-attachments/assets/120c97ae-c926-4955-8c0b-cd06479d613a" />
- 이미 삭제했던 kakaoPlaceId 1에 대해서 즐겨찾기 추가 시도, 성공 

> <img width="1092" alt="스크린샷 2025-06-17 오전 1 36 55" src="https://github.com/user-attachments/assets/97810b79-91b7-49ba-9094-16fe33789a79" />
- 이전의 id:42 데이터가 삭제되고, id: 46 데이터 생성완료. 기존 즐겨찾기 데이터 완전 삭제 후 추가 됨.
----------
3. 그룹 리스트 조회 시, 조회된 값이 없을 시 예외를 던지는 대신 빈 배열 응답
> <img width="1479" alt="image" src="https://github.com/user-attachments/assets/fda847c1-1d66-432d-8ac8-b687054eef12" />
- 모든 그룹 삭제 후, 조회 시도. 빈 배열 응답과 적절한 메시지 응답.

---

## ✅ 작업 체크리스트
- [x] API 테스트 완료 (POSTMAN)
- [ ] 스웨거 ui 관련 코드 추가
- [x] 기능별 예외 케이스 고려
- [ ] log.info / 불필요한 주석 제거
- [x] 변수명, 클래스명, 메서드명 의미있게 작성
- [ ] 반복 코드 메서드로 분리

---

## 📂 테스트 방법
- [ ] 테스트 코드 작성
- [ ] 시나리오 기반 테스트 유무
    - ex: ID 중복 시 예외 처리 발생
- [x] SwaggerUI  

---

## 💬 기타 참고 사항
- 프론트엔드 코드 작성하다가 버그를 발견해서 수정했습니다.

---

## 📎 관련 이슈 / 문서
- 
