### PR TITLE
Ref : 팔로우 기능에서 탈퇴한 사용자는 조회하지 않도록 설정 , [sse] emitter 제거하는 시간을 heartbeatTimeout시간과 맞춤

### DIFF
--- a/src/main/java/com/even/zaro/service/NotificationSseService.java
+++ b/src/main/java/com/even/zaro/service/NotificationSseService.java
@@ -67,7 +67,9 @@ public class NotificationSseService {
 
     public SseEmitter connect(Long userId) {
         log.info("[SSE] 유저 {} 연결 시도", userId);
-        SseEmitter emitter = new SseEmitter(Long.MAX_VALUE);
+        long timeout = 10800000L; // 클라이언트와 동일하게 timeout 3시간으로 설정
+
+        SseEmitter emitter = new SseEmitter(timeout);
         EmitterInfo emitterInfo = new EmitterInfo(emitter);
         emitters.put(userId, emitterInfo);
 

--- a/src/main/java/com/even/zaro/service/ProfileService.java
+++ b/src/main/java/com/even/zaro/service/ProfileService.java
@@ -179,10 +179,12 @@ public class ProfileService {
         User user = userService.findUserById(userId);
 
         return followRepository.findByFollower(user).stream()
-                .map(follow -> FollowerFollowingListDto.builder()
-                        .userId(follow.getFollowee().getId())
-                        .userName(follow.getFollowee().getNickname())
-                        .profileImage(follow.getFollowee().getProfileImage())
+                .map(Follow::getFollowee)
+                .filter(followee -> followee.getStatus() != Status.DELETED)
+                .map(followee -> FollowerFollowingListDto.builder()
+                        .userId(followee.getId())
+                        .userName(followee.getNickname())
+                        .profileImage(followee.getProfileImage())
                         .build())
                 .toList();
     }
@@ -192,10 +194,12 @@ public class ProfileService {
         User user = userService.findUserById(userId);
 
         return followRepository.findByFollowee(user).stream()
-                .map(follow -> FollowerFollowingListDto.builder()
-                        .userId(follow.getFollower().getId())
-                        .userName(follow.getFollower().getNickname())
-                        .profileImage(follow.getFollower().getProfileImage())
+                .map(Follow::getFollower)
+                .filter(follower -> follower.getStatus() != Status.DELETED)
+                .map(follower -> FollowerFollowingListDto.builder()
+                        .userId(follower.getId())
+                        .userName(follower.getNickname())
+                        .profileImage(follower.getProfileImage())
                         .build())
                 .toList();
     }


### PR DESCRIPTION
## 📌 작업 개요
- 팔로우 기능에서 탈퇴한 사용자는 조회하지 않도록 설정
- [sse] emitter 제거하는 시간을 heartbeatTimeout시간과 맞춤

---

## ✨ 주요 변경 사항
- 팔로우/팔로잉 리스트에서 탈퇴한 사용자는 조회하지 않도록 설정
  - 현재의 팔로워/팔로잉 리스트 조회는 탈퇴한 사용자까지 조회가 되더군요,
  - 인스타도 탈퇴계정은 팔로우/팔로잉 리스트에 띄우지 않으니 Status.DELETED인 사용자는 조회하지 않도록 설정했습니다

- [sse] emitter 제거하는 시간을 heartbeatTimeout시간과 맞춤
  - 클라이언트 heartbeatTimeout 시간을 3시간으로 설정하게되어, 서버 emitter 제거하는 시간도 동일하게 설정했습니다
  
---

## 🖼️ 기능 살펴 보기
> 기존 user2의 팔로워 리스트
![image](https://github.com/user-attachments/assets/8311726b-4682-46d5-bf8f-67004e6a4a89)

> user3을 softDeleted 처리
![image](https://github.com/user-attachments/assets/3ead4ca1-d6c0-4a85-9da9-005db9fcbbd2)

> 이후 user2의 팔로워 리스트
![image](https://github.com/user-attachments/assets/0242fed1-5db6-43f2-b10f-73f5de09fb19)


---

## ✅ 작업 체크리스트
- [x] API 테스트 완료
- [ ] 스웨거 ui 관련 코드 추가
- [ ] 기능별 예외 케이스 고려
- [ ] log.info / 불필요한 주석 제거
- [ ] 변수명, 클래스명, 메서드명 의미있게 작성
- [ ] 반복 코드 메서드로 분리

---

## 📂 테스트 방법
- [x] swagger
- [x] DBvear

---

## 💬 기타 참고 사항
- @nahyukk 현재 팔로워/팔로잉 count의 경우 유지됩니다. UserService.softDelete 에서 이 count 계산 또한 처리하는 것이 좋을지도 고민되는군용 ..
  - softDeleted된 계정을 restore했을때 팔로우관계는 원래대로 살아있게 되니, Follow 테이블 자체에서 관계를 삭제할 필요는 없을 듯 합니다
  - softDeleted된 계정을 restore하는 로직을 찾아도 안 보여서... count 계산을 하게된다면 이 부분에서도 계산이 들어가야할 듯 싶슴다
  - count가 현재시점 우선순위는 아니지만 의견 여쭈어보아요

---

## 📎 관련 이슈 / 문서

