### PR TITLE
ref : db의 모든 장소 조회 api 삭제

### DIFF
--- a/src/main/java/com/even/zaro/controller/MapController.java
+++ b/src/main/java/com/even/zaro/controller/MapController.java
@@ -55,15 +55,4 @@ public class MapController {
         }
         return ResponseEntity.ok(ApiResponse.success("인근 장소 리스트를 성공적으로 조회했습니다.", placesByCoordinate));
     }
-
-
-    @Operation(summary = "모든 장소 조회", description = "등록되어 있는 모든 장소를 조회합니다.", security = {@SecurityRequirement(name = "bearer-key")})
-    @GetMapping("/place/all")
-    public ResponseEntity<ApiResponse<PlaceResponse>> getPlaceAll(
-            @AuthenticationPrincipal JwtUserInfoDto userInfo) {
-        PlaceResponse places = mapService.getPlaceAll();
-
-        return ResponseEntity.ok(ApiResponse.success("등록된 모든 장소를 조회했습니다.", places));
-    }
-
 }

--- a/src/main/java/com/even/zaro/service/MapService.java
+++ b/src/main/java/com/even/zaro/service/MapService.java
@@ -72,34 +72,4 @@ public class MapService {
 
         return placeResponse;
     }
-
-    public PlaceResponse getPlaceAll() {
-        List<Place> all = placeRepository.findAll();
-
-        // 조회된 장소가 없을 때
-        if (all.isEmpty()) {
-            throw new MapException(ErrorCode.BY_COORDINATE_NOT_FOUND_PLACE_LIST);
-        }
-
-        List<PlaceResponse.PlaceInfo> placeInfos =  all.stream()
-                .map(place -> PlaceResponse.PlaceInfo.builder()
-                        .placeId(place.getId())
-                        .name(place.getName())
-                        .address(place.getAddress())
-                        .lat(place.getLat())
-                        .lng(place.getLng())
-                        .category(place.getCategory())
-                        .favoriteCount(place.getFavoriteCount())
-                        .build()
-                ).toList();
-
-        int totalCount = all.size();
-
-        PlaceResponse placeResponse = PlaceResponse.builder()
-                .totalCount(totalCount)
-                .placeInfos(placeInfos)
-                .build();
-
-        return placeResponse;
-    }
 }


### PR DESCRIPTION
## 📌 작업 개요
- db의 모든 장소 조회 api 삭제

---

## ✨ 주요 변경 사항
- db의 모든 장소 조회 api 삭제

---

## 🖼️ 기능 살펴 보기


---

## ✅ 작업 체크리스트
- [ ] API 테스트 완료 (POSTMAN)
- [ ] 스웨거 ui 관련 코드 추가
- [ ] 기능별 예외 케이스 고려
- [ ] log.info / 불필요한 주석 제거
- [ ] 변수명, 클래스명, 메서드명 의미있게 작성
- [ ] 반복 코드 메서드로 분리

---

## 📂 테스트 방법
- [ ] 테스트 코드 작성
- [ ] 시나리오 기반 테스트 유무
    - ex: ID 중복 시 예외 처리 발생

---

## 💬 기타 참고 사항

---

## 📎 관련 이슈 / 문서
- close #158 