### PR TITLE
Ref/enum converter enum <-> string converter 적용

### DIFF
--- a/src/main/java/com/even/zaro/controller/UserController.java
+++ b/src/main/java/com/even/zaro/controller/UserController.java
@@ -57,7 +57,7 @@ public class UserController {
     @Operation(summary = "프로필 변경", description = "로그인한 사용자의 프로필(생일, 자취 시작일, 성별, mbti를 변경합니다.", security = {@SecurityRequirement(name = "bearer-key")})
     @PatchMapping("/me/profile")
     public ResponseEntity<ApiResponse<UpdateProfileResponseDto>> updateProfile(
-            @RequestBody UpdateProfileRequestDto requestDto,
+            @RequestBody @Valid UpdateProfileRequestDto requestDto,
             @AuthenticationPrincipal JwtUserInfoDto userInfoDto
     ) {
         UpdateProfileResponseDto responseDto = userService.updateProfile(userInfoDto.getUserId(), requestDto);

--- a/src/main/java/com/even/zaro/dto/user/UpdateProfileRequestDto.java
+++ b/src/main/java/com/even/zaro/dto/user/UpdateProfileRequestDto.java
@@ -2,6 +2,7 @@ package com.even.zaro.dto.user;
 
 import com.even.zaro.entity.Gender;
 import com.even.zaro.entity.Mbti;
+import com.even.zaro.global.validator.annotation.ValidEnum;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -19,8 +20,10 @@ public class UpdateProfileRequestDto {
     private LocalDate liveAloneDate;
 
     @Schema(description = "성별", example = "MALE", nullable = true)
+    @ValidEnum(enumClass = Gender.class)
     private Gender gender;
 
     @Schema(description = "MBTI", example = "INFP", nullable = true)
+    @ValidEnum(enumClass = Mbti.class)
     private Mbti mbti;
 }

--- a/src/main/java/com/even/zaro/dto/user/UpdateProfileRequestDto.java
+++ b/src/main/java/com/even/zaro/dto/user/UpdateProfileRequestDto.java
@@ -21,9 +21,9 @@ public class UpdateProfileRequestDto {
 
     @Schema(description = "성별", example = "MALE", nullable = true)
     @ValidEnum(enumClass = Gender.class)
-    private Gender gender;
+    private String gender;
 
     @Schema(description = "MBTI", example = "INFP", nullable = true)
     @ValidEnum(enumClass = Mbti.class)
-    private Mbti mbti;
+    private String mbti;
 }

--- a/src/main/java/com/even/zaro/entity/User.java
+++ b/src/main/java/com/even/zaro/entity/User.java
@@ -81,8 +81,7 @@ public class User {
     @Builder.Default
     private int followingCount = 0;
 
-    @Enumerated(EnumType.STRING)
-    @Column(name = "provider", nullable = false)
+    @Column(name = "provider", nullable = false, length = 10)
     private Provider provider;
 
     @Column(name = "provider_id")

--- a/src/main/java/com/even/zaro/entity/User.java
+++ b/src/main/java/com/even/zaro/entity/User.java
@@ -47,16 +47,13 @@ public class User {
     @Column(name = "live_alone_date")
     private LocalDate liveAloneDate;
 
-    @Enumerated(EnumType.STRING)
-    @Column(name = "gender")
+    @Column(name = "gender", length = 10)
     private Gender gender;
 
-    @Enumerated(EnumType.STRING)
-    @Column(name = "mbti",  length = 4)
+    @Column(name = "mbti",  length = 10)
     private Mbti mbti;
 
-    @Enumerated(EnumType.STRING)
-    @Column(name = "status", nullable = false)
+    @Column(name = "status", nullable = false, length = 10)
     private Status status;
 
     @CreationTimestamp

--- a/src/main/java/com/even/zaro/global/ErrorCode.java
+++ b/src/main/java/com/even/zaro/global/ErrorCode.java
@@ -16,6 +16,7 @@ public enum ErrorCode {
 
     // 공통
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버에서 알 수 없는 오류가 발생했습니다."),
+    INVALID_ENUM(HttpStatus.BAD_REQUEST, "지원하지 않는 enum 입니다."),
     INVALID_USER_ID(HttpStatus.BAD_REQUEST,  "userId는 필수입니다."),
     UNAUTHORIZED_IMAGE_UPLOAD(HttpStatus.UNAUTHORIZED, "이미지 업로드 권한이 있는 사용자가 아닙니다."),
     INVALID_POST_ID(HttpStatus.BAD_REQUEST,  "postId는 필수입니다."),

--- a/src/main/java/com/even/zaro/global/converter/GenderConverter.java
+++ b/src/main/java/com/even/zaro/global/converter/GenderConverter.java
@@ -1,0 +1,19 @@
+package com.even.zaro.global.converter;
+
+import com.even.zaro.entity.Gender;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+@Converter(autoApply = true)
+public class GenderConverter implements AttributeConverter<Gender, String> {
+
+    @Override
+    public String convertToDatabaseColumn(Gender gender) {
+        return gender != null ? gender.name() : null;
+    }
+
+    @Override
+    public Gender convertToEntityAttribute(String dbData) {
+        return dbData != null ? Gender.valueOf(dbData) : null;
+    }
+}

--- a/src/main/java/com/even/zaro/global/converter/MbtiConverter.java
+++ b/src/main/java/com/even/zaro/global/converter/MbtiConverter.java
@@ -1,0 +1,19 @@
+package com.even.zaro.global.converter;
+
+import com.even.zaro.entity.Mbti;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+@Converter(autoApply = true)
+public class MbtiConverter implements AttributeConverter<Mbti, String> {
+
+    @Override
+    public String convertToDatabaseColumn(Mbti mbti) {
+        return mbti != null ? mbti.name() : null;
+    }
+
+    @Override
+    public Mbti convertToEntityAttribute(String dbData) {
+        return dbData != null ? Mbti.valueOf(dbData) : null;
+    }
+}

--- a/src/main/java/com/even/zaro/global/converter/ProviderConverter.java
+++ b/src/main/java/com/even/zaro/global/converter/ProviderConverter.java
@@ -1,0 +1,19 @@
+package com.even.zaro.global.converter;
+
+import com.even.zaro.entity.Provider;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+@Converter(autoApply = true)
+public class ProviderConverter implements AttributeConverter<Provider, String> {
+
+    @Override
+    public String convertToDatabaseColumn(Provider provider) {
+        return provider != null ? provider.name() : null;
+    }
+
+    @Override
+    public Provider convertToEntityAttribute(String dbData) {
+        return dbData != null ? Provider.valueOf(dbData) : null;
+    }
+}

--- a/src/main/java/com/even/zaro/global/converter/StatusConverter.java
+++ b/src/main/java/com/even/zaro/global/converter/StatusConverter.java
@@ -1,0 +1,19 @@
+package com.even.zaro.global.converter;
+
+import com.even.zaro.entity.Status;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+@Converter(autoApply = true)
+public class StatusConverter implements AttributeConverter<Status, String> {
+
+    @Override
+    public String convertToDatabaseColumn(Status status) {
+        return status != null ? status.name() : null;
+    }
+
+    @Override
+    public Status convertToEntityAttribute(String dbData) {
+        return dbData != null ? Status.valueOf(dbData) : null;
+    }
+}

--- a/src/main/java/com/even/zaro/global/validator/EnumValidator.java
+++ b/src/main/java/com/even/zaro/global/validator/EnumValidator.java
@@ -1,0 +1,26 @@
+package com.even.zaro.global.validator;
+
+import com.even.zaro.global.validator.annotation.ValidEnum;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class EnumValidator implements ConstraintValidator<ValidEnum, String> {
+
+    private Set<String> acceptedValues;
+
+    @Override
+    public void initialize(ValidEnum annotation) {
+        acceptedValues = Arrays.stream(annotation.enumClass().getEnumConstants())
+                .map(Enum::name)
+                .collect(Collectors.toSet());
+    }
+
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext context) {
+        return value == null || acceptedValues.contains(value);
+    }
+}

--- a/src/main/java/com/even/zaro/global/validator/annotation/ValidEnum.java
+++ b/src/main/java/com/even/zaro/global/validator/annotation/ValidEnum.java
@@ -1,0 +1,18 @@
+package com.even.zaro.global.validator.annotation;
+
+import com.even.zaro.global.validator.EnumValidator;
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.*;
+
+@Documented
+@Constraint(validatedBy = EnumValidator.class)
+@Target({ElementType.FIELD, ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ValidEnum {
+    Class<? extends Enum<?>> enumClass();
+    String message() default "INVALID_ENUM";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/com/even/zaro/service/UserService.java
+++ b/src/main/java/com/even/zaro/service/UserService.java
@@ -1,9 +1,7 @@
 package com.even.zaro.service;
 
 import com.even.zaro.dto.user.*;
-import com.even.zaro.entity.Status;
-import com.even.zaro.entity.User;
-import com.even.zaro.entity.WithdrawalHistory;
+import com.even.zaro.entity.*;
 import com.even.zaro.global.ErrorCode;
 import com.even.zaro.global.exception.user.UserException;
 import com.even.zaro.repository.UserRepository;
@@ -102,8 +100,8 @@ public class UserService {
 
         user.updateBirthday(requestDto.getBirthday());
         user.updateLiveAloneDate(requestDto.getLiveAloneDate());
-        user.updateGender(requestDto.getGender());
-        user.updateMbti(requestDto.getMbti());
+        user.updateGender(Gender.valueOf(requestDto.getGender()));
+        user.updateMbti(Mbti.valueOf(requestDto.getMbti()));
 
         return new UpdateProfileResponseDto(
                 user.getBirthday(),

--- a/src/test/java/com/even/zaro/global/converter/EnumConversionPerformanceTest.java
+++ b/src/test/java/com/even/zaro/global/converter/EnumConversionPerformanceTest.java
@@ -1,0 +1,42 @@
+package com.even.zaro.global.converter;
+
+import com.even.zaro.entity.Provider;
+import com.even.zaro.entity.Status;
+import com.even.zaro.entity.User;
+import com.even.zaro.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+public class EnumConversionPerformanceTest {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @BeforeEach
+    void setUp() {
+        userRepository.deleteAll();
+    }
+
+    @Test
+    void ProviderEnumTest() {
+        long start = System.currentTimeMillis();
+
+        for (int i = 0; i < 10000; i++) {
+            User user = User.builder()
+                    .email("string" + i + "@test.com")
+                    .nickname("user" + i)
+                    .provider(Provider.LOCAL)
+                    .status(Status.ACTIVE)
+                    .build();
+            userRepository.save(user);
+        }
+
+        long end = System.currentTimeMillis();
+        System.out.println("소요 시간: " + (end - start) + "ms");
+    }
+}

--- a/src/test/java/com/even/zaro/integration/profile/ProfileIntegrationTest.java
+++ b/src/test/java/com/even/zaro/integration/profile/ProfileIntegrationTest.java
@@ -98,8 +98,8 @@ public class ProfileIntegrationTest {
         profileService.followUser(follower.getId(), followee.getId());
 
         // then
-        assertThat(profileService.getUserFollowings(follower.getId())).hasSize(1);
-        assertThat(profileService.getUserFollowers(followee.getId())).hasSize(1);
+        assertThat(profileService.getUserFollowings(follower.getId(), followee.getId())).hasSize(1);
+        assertThat(profileService.getUserFollowers(followee.getId(), followee.getId())).hasSize(1);
     }
 
     @Test
@@ -113,8 +113,8 @@ public class ProfileIntegrationTest {
         profileService.unfollowUser(follower.getId(), followee.getId());
 
         // then
-        assertThat(profileService.getUserFollowings(follower.getId())).isEmpty();
-        assertThat(profileService.getUserFollowers(followee.getId())).isEmpty();
+        assertThat(profileService.getUserFollowings(follower.getId(), followee.getId())).isEmpty();
+        assertThat(profileService.getUserFollowers(followee.getId(), followee.getId())).isEmpty();
     }
 
     @Test
@@ -128,7 +128,7 @@ public class ProfileIntegrationTest {
         profileService.followUser(userA.getId(), userC.getId());
 
         // when
-        List<FollowerFollowingListDto> followings = profileService.getUserFollowings(userA.getId());
+        List<FollowerFollowingListDto> followings = profileService.getUserFollowings(userA.getId(), userB.getId());
 
         // then
         assertThat(followings).hasSize(2);
@@ -147,7 +147,7 @@ public class ProfileIntegrationTest {
         profileService.followUser(userC.getId(), userA.getId());
 
         // when
-        List<FollowerFollowingListDto> followers = profileService.getUserFollowers(userA.getId());
+        List<FollowerFollowingListDto> followers = profileService.getUserFollowers(userA.getId(), userB.getId());
 
         // then
         assertThat(followers).hasSize(2);


### PR DESCRIPTION
## 📌 작업 개요
- enum <-> string converter 적용

---

## ✨ 주요 변경 사항
- enum <-> string converter 적용 - user 만 적용
   - provider, status
   - gender, mbti 
- enum validator 추가
   - gender, mbti 에만 적용(request로 받을 때 valid) / provider, status는 내부 로직에만 사용하기에 적용 x

---

## 🖼️ 기능 살펴 보기
> 포스트맨 요청 응답 스크린샷
- [ ] API 문서(요청, 응답)와 일치하는지 확인 - 필요시 API 문서 수정 가능

enum <-> varchar(10)
![image](https://github.com/user-attachments/assets/bab853d1-6cbf-4df0-9369-34f230c77469)


enum valid
![image](https://github.com/user-attachments/assets/7f9482ae-91cf-48e0-aff2-403a859b7743)

---

## ✅ 작업 체크리스트
- [ ] API 테스트 완료 (POSTMAN)
- [ ] 스웨거 ui 관련 코드 추가
- [ ] 기능별 예외 케이스 고려
- [ ] log.info / 불필요한 주석 제거
- [ ] 변수명, 클래스명, 메서드명 의미있게 작성
- [ ] 반복 코드 메서드로 분리

---

## 📂 테스트 방법
- [ ] 테스트 코드 작성
- [ ] 시나리오 기반 테스트 유무
    - ex: ID 중복 시 예외 처리 발생

---

## 💬 기타 참고 사항
- 성능 때문이라고 들어서 하기는 했는데.. 차이는 없어보입니다. 대신 가독성과 유지보수 때문에 사용한다고 하네요!
    - enum 이름 변경 등.. 
- db는 varchar(10)으로 변경하려는데 그대로 enum으로 둬도 오류가 나지는 않습니다. 그래도 구조적으로 잘못된 것으로 varchar(10)으로 수정해놓겠습니다!
- user만 한번 시도해본 거라.. 제가 구현하지 않은 다른 코드들은 혹시나 틀어질까 건들지 않았습니다.

---

## 📎 관련 이슈 / 문서
[공부할 때 참고하면 좋을 블로그](https://velog.io/@pood/Spring-DB-%EC%BD%94%EB%93%9C%EA%B0%92%EA%B3%BC-Enum%EC%9D%98-%EB%A7%A4%ED%95%91-%EB%B0%A9%EB%B2%95-Enumerated-vs-Convert)
